### PR TITLE
[CDS] Set the VM flag "UseSharedSpaces" to false by default

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2478,7 +2478,7 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
                                                                             \
   /* Shared spaces */                                                       \
                                                                             \
-  product(bool, UseSharedSpaces, true,                                      \
+  product(bool, UseSharedSpaces, false,                                     \
           "Use shared spaces for metadata")                                 \
                                                                             \
   product(bool, VerifySharedSpaces, false,                                  \

--- a/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
+++ b/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
@@ -45,12 +45,8 @@ public class XShareAuto {
         output.shouldContain("Loading classes to share");
         output.shouldHaveExitValue(0);
 
-
-        // We have 2 test cases:
         String cases[] = {
             "-Xshare:auto",    // case [1]: -Xshare:auto is explicitly specified.
-            "-showversion"     // case [2]: -Xshare:auto is not explicitly specified,
-                               //           but VM should still use it by default.
         };
 
         for (String x : cases) {
@@ -68,6 +64,22 @@ public class XShareAuto {
                 // ASLR.
                 output.shouldContain("sharing");
             }
+            output.shouldHaveExitValue(0);
+        }
+
+        //We turn off UseSharedSpace by default.so if no -Xshare:auto, VM should not use it by default
+        String noShareCases[] = {
+                "-showversion"
+        };
+        for (String x : noShareCases) {
+            pb = ProcessTools.createJavaProcessBuilder(
+                    "-XX:+UnlockDiagnosticVMOptions",
+                    "-XX:SharedArchiveFile=./XShareAuto.jsa",
+                    "-Xlog:cds",
+                    x,
+                    "-version");
+            output = new OutputAnalyzer(pb.start());
+            output.shouldNotContain("sharing");
             output.shouldHaveExitValue(0);
         }
     }


### PR DESCRIPTION
Summary: The UseSharedSpaces default value is true, but change to false later.But this result in narrow klass base always not zero.

Test Plan: all jdk testcases

Reviewed-by: kuaiwei, yuleil

Issue: https://github.com/dragonwell-project/dragonwell11/issues/557