### PR TITLE
[CDS] Add CDS Support for AArch64

### DIFF
--- a/test/jdk/com/alibaba/cds/TestClassPathOrderChanged.java
+++ b/test/jdk/com/alibaba/cds/TestClassPathOrderChanged.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
  * @test
  * @summary Test order changed of class path
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestClassPathOrderChanged
  */
 public class TestClassPathOrderChanged implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClass.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClass.java
@@ -34,7 +34,7 @@
  * @build Classes4CDS
  * @build TestSimple
  * @build TestClassLoaderWithSignature
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test.jar TestClassLoaderWithSignature
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadClass
  */

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithDifferentCP.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithDifferentCP.java
@@ -33,7 +33,7 @@
  * @build Classes4CDS
  * @build trivial.ThrowException
  * @build TestAppClassLoader
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar testSimple.jar trivial.ThrowException
  * @run driver ClassFileInstaller -jar test.jar TestAppClassLoader
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadClassWithDifferentCP

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithException.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithException.java
@@ -35,7 +35,7 @@
  * @build trivial.TestSimple
  * @build TestSimpleWispUsage
  * @build TestLoadClassWithException
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar testSimple.jar trivial.TestSimple TestSimpleWispUsage
  * @run driver ClassFileInstaller -jar test.jar TestLoadClassWithException TestLoadClassWithException$1 TestLoadClassWithException$2
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadClassWithException

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithNullURL.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithNullURL.java
@@ -36,7 +36,7 @@
  * @build Classes4CDS
  * @build TestSimple
  * @build TestClassLoaderWithNullURL
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test.jar TestClassLoaderWithNullURL MyWebAppClassLoader
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadClassWithNullURL
  */

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithWisp.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithWisp.java
@@ -33,7 +33,7 @@
  * @build Classes4CDS
  * @build TestSimple
  * @build TestClassLoaderWithSignature
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test.jar TestClassLoaderWithSignature
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadClassWithWisp
  */

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadNotFound.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadNotFound.java
@@ -33,7 +33,7 @@
  * @build Classes4CDS
  * @build TestSimple
  * @build TestLoaderInexistentClass
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test.jar TestLoaderInexistentClass
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpAndLoadNotFound
  */

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadVerficationFailure.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadVerficationFailure.java
@@ -34,7 +34,7 @@
  * @build trivial.Parent
  * @build trivial.ChildA
  * @build trivial.ChildB
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @compile --add-exports=java.base/jdk.internal.loader=ALL-UNNAMED TestVerificationFailure.java
  * @run driver ClassFileInstaller -jar test.jar TestVerificationFailure TestVerificationFailure$1 TestVerificationFailure$2 TestVerificationFailure$3
  * @run main/othervm -XX:+UnlockExperimentalVMOptions --add-exports=java.base/jdk.internal.loader=ALL-UNNAMED TestDumpAndLoadVerficationFailure

--- a/test/jdk/com/alibaba/cds/TestDumpListInParallel.java
+++ b/test/jdk/com/alibaba/cds/TestDumpListInParallel.java
@@ -34,7 +34,7 @@
  * @build Classes4CDS
  * @build TestSimple
  * @build TestClassLoaderInParallel
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test.jar TestClassLoaderInParallel TestClassLoaderInParallel$1 TestClassLoaderInParallel$2
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpListInParallel
  */

--- a/test/jdk/com/alibaba/cds/TestDumpUnsupportedCheck.java
+++ b/test/jdk/com/alibaba/cds/TestDumpUnsupportedCheck.java
@@ -30,7 +30,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @modules jdk.compiler
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestDumpUnsupportedCheck
  */
 

--- a/test/jdk/com/alibaba/cds/TestFatJarNoManifest.java
+++ b/test/jdk/com/alibaba/cds/TestFatJarNoManifest.java
@@ -25,7 +25,7 @@
  * @test
  * @summary far jar and some jar have no manifest.
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestFatJarNoManifest
  */
 public class TestFatJarNoManifest implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/cds/TestLoadClassFlow.java
+++ b/test/jdk/com/alibaba/cds/TestLoadClassFlow.java
@@ -34,7 +34,7 @@
  * @build Classes4CDS
  * @build TestSimple
  * @build TestLoadClass
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test.jar TestLoadClass
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestLoadClassFlow
  */

--- a/test/jdk/com/alibaba/cds/TestNoURLsURLClassLoader.java
+++ b/test/jdk/com/alibaba/cds/TestNoURLsURLClassLoader.java
@@ -25,7 +25,7 @@
  * @test
  * @summary jars that load by a custom URLClassLoader.This class loader override loadClass and findResource, not use the URLs that provided by constructor.
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestNoURLsURLClassLoader
  */
 public class TestNoURLsURLClassLoader implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/cds/TestPlainJarNoManifest.java
+++ b/test/jdk/com/alibaba/cds/TestPlainJarNoManifest.java
@@ -2,7 +2,7 @@
  * @test
  * @summary far jar and some jar have no manifest.
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestPlainJarNoManifest
  */
 public class TestPlainJarNoManifest implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/cds/TestPrefixClassPath.java
+++ b/test/jdk/com/alibaba/cds/TestPrefixClassPath.java
@@ -7,7 +7,7 @@ import java.util.List;
  * @test
  * @summary Test the jar when dumping is subset of jars when replaying
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestPrefixClassPath
  */
 public class TestPrefixClassPath implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/cds/TestRegisterClassLoader.java
+++ b/test/jdk/com/alibaba/cds/TestRegisterClassLoader.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.base/com.alibaba.util:+open
  * @build jdk.test.lib.compiler.CompilerUtils
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestRegisterClassLoader
  */
 

--- a/test/jdk/com/alibaba/cds/TestSignedJar.java
+++ b/test/jdk/com/alibaba/cds/TestSignedJar.java
@@ -4,7 +4,7 @@ import java.io.File;
  * @test
  * @summary Test EagerAppCDS that process signed jar.When a jar is signed, EagerAppCDS will not process it.
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestSignedJar
  */
 public class TestSignedJar implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/cds/TestWispWithAppCDS.java
+++ b/test/jdk/com/alibaba/cds/TestWispWithAppCDS.java
@@ -32,7 +32,7 @@
  * @modules java.base/com.alibaba.util:+open
  * @build TestSimpleWispUsage
  * @build Classes4CDS
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller  -jar test.jar TestSimpleWispUsage
  * @run main/othervm TestWispWithAppCDS
  */

--- a/test/jdk/com/alibaba/cds/testClassLoaderJVMTI.sh
+++ b/test/jdk/com/alibaba/cds/testClassLoaderJVMTI.sh
@@ -30,7 +30,7 @@
 # @modules jdk.compiler
 # @modules java.base/jdk.internal.misc
 # @build jdk.test.lib.compiler.CompilerUtils
-# @requires os.arch=="amd64"
+# @requires os.arch=="amd64"| os.arch=="aarch64"
 # @run shell testClassLoaderJVMTI.sh
 #
 
@@ -51,12 +51,6 @@ case ${OS} in
     exit 1
     ;;
 esac
-
-if [ "x$(uname -m)" = "xaarch64" ];
-then
-  echo "Test only valid for x86"
-  exit 0
-fi
 
 JAVA=${TESTJAVA}${FS}bin${FS}java
 JAVAC=${TESTJAVA}${FS}bin${FS}javac

--- a/test/jdk/com/alibaba/cds/testDelegatingClassLoaderJVMTI.sh
+++ b/test/jdk/com/alibaba/cds/testDelegatingClassLoaderJVMTI.sh
@@ -29,7 +29,7 @@
 # @modules jdk.compiler
 # @modules java.base/jdk.internal.misc
 # @build jdk.test.lib.compiler.CompilerUtils
-# @requires os.arch=="amd64"
+# @requires os.arch=="amd64" | os.arch=="aarch64"
 # @run shell testDelegatingClassLoaderJVMTI.sh
 #
 
@@ -50,12 +50,6 @@ case ${OS} in
     exit 1
     ;;
 esac
-
-if [[ "x$(uname -m)" = "xaarch64" ]];
-then
-  echo "Test only valid for x86"
-  exit 0
-fi
 
 JAVA=${TESTJAVA}${FS}bin${FS}java
 JAVAC=${TESTJAVA}${FS}bin${FS}javac

--- a/test/jdk/com/alibaba/quickstart/TestAllFeaturePlainJarProfileDump.java
+++ b/test/jdk/com/alibaba/quickstart/TestAllFeaturePlainJarProfileDump.java
@@ -25,7 +25,7 @@
  * @test
  * @summary test quickstart with all features with the process: profile,dump,replay
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestAllFeaturePlainJarProfileDump
  */
 public class TestAllFeaturePlainJarProfileDump implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/quickstart/TestAssemblyFiles.java
+++ b/test/jdk/com/alibaba/quickstart/TestAssemblyFiles.java
@@ -26,7 +26,7 @@
  * @summary Test files assemblied into JDK
  * @library /test/lib
  * @library /lib/testlibrary
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestAssemblyFiles
  */
 

--- a/test/jdk/com/alibaba/quickstart/TestDeterminingTracerOrReplayer.java
+++ b/test/jdk/com/alibaba/quickstart/TestDeterminingTracerOrReplayer.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Test the flow to determine tracer or replayer
  * @library /test/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm/timeout=600 TestDeterminingTracerOrReplayer
  */
 

--- a/test/jdk/com/alibaba/quickstart/TestEagerAppCDSPlainJarProfileDump.java
+++ b/test/jdk/com/alibaba/quickstart/TestEagerAppCDSPlainJarProfileDump.java
@@ -25,7 +25,7 @@
  * @test
  * @summary test quickstart when enable EagerAppCDS with the process: profile,dump,replay
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestEagerAppCDSPlainJarProfileDump
  */
 public class TestEagerAppCDSPlainJarProfileDump implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/quickstart/TestEagerAppCDSWithParametersProfileDump.java
+++ b/test/jdk/com/alibaba/quickstart/TestEagerAppCDSWithParametersProfileDump.java
@@ -25,7 +25,7 @@
  * @test
  * @summary test main class with parameter like a VM option.
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestEagerAppCDSWithParametersProfileDump
  */
 public class TestEagerAppCDSWithParametersProfileDump implements SingleProjectProvider {

--- a/test/jdk/com/alibaba/quickstart/TestExecStartupProbe.java
+++ b/test/jdk/com/alibaba/quickstart/TestExecStartupProbe.java
@@ -29,7 +29,7 @@ import java.util.Base64;
  * @test
  * @summary test startupProbe of quickstart
  * @library /test/lib /com/alibaba/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm TestExecStartupProbe
  */
 public class TestExecStartupProbe implements SingleProjectProvider {
@@ -68,7 +68,9 @@ public class TestExecStartupProbe implements SingleProjectProvider {
                         "        FileWriter fw = new FileWriter(\"%s\");\n" +
                         "        fw.write(\"%s\");\n" +
                         "        fw.close();\n" +
-                        "        Thread.sleep(10 * 1000);\n" +
+                        "        String debug = System.getProperty(\"jdk.debug\");\n" +
+                        "        int time = 10 + (debug.equals(\"release\") ? 0 : 10);\n"+
+                        "        Thread.sleep(time * 1000);\n" +
                         "    }" +
                         " }";
 

--- a/test/jdk/com/alibaba/quickstart/TestForceReplayer.java
+++ b/test/jdk/com/alibaba/quickstart/TestForceReplayer.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Test -Xquickstart:replay option
  * @library /test/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm/timeout=600 TestForceReplayer
  */
 

--- a/test/jdk/com/alibaba/quickstart/TestIntegrityCheck.java
+++ b/test/jdk/com/alibaba/quickstart/TestIntegrityCheck.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Test Integrity Check
  * @library /test/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm/timeout=600 TestIntegrityCheck
  */
 

--- a/test/jdk/com/alibaba/quickstart/TestMultiVersionedJar.java
+++ b/test/jdk/com/alibaba/quickstart/TestMultiVersionedJar.java
@@ -12,7 +12,7 @@
  * @build MyWebAppClassLoader
  * @build LoadMultiVersionedJarClass
  * @build Compiler JarBuilder CreateMultiReleaseTestJars
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test.jar LoadMultiVersionedJarClass MyWebAppClassLoader
  * @run main/othervm -XX:+UnlockExperimentalVMOptions TestMultiVersionedJar
  */

--- a/test/jdk/com/alibaba/quickstart/TestNotifyDump.java
+++ b/test/jdk/com/alibaba/quickstart/TestNotifyDump.java
@@ -27,7 +27,7 @@
  * @summary Test dumping when process exits
  * @library /test/lib
  * @build TestDump
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test-notifyDump.jar TestDump TestDump$Policy TestDump$ClassLoadingPolicy TestDump$WatcherThread
  * @run main/othervm/timeout=600 TestNotifyDump
  */

--- a/test/jdk/com/alibaba/quickstart/TestNotifyDumpByAPI.java
+++ b/test/jdk/com/alibaba/quickstart/TestNotifyDumpByAPI.java
@@ -27,7 +27,7 @@
  * @summary Test dumping using java level API hooks
  * @library /test/lib
  * @build TestDump
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test-notifyDumpByAPI.jar TestDump TestDump$Policy TestDump$ClassLoadingPolicy TestDump$WatcherThread
  * @run main/othervm/timeout=600 TestNotifyDumpByAPI
  */

--- a/test/jdk/com/alibaba/quickstart/TestNotifyDumpByJcmd.java
+++ b/test/jdk/com/alibaba/quickstart/TestNotifyDumpByJcmd.java
@@ -27,7 +27,7 @@
  * @summary Test dumping using jcmd
  * @library /test/lib
  * @build TestDump
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run driver ClassFileInstaller -jar test-notifyDumpByJcmd.jar TestDump TestDump$Policy TestDump$ClassLoadingPolicy TestDump$WatcherThread
  * @run main/othervm/timeout=600 TestNotifyDumpByJcmd
  */

--- a/test/jdk/com/alibaba/quickstart/TestParallelProcessRun.java
+++ b/test/jdk/com/alibaba/quickstart/TestParallelProcessRun.java
@@ -26,7 +26,7 @@
  * @summary Test the file lock to determine tracer or replayer
  * @library /test/lib
  * @library /lib/testlibrary
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm/timeout=600 TestParallelProcessRun
  */
 

--- a/test/jdk/com/alibaba/quickstart/TestPrintStat.java
+++ b/test/jdk/com/alibaba/quickstart/TestPrintStat.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Test -Xquickstart:printStat option
  * @library /test/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm/timeout=600 TestPrintStat
  */
 

--- a/test/jdk/com/alibaba/quickstart/TestQuickStartOptions.java
+++ b/test/jdk/com/alibaba/quickstart/TestQuickStartOptions.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Test -Xquickstart options
  * @library /test/lib
- * @requires os.arch=="amd64"
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
  * @run main/othervm/timeout=600 TestQuickStartOptions
  */
 


### PR DESCRIPTION
Summary: Change Jtreg tests in `/cds` and `quickstart` for AArch64

Test Plan: ci jtreg

Reviewed-by: yuleil, zhengxiaolinX, lingjun-cg

Issue: