### PR TITLE
[Misc] Update serverless-adapter.jar in Git Action

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -248,7 +248,7 @@ jobs:
           tar xf jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
           rm -rf jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz
           mkdir -p jdk-${{ env.JDK_VERSION }}/${{ matrix.artifact-path }}lib/serverless
-          cp -f ../serverless-adapter/target/serverless-adapter-0.1-jar-with-dependencies.jar jdk-${{ env.JDK_VERSION }}/${{ matrix.artifact-path }}lib/serverless/serverless-adapter.jar
+          cp -f ../serverless-adapter/target/serverless-adapter-0.1.jar jdk-${{ env.JDK_VERSION }}/${{ matrix.artifact-path }}lib/serverless/serverless-adapter.jar
           cp -f ../serverless-adapter/output/libloadclassagent.so jdk-${{ env.JDK_VERSION }}/${{ matrix.artifact-path }}lib/serverless/
           tar zcf jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz *
           cp -f jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin${{ matrix.artifact }}.tar.gz ../jdk/build/linux-x64/bundles/


### PR DESCRIPTION
Summary: We should use an un-shaded serverless-adapter.

Test Plan: -

Reviewed-by: lingjun-cg, Accelerator1996

Issue: #345