### PR TITLE
speed up : LocalDate.of & LocalTime.of checkValidValue

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -245,9 +245,13 @@ public final class LocalDate
      *  or if the day-of-month is invalid for the month-year
      */
     public static LocalDate of(int year, Month month, int dayOfMonth) {
-        YEAR.checkValidValue(year);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
         Objects.requireNonNull(month, "month");
-        DAY_OF_MONTH.checkValidValue(dayOfMonth);
+        if (dayOfMonth < 1 || dayOfMonth > 31) {
+            throw new DateTimeException("Invalid value for DayOfMonth (valid values 1 - 28/31): " + dayOfMonth);
+        }
         return create(year, month.getValue(), dayOfMonth);
     }
 
@@ -265,9 +269,15 @@ public final class LocalDate
      *  or if the day-of-month is invalid for the month-year
      */
     public static LocalDate of(int year, int month, int dayOfMonth) {
-        YEAR.checkValidValue(year);
-        MONTH_OF_YEAR.checkValidValue(month);
-        DAY_OF_MONTH.checkValidValue(dayOfMonth);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
+        if (month < 1 || month > 12) {
+            throw new DateTimeException("Invalid value for MonthOfYear (valid values 1 - 12): " + month);
+        }
+        if (dayOfMonth < 1 || dayOfMonth > 31) {
+            throw new DateTimeException("Invalid value for DayOfMonth (valid values 1 - 28/31): " + dayOfMonth);
+        }
         return create(year, month, dayOfMonth);
     }
 
@@ -285,8 +295,12 @@ public final class LocalDate
      *  or if the day-of-year is invalid for the year
      */
     public static LocalDate ofYearDay(int year, int dayOfYear) {
-        YEAR.checkValidValue(year);
-        DAY_OF_YEAR.checkValidValue(dayOfYear);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
+        if (dayOfYear < 1 || dayOfYear > 366) {
+            throw new DateTimeException("Invalid value for DayOfYear (valid values 1 - 365/366): " + dayOfYear);
+        }
         boolean leap = IsoChronology.INSTANCE.isLeapYear(year);
         if (dayOfYear == 366 && leap == false) {
             throw new DateTimeException("Invalid date 'DayOfYear 366' as '" + year + "' is not a leap year");
@@ -1082,7 +1096,9 @@ public final class LocalDate
         if (this.year == year) {
             return this;
         }
-        YEAR.checkValidValue(year);
+        if (year < Year.MIN_VALUE || year > Year.MAX_VALUE) {
+            throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+        }
         return resolvePreviousValid(year, month, day);
     }
 
@@ -1101,7 +1117,9 @@ public final class LocalDate
         if (this.month == month) {
             return this;
         }
-        MONTH_OF_YEAR.checkValidValue(month);
+        if (month < 1 || month > 12) {
+            throw new DateTimeException("Invalid value for MonthOfYear (valid values 1 - 12): " + month);
+        }
         return resolvePreviousValid(year, month, day);
     }
 
@@ -1383,7 +1401,9 @@ public final class LocalDate
                 } else if (month < 12) {
                     return new LocalDate(year, month + 1, (int) (dom - monthLen));
                 } else {
-                    YEAR.checkValidValue(year + 1);
+                    if (year + 1 < Year.MIN_VALUE || year + 1 > Year.MAX_VALUE) {
+                        throw new DateTimeException("Invalid value for Year (valid values " + Year.MIN_VALUE + " - " + Year.MAX_VALUE + "): " + year);
+                    }
                     return new LocalDate(year + 1, 1, (int) (dom - monthLen));
                 }
             }

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -293,11 +293,15 @@ public final class LocalTime
      * @throws DateTimeException if the value of any field is out of range
      */
     public static LocalTime of(int hour, int minute) {
-        HOUR_OF_DAY.checkValidValue(hour);
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
         if (minute == 0) {
             return HOURS[hour];  // for performance
         }
-        MINUTE_OF_HOUR.checkValidValue(minute);
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
         return new LocalTime(hour, minute, 0, 0);
     }
 
@@ -314,12 +318,18 @@ public final class LocalTime
      * @throws DateTimeException if the value of any field is out of range
      */
     public static LocalTime of(int hour, int minute, int second) {
-        HOUR_OF_DAY.checkValidValue(hour);
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
         if ((minute | second) == 0) {
             return HOURS[hour];  // for performance
         }
-        MINUTE_OF_HOUR.checkValidValue(minute);
-        SECOND_OF_MINUTE.checkValidValue(second);
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
+        if (second < 0 || second > 59) {
+            throw new DateTimeException("Invalid value for SecondOfMinute (valid values 0 - 59): " + second);
+        }
         return new LocalTime(hour, minute, second, 0);
     }
 
@@ -336,10 +346,18 @@ public final class LocalTime
      * @throws DateTimeException if the value of any field is out of range
      */
     public static LocalTime of(int hour, int minute, int second, int nanoOfSecond) {
-        HOUR_OF_DAY.checkValidValue(hour);
-        MINUTE_OF_HOUR.checkValidValue(minute);
-        SECOND_OF_MINUTE.checkValidValue(second);
-        NANO_OF_SECOND.checkValidValue(nanoOfSecond);
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
+        if (second < 0 || second > 59) {
+            throw new DateTimeException("Invalid value for SecondOfMinute (valid values 0 - 59): " + second);
+        }
+        if (nanoOfSecond < 0 || nanoOfSecond > 999_999_999) {
+            throw new DateTimeException("Invalid value for NanoOfSecond (valid values 0 - 999999999): " + nanoOfSecond);
+        }
         return create(hour, minute, second, nanoOfSecond);
     }
 
@@ -377,7 +395,10 @@ public final class LocalTime
      * @throws DateTimeException if the second-of-day value is invalid
      */
     public static LocalTime ofSecondOfDay(long secondOfDay) {
-        SECOND_OF_DAY.checkValidValue(secondOfDay);
+        if (secondOfDay < 0 || secondOfDay > 86399L) {
+            throw new DateTimeException("Invalid value for SecondOfDay (valid values 0 - 86399): " + secondOfDay);
+        }
+
         int hours = (int) (secondOfDay / SECONDS_PER_HOUR);
         secondOfDay -= hours * SECONDS_PER_HOUR;
         int minutes = (int) (secondOfDay / SECONDS_PER_MINUTE);
@@ -395,7 +416,10 @@ public final class LocalTime
      * @throws DateTimeException if the nanos of day value is invalid
      */
     public static LocalTime ofNanoOfDay(long nanoOfDay) {
-        NANO_OF_DAY.checkValidValue(nanoOfDay);
+        if (nanoOfDay < 0 || nanoOfDay > 86399999999999L) {
+            throw new DateTimeException("Invalid value for NanoOfDay (valid values 0 - 86399999999999): " + nanoOfDay);
+        }
+
         int hours = (int) (nanoOfDay / NANOS_PER_HOUR);
         nanoOfDay -= hours * NANOS_PER_HOUR;
         int minutes = (int) (nanoOfDay / NANOS_PER_MINUTE);
@@ -892,7 +916,11 @@ public final class LocalTime
         if (this.hour == hour) {
             return this;
         }
-        HOUR_OF_DAY.checkValidValue(hour);
+
+        if (hour < 0 || hour > 23) {
+            throw new DateTimeException("Invalid value for HourOfDay (valid values 0 - 23): " + hour);
+        }
+
         return create(hour, minute, second, nano);
     }
 
@@ -909,7 +937,11 @@ public final class LocalTime
         if (this.minute == minute) {
             return this;
         }
-        MINUTE_OF_HOUR.checkValidValue(minute);
+
+        if (minute < 0 || minute > 59) {
+            throw new DateTimeException("Invalid value for MinuteOfHour (valid values 0 - 59): " + minute);
+        }
+
         return create(hour, minute, second, nano);
     }
 
@@ -926,7 +958,11 @@ public final class LocalTime
         if (this.second == second) {
             return this;
         }
-        SECOND_OF_MINUTE.checkValidValue(second);
+
+        if (second < 0 || second > 59) {
+            throw new DateTimeException("Invalid value for SecondOfMinute (valid values 0 - 59): " + second);
+        }
+
         return create(hour, minute, second, nano);
     }
 
@@ -943,7 +979,11 @@ public final class LocalTime
         if (this.nano == nanoOfSecond) {
             return this;
         }
-        NANO_OF_SECOND.checkValidValue(nanoOfSecond);
+
+        if (nanoOfSecond < 0 || nanoOfSecond > 999_999_999) {
+            throw new DateTimeException("Invalid value for NanoOfSecond (valid values 0 - 999999999): " + nanoOfSecond);
+        }
+
         return create(hour, minute, second, nanoOfSecond);
     }
 


### PR DESCRIPTION
LocalDate & LocalTime is small object, ChronoField#checkValidValue is too slow for it.

checkValidateValue cost 58.91% in LocalDate.of
![image](https://user-images.githubusercontent.com/1166785/232314618-d51c0490-7946-4dde-ab95-ae2ffa896b4a.png)

checkValidateValue cost 54.92% in LocalTime.of
![image](https://user-images.githubusercontent.com/1166785/232314690-579fd397-426c-4786-a810-28fe7e0ca9d0.png)

