### PR TITLE
speed up SimpleDateFormat parse & format when pattern is 'yyyy-MM-dd' or 'yyyy-MM-dd HH:mm:ss'

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1423,6 +1423,7 @@ G1CollectedHeap::G1CollectedHeap(G1CollectorPolicy* collector_policy) :
   _card_table(NULL),
   _memory_manager("G1 Young Generation", "end of minor GC"),
   _full_gc_memory_manager("G1 Old Generation", "end of major GC"),
+  _conc_gc_memory_manager("G1 Concurrent GC", "end of concurrent GC pause"),
   _eden_pool(NULL),
   _survivor_pool(NULL),
   _old_pool(NULL),
@@ -1742,6 +1743,8 @@ void G1CollectedHeap::initialize_serviceability() {
   _full_gc_memory_manager.add_pool(_eden_pool);
   _full_gc_memory_manager.add_pool(_survivor_pool);
   _full_gc_memory_manager.add_pool(_old_pool);
+
+  _conc_gc_memory_manager.add_pool(_old_pool);
 
   _memory_manager.add_pool(_eden_pool);
   _memory_manager.add_pool(_survivor_pool);
@@ -5024,9 +5027,10 @@ void G1CollectedHeap::rebuild_strong_code_roots() {
 }
 
 GrowableArray<GCMemoryManager*> G1CollectedHeap::memory_managers() {
-  GrowableArray<GCMemoryManager*> memory_managers(2);
+  GrowableArray<GCMemoryManager*> memory_managers(3);
   memory_managers.append(&_memory_manager);
   memory_managers.append(&_full_gc_memory_manager);
+  memory_managers.append(&_conc_gc_memory_manager);
   return memory_managers;
 }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -130,6 +130,7 @@ class G1RegionMappingChangedListener : public G1MappingChangedListener {
 class G1CollectedHeap : public CollectedHeap {
   friend class G1FreeCollectionSetTask;
   friend class VM_CollectForMetadataAllocation;
+  friend class VM_CGC_Operation;
   friend class VM_G1CollectForAllocation;
   friend class VM_G1CollectFull;
   friend class VMStructs;
@@ -162,6 +163,7 @@ private:
 
   GCMemoryManager _memory_manager;
   GCMemoryManager _full_gc_memory_manager;
+  GCMemoryManager _conc_gc_memory_manager;
 
   MemoryPool* _eden_pool;
   MemoryPool* _survivor_pool;

--- a/src/hotspot/share/gc/g1/vm_operations_g1.cpp
+++ b/src/hotspot/share/gc/g1/vm_operations_g1.cpp
@@ -205,9 +205,13 @@ void VM_CGC_Operation::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   GCTraceTime(Info, gc) t(_printGCMessage, g1h->concurrent_mark()->gc_timer_cm(), GCCause::_no_gc, true);
   TraceCollectorStats tcs(g1h->g1mm()->conc_collection_counters());
+  TraceMemoryManagerStats tms(&g1h->_conc_gc_memory_manager, g1h->gc_cause(),
+                              true /* allMemoryPoolsAffected */);
   SvcGCMarker sgcm(SvcGCMarker::CONCURRENT);
   IsGCActiveMark x;
   _cl->do_void();
+  // Update before TraceMemoryManagerStats destructor.
+  g1h->g1mm()->update_sizes();
 }
 
 bool VM_CGC_Operation::doit_prologue() {

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -563,6 +563,9 @@ public class SimpleDateFormat extends DateFormat {
      */
     transient boolean useDateFormatSymbols;
 
+    transient boolean format19;
+    transient boolean format10;
+
     /**
      * Constructs a <code>SimpleDateFormat</code> using the default pattern and
      * date format symbols for the default
@@ -617,6 +620,17 @@ public class SimpleDateFormat extends DateFormat {
             throw new NullPointerException();
         }
 
+        switch (pattern) {
+            case "yyyy-MM-dd HH:mm:ss":
+                format19 = true;
+                break;
+            case "yyyy-MM-dd":
+                format10 = true;
+                break;
+            default:
+                break;
+        }
+
         initializeCalendar(locale);
         this.pattern = pattern;
         this.formatData = DateFormatSymbols.getInstanceRef(locale);
@@ -637,6 +651,17 @@ public class SimpleDateFormat extends DateFormat {
     {
         if (pattern == null || formatSymbols == null) {
             throw new NullPointerException();
+        }
+
+        switch (pattern) {
+            case "yyyy-MM-dd HH:mm:ss":
+                format19 = true;
+                break;
+            case "yyyy-MM-dd":
+                format10 = true;
+                break;
+            default:
+                break;
         }
 
         this.pattern = pattern;
@@ -972,6 +997,44 @@ public class SimpleDateFormat extends DateFormat {
                                 FieldDelegate delegate) {
         // Convert input date to time field list
         calendar.setTime(date);
+
+        if (format19 || format10) {
+            int year = calendar.get(Calendar.YEAR);
+            int month = calendar.get(Calendar.MONTH) + 1;
+            int dayOfMonth = calendar.get(Calendar.DAY_OF_MONTH);
+
+            toAppendTo.append(year).append('-');
+            if (month < 10) {
+                toAppendTo.append('0');
+            }
+            toAppendTo.append(month).append('-');
+            if (dayOfMonth < 10) {
+                toAppendTo.append('0');
+            }
+            toAppendTo.append(dayOfMonth);
+            if (format10) {
+                return toAppendTo;
+            }
+
+            int hour = calendar.get(Calendar.HOUR_OF_DAY);
+            int minute = calendar.get(Calendar.MINUTE);
+            int second = calendar.get(Calendar.SECOND);
+
+            toAppendTo.append(' ');
+            if (hour < 10) {
+                toAppendTo.append('0');
+            }
+            toAppendTo.append(hour).append(':');
+            if (minute < 10) {
+                toAppendTo.append('0');
+            }
+            toAppendTo.append(minute).append(':');
+            if (second < 10) {
+                toAppendTo.append('0');
+            }
+            toAppendTo.append(second);
+            return toAppendTo;
+        }
 
         boolean useDateFormatSymbols = useDateFormatSymbols();
 
@@ -1468,6 +1531,110 @@ public class SimpleDateFormat extends DateFormat {
         int start = pos.index;
         int oldStart = start;
         int textLength = text.length();
+
+        if ((format10 && textLength == 10) || (format19 && textLength == 19)) {
+            char c0 = text.charAt(0);
+            char c1 = text.charAt(1);
+            char c2 = text.charAt(2);
+            char c3 = text.charAt(3);
+            char c4 = text.charAt(4);
+            char c5 = text.charAt(5);
+            char c6 = text.charAt(6);
+            char c7 = text.charAt(7);
+            char c8 = text.charAt(8);
+            char c9 = text.charAt(9);
+
+            int year, month, dayOfMonth;
+            if (c0 >= '0' && c0 <= '9'
+                    && c1 >= '0' && c1 <= '9'
+                    && c2 >= '0' && c2 <= '9'
+                    && c3 >= '0' && c3 <= '9'
+                    && c4 == '-'
+                    && c5 >= '0' && c5 <= '9'
+                    && c6 >= '0' && c6 <= '9'
+                    && c7 == '-'
+                    && c8 >= '0' && c8 <= '9'
+                    && c9 >= '0' && c9 <= '9'
+            ) {
+                year = (c0 - '0') * 1000 + (c1 - '0') * 100 + (c2 - '0') * 10 + (c3 - '0');
+                month = (c5 - '0') * 10 + (c6 - '0');
+                dayOfMonth = (c8 - '0') * 10 + (c9 - '0');
+            } else {
+                return super.parse(text);
+            }
+
+            int dom = 31;
+            switch (month) {
+                case 2:
+                    boolean isLeapYear = ((year & 3) == 0) && ((year % 100) != 0 || (year % 400) == 0);
+                    dom = isLeapYear ? 29 : 28;
+                    break;
+                case 4:
+                case 6:
+                case 9:
+                case 11:
+                    dom = 30;
+                    break;
+            }
+
+            if (year >= -999999999 && year <= 999999999
+                    && month >= 1 && month <= 12
+                    && dayOfMonth >= 1 && dayOfMonth <= dom
+            ) {
+                calendar.set(Calendar.YEAR, year);
+                calendar.set(Calendar.MONTH, month - 1);
+                calendar.set(Calendar.DAY_OF_MONTH, dayOfMonth);
+
+                if (format10) {
+                    calendar.set(Calendar.HOUR_OF_DAY, 0);
+                    calendar.set(Calendar.MINUTE, 0);
+                    calendar.set(Calendar.SECOND, 0);
+                    calendar.set(Calendar.MILLISECOND, 0);
+
+                    pos.index = 10;
+                    return calendar.getTime();
+                }
+
+                char c10 = text.charAt(10);
+                char c11 = text.charAt(11);
+                char c12 = text.charAt(12);
+                char c13 = text.charAt(13);
+                char c14 = text.charAt(14);
+                char c15 = text.charAt(15);
+                char c16 = text.charAt(16);
+                char c17 = text.charAt(17);
+                char c18 = text.charAt(18);
+
+                int hour, minute, second;
+                if (c10 == ' '
+                        && c11 >= '0' && c11 <= '9'
+                        && c12 >= '0' && c12 <= '9'
+                        && c13 == ':'
+                        && c14 >= '0' && c14 <= '9'
+                        && c15 >= '0' && c15 <= '9'
+                        && c16 == ':'
+                        && c17 >= '0' && c17 <= '9'
+                        && c18 >= '0' && c18 <= '9'
+                ) {
+                    hour = (c11 - '0') * 10 + (c12 - '0');
+                    minute = (c14 - '0') * 10 + (c15 - '0');
+                    second = (c17 - '0') * 10 + (c18 - '0');
+
+                    if (hour >= 0 && hour <= 23
+                            && minute >= 0 && minute <= 59
+                            && second >= 0 && second <= 59
+                    ) {
+                        calendar.set(Calendar.HOUR_OF_DAY, hour);
+                        calendar.set(Calendar.MINUTE, minute);
+                        calendar.set(Calendar.SECOND, second);
+                        calendar.set(Calendar.MILLISECOND, 0);
+
+                        pos.index = 19;
+                        return calendar.getTime();
+                    }
+                }
+            }
+        }
 
         boolean[] ambiguousYear = {false};
 

--- a/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
+++ b/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
@@ -107,7 +107,8 @@ public class TestMemoryMXBeansAndPoolsPresence {
         switch (args[0]) {
             case "G1":
                 test(new GCBeanDescription("G1 Young Generation", new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}),
-                     new GCBeanDescription("G1 Old Generation",   new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}));
+                     new GCBeanDescription("G1 Old Generation",   new String[] {"G1 Eden Space", "G1 Survivor Space", "G1 Old Gen"}),
+                     new GCBeanDescription("G1 Concurrent GC",    new String[] {"G1 Old Gen"}));
                 break;
             case "CMS":
                 test(new GCBeanDescription("ParNew",              new String[] {"Par Eden Space", "Par Survivor Space"}),

--- a/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemarkCleanupMXBean.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+/*
+ * @test TestRemarkCleanupMXBean
+ * @bug 8297247
+ * @summary Test that Remark and Cleanup are correctly reported by
+ *          a GarbageCollectorMXBean
+ * @requires vm.gc.G1
+ * @library /test/lib /
+ * @build   sun.hotspot.WhiteBox
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run     driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UseG1GC -Xlog:gc
+ *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   gc.g1.TestRemarkCleanupMXBean
+ */
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import sun.hotspot.WhiteBox;
+import sun.hotspot.gc.GC;
+
+public class TestRemarkCleanupMXBean {
+    public static void main(String[] args) throws Exception {
+        GarbageCollectorMXBean g1ConcGCBean = null;
+        String expectedName = "G1 Concurrent GC";
+        for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (expectedName.equals(bean.getName())) {
+                g1ConcGCBean = bean;
+                break;
+            }
+        }
+        if (g1ConcGCBean == null) {
+            throw new RuntimeException("Unable to find GC bean: " + expectedName);
+        }
+
+        long before = g1ConcGCBean.getCollectionCount();
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        wb.g1StartConcMarkCycle();
+        while (wb.g1InConcurrentMark()) {
+            Thread.sleep(5);
+        }
+        long after = g1ConcGCBean.getCollectionCount();
+
+        if (after >= before + 2) { // Must report a Remark and a Cleanup
+            System.out.println(g1ConcGCBean.getName() + " reports a difference " +
+                               after + " - " + before + " = " + (after - before));
+        } else {
+            throw new RuntimeException("Remark or Cleanup not reported by " +
+                                       g1ConcGCBean.getName());
+        }
+    }
+}

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -48,6 +48,7 @@ requires.extraPropDefns.vmOpts = -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
 requires.properties= \
     sun.arch.data.model \
     java.runtime.name \
+    vm.gc.G1 \
     vm.gc.Z \
     vm.gc.Shenandoah \
     vm.graal.enabled \

--- a/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
+++ b/test/jdk/com/sun/management/GarbageCollectorMXBean/GarbageCollectionNotificationTest.java
@@ -29,7 +29,11 @@
  * @requires vm.opt.ExplicitGCInvokesConcurrent == null | vm.opt.ExplicitGCInvokesConcurrent == false
  * @modules java.management/sun.management
  *          jdk.management
- * @run     main/othervm GarbageCollectionNotificationTest
+ * @library /test/lib /
+ * @build   sun.hotspot.WhiteBox
+ * @run     driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run     main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                       GarbageCollectionNotificationTest
  */
 
 import java.util.*;
@@ -42,6 +46,8 @@ import com.sun.management.GcInfo;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.lang.reflect.Field;
+import sun.hotspot.WhiteBox;
+import sun.hotspot.gc.GC;
 
 public class GarbageCollectionNotificationTest {
     private static HashMap<String,Boolean> listenerInvoked = new HashMap<String,Boolean>();
@@ -98,6 +104,14 @@ public class GarbageCollectionNotificationTest {
         Object data[] = new Object[32];
         for(int i = 0; i<100000000; i++) {
             data[i%32] = new int[8];
+        }
+        // Trigger G1's concurrent mark
+        if (GC.G1.isSelected()) {
+            WhiteBox wb = WhiteBox.getWhiteBox();
+            wb.g1StartConcMarkCycle();
+            while (wb.g1InConcurrentMark()) {
+                Thread.sleep(5);
+            }
         }
         int wakeup = 0;
         synchronized(synchronizer) {

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -26,7 +26,7 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah" & !vm.gc.G1
  * @author  Mandy Chung
  *
  * @modules jdk.management
@@ -43,6 +43,18 @@
  *
  * @modules jdk.management
  * @run main MemoryTest 2 1
+ */
+
+/*
+ * @test
+ * @bug     4530538
+ * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
+ *          MemoryMXBean.getMemoryManager().
+ * @requires vm.gc.G1
+ * @author  Mandy Chung
+ *
+ * @modules jdk.management
+ * @run main MemoryTest 3 3
  */
 
 /*

--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTestAllGC.sh
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTestAllGC.sh
@@ -49,7 +49,7 @@ runOne()
 }
 
 # Test MemoryTest with default collector
-runOne MemoryTest 2 3
+runOne MemoryTest 3 3
 
 # Test MemoryTest with parallel scavenger collector
 runOne -XX:+UseParallelGC MemoryTest 2 3

--- a/test/lib/jdk/test/lib/jfr/GCHelper.java
+++ b/test/lib/jdk/test/lib/jfr/GCHelper.java
@@ -178,6 +178,7 @@ public class GCHelper {
 
         // old GarbageCollectionMXBeans.
         beanCollectorTypes.put("G1 Old Generation", false);
+        beanCollectorTypes.put("G1 Concurrent GC", false);
         beanCollectorTypes.put("ConcurrentMarkSweep", false);
         beanCollectorTypes.put("PS MarkSweep", false);
         beanCollectorTypes.put("MarkSweepCompact", false);


### PR DESCRIPTION
speed up SimpleDateFormat parse & format when pattern is 'yyyy-MM-dd HH:mm:ss' or 'yyyy-MM-dd'

```
Benchmark                      Mode    Cnt  Score    Error   Units
DateFormat10.simpleFormat      thrpt   5  1858.539 ± 78.923  ops/ms
DateFormat10.simpleFormat_new  thrpt   5  2402.644 ± 30.438  ops/ms
DateFormat10.simpleParse       thrpt   5  1568.848 ± 60.130  ops/ms
DateFormat10.simpleParse_new   thrpt   5  2708.162 ± 43.103  ops/ms
```

```
Benchmark                       Mode  Cnt     Score   Error   Units
DateFormat19.simpleFormat      thrpt    5  1566.106 ± 5.766  ops/ms
DateFormat19.simpleFormat_new  thrpt    5  1994.802 ± 8.613  ops/ms
DateFormat19.simpleParse       thrpt    5  1120.000 ± 6.246  ops/ms
DateFormat19.simpleParse_new   thrpt    5  2392.971 ± 8.166  ops/ms
```