### PR TITLE
[Backport] 8297247: Add GarbageCollectorMXBean for Remark and Cleanup pause time in G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1423,6 +1423,7 @@ G1CollectedHeap::G1CollectedHeap(G1CollectorPolicy* collector_policy) :
   _card_table(NULL),
   _memory_manager("G1 Young Generation", "end of minor GC"),
   _full_gc_memory_manager("G1 Old Generation", "end of major GC"),
+  _conc_gc_memory_manager("G1 Concurrent GC", "end of concurrent GC pause"),
   _eden_pool(NULL),
   _survivor_pool(NULL),
   _old_pool(NULL),
@@ -1742,6 +1743,8 @@ void G1CollectedHeap::initialize_serviceability() {
   _full_gc_memory_manager.add_pool(_eden_pool);
   _full_gc_memory_manager.add_pool(_survivor_pool);
   _full_gc_memory_manager.add_pool(_old_pool);
+
+  _conc_gc_memory_manager.add_pool(_old_pool);
 
   _memory_manager.add_pool(_eden_pool);
   _memory_manager.add_pool(_survivor_pool);
@@ -5024,9 +5027,10 @@ void G1CollectedHeap::rebuild_strong_code_roots() {
 }
 
 GrowableArray<GCMemoryManager*> G1CollectedHeap::memory_managers() {
-  GrowableArray<GCMemoryManager*> memory_managers(2);
+  GrowableArray<GCMemoryManager*> memory_managers(3);
   memory_managers.append(&_memory_manager);
   memory_managers.append(&_full_gc_memory_manager);
+  memory_managers.append(&_conc_gc_memory_manager);
   return memory_managers;
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -130,6 +130,7 @@ class G1RegionMappingChangedListener : public G1MappingChangedListener {
 class G1CollectedHeap : public CollectedHeap {
   friend class G1FreeCollectionSetTask;
   friend class VM_CollectForMetadataAllocation;
+  friend class VM_CGC_Operation;
   friend class VM_G1CollectForAllocation;
   friend class VM_G1CollectFull;
   friend class VMStructs;
@@ -162,6 +163,7 @@ private:
 
   GCMemoryManager _memory_manager;
   GCMemoryManager _full_gc_memory_manager;
+  GCMemoryManager _conc_gc_memory_manager;
 
   MemoryPool* _eden_pool;
   MemoryPool* _survivor_pool;

--- a/src/hotspot/share/gc/g1/vm_operations_g1.cpp
+++ b/src/hotspot/share/gc/g1/vm_operations_g1.cpp
@@ -205,9 +205,13 @@ void VM_CGC_Operation::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   GCTraceTime(Info, gc) t(_printGCMessage, g1h->concurrent_mark()->gc_timer_cm(), GCCause::_no_gc, true);
   TraceCollectorStats tcs(g1h->g1mm()->conc_collection_counters());
+  TraceMemoryManagerStats tms(&g1h->_conc_gc_memory_manager, g1h->gc_cause(),
+                              true /* allMemoryPoolsAffected */);
   SvcGCMarker sgcm(SvcGCMarker::CONCURRENT);
   IsGCActiveMark x;
   _cl->do_void();
+  // Update before TraceMemoryManagerStats destructor.
+  g1h->g1mm()->update_sizes();
 }
 
 bool VM_CGC_Operation::doit_prologue() {

--- a/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
+++ b/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
@@ -107,7 +107,8 @@ public class TestMemoryMXBeansAndPoolsPresence {
         switch (args[0]) {
             case "G1":
                 test(new GCBeanDescription("G1 Young Generation", new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}),
-                     new GCBeanDescription("G1 Old Generation",   new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}));
+                     new GCBeanDescription("G1 Old Generation",   new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}),
+                     new GCBeanDescription("G1 Concurrent GC",    new String[] {"G1 Old Gen"}));
                 break;
             case "CMS":
                 test(new GCBeanDescription("ParNew",              new String[] {"Par Eden Space", "Par Survivor Space"}),

--- a/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+/*
+ * @test TestRemarkCleanupMXBean
+ * @bug 8297247
+ * @summary Test that Remark and Cleanup are correctly reported by
+ *          a GarbageCollectorMXBean
+ * @requires vm.gc.G1
+ * @library /test/lib /
+ * @build   sun.hotspot.WhiteBox
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run     driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UseG1GC -Xlog:gc
+ *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   gc.g1.TestRemarkCleanupMXBean
+ */
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import sun.hotspot.WhiteBox;
+import sun.hotspot.gc.GC;
+
+public class TestRemarkCleanupMXBean {
+    public static void main(String[] args) throws Exception {
+        GarbageCollectorMXBean g1ConcGCBean = null;
+        String expectedName = "G1 Concurrent GC";
+        for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (expectedName.equals(bean.getName())) {
+                g1ConcGCBean = bean;
+                break;
+            }
+        }
+        if (g1ConcGCBean == null) {
+            throw new RuntimeException("Unable to find GC bean: " + expectedName);
+        }
+
+        long before = g1ConcGCBean.getCollectionCount();
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        wb.g1StartConcMarkCycle();
+        while (wb.g1InConcurrentMark()) {
+            Thread.sleep(5);
+        }
+        long after = g1ConcGCBean.getCollectionCount();
+
+        if (after >= before + 2) { // Must report a Remark and a Cleanup
+            System.out.println(g1ConcGCBean.getName() + " reports a difference " +
+                               after + " - " + before + " = " + (after - before));
+        } else {
+            throw new RuntimeException("Remark or Cleanup not reported by " +
+                                       g1ConcGCBean.getName());
+        }
+    }
+}

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -48,6 +48,7 @@ requires.extraPropDefns.vmOpts = -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
 requires.properties= \
     sun.arch.data.model \
     java.runtime.name \
+    vm.gc.G1 \
     vm.gc.Z \
     vm.gc.Shenandoah \
     vm.graal.enabled \

--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
@@ -29,7 +29,11 @@
  * @requires vm.opt.ExplicitGCInvokesConcurrent == null | vm.opt.ExplicitGCInvokesConcurrent == false
  * @modules java.management/sun.management
  *          jdk.management
- * @run     main/othervm GarbageCollectionNotificationTest
+ * @library /test/lib /
+ * @build   sun.hotspot.WhiteBox
+ * @run     driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run     main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                       GarbageCollectionNotificationTest
  */
 
 import java.util.*;
@@ -42,6 +46,8 @@ import com.sun.management.GcInfo;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.lang.reflect.Field;
+import sun.hotspot.WhiteBox;
+import sun.hotspot.gc.GC;
 
 public class GarbageCollectionNotificationTest {
     private static HashMap<String,Boolean> listenerInvoked = new HashMap<String,Boolean>();
@@ -98,6 +104,14 @@ public class GarbageCollectionNotificationTest {
         Object data[] = new Object[32];
         for(int i = 0; i<100000000; i++) {
             data[i%32] = new int[8];
+        }
+        // Trigger G1's concurrent mark
+        if (GC.G1.isSelected()) {
+            WhiteBox wb = WhiteBox.getWhiteBox();
+            wb.g1StartConcMarkCycle();
+            while (wb.g1InConcurrentMark()) {
+                Thread.sleep(5);
+            }
         }
         int wakeup = 0;
         synchronized(synchronizer) {

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -26,7 +26,7 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah" & !vm.gc.G1
  * @author  Mandy Chung
  *
  * @modules jdk.management
@@ -43,6 +43,18 @@
  *
  * @modules jdk.management
  * @run main MemoryTest 2 1
+ */
+
+/*
+ * @test
+ * @bug     4530538
+ * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
+ *          MemoryMXBean.getMemoryManager().
+ * @requires vm.gc.G1
+ * @author  Mandy Chung
+ *
+ * @modules jdk.management
+ * @run main MemoryTest 3 3
  */
 
 /*

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTestAllGC.sh
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTestAllGC.sh
@@ -49,7 +49,7 @@ runOne()
 }
 
 # Test MemoryTest with default collector
-runOne MemoryTest 2 3
+runOne MemoryTest 3 3
 
 # Test MemoryTest with parallel scavenger collector
 runOne -XX:+UseParallelGC MemoryTest 2 3

--- a/test/lib/jdk/test/lib/jfr/GCHelper.java
+++ b/test/lib/jdk/test/lib/jfr/GCHelper.java
@@ -178,6 +178,7 @@ public class GCHelper {
 
         // old GarbageCollectionMXBeans.
         beanCollectorTypes.put("G1 Old Generation", false);
+        beanCollectorTypes.put("G1 Concurrent GC", false);
         beanCollectorTypes.put("ConcurrentMarkSweep", false);
         beanCollectorTypes.put("PS MarkSweep", false);
         beanCollectorTypes.put("MarkSweepCompact", false);


### PR DESCRIPTION
Summary: Backport of 8297247

Test Plan: hotspot/jtreg:tier1-4, jdk:tier1, jdk:needs_g1gc, jdk:jdk_management, jdk:jdk_jmx, hotspot/jtreg:vmTestbase_vm_gc, hotspot/jtreg:vmTestbase_nsk_monitoring

Reviewed-by: leveretconey, D-D-H

Issue: https://github.com/dragonwell-project/dragonwell11/issues/538