### PR TITLE
[Backport] 8257483: C2: Split immediate vector rotate from RotateLeft…

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2221,6 +2221,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return false;
 }
 
+bool Matcher::supports_vector_variable_rotates(void) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1112,6 +1112,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return VM_Version::has_simd();
 }
 
+bool Matcher::supports_vector_variable_rotates(void) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2261,6 +2261,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return false; // not supported
 }
 
+bool Matcher::supports_vector_variable_rotates(void) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1545,6 +1545,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return false; // not supported
 }
 
+bool Matcher::supports_vector_variable_rotates(void) {
+  return false; // not supported
+}
+
 const int Matcher::float_pressure(int default_pressure_threshold) {
   return default_pressure_threshold;
 }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1894,6 +1894,10 @@ bool Matcher::supports_vector_variable_shifts(void) {
   return (UseAVX >= 2);
 }
 
+bool Matcher::supports_vector_variable_rotates(void) {
+  return true;
+}
+
 const bool Matcher::has_predicated_vectors(void) {
   bool ret_value = false;
   if (UseAVX > 2) {

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -341,6 +341,9 @@ public:
   // Does the CPU supports vector variable shift instructions?
   static bool supports_vector_variable_shifts(void);
 
+  // Does the CPU supports vector vairable rotate instructions?
+  static bool supports_vector_variable_rotates(void);
+
   // CPU supports misaligned vectors store/load.
   static const bool misaligned_vectors_ok();
 


### PR DESCRIPTION
…V and RotateRightV nodes

Summary: [Backport] 8257483: C2: Split immediate vector rotate from RotateLeftV and RotateRightV nodes
         Not introduce the changes in src/hotspot/share/opto/vectornode.cpp, since it based on 8248830 that not introduced in Dragonwell11

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/456