### PR TITLE
[Backport] Fix incorrect memory order in UL

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -2272,8 +2272,6 @@ void Parker::unpark() {
   }
 }
 
-#if INCLUDE_ZGC
-
 // Platform Monitor implementation
 
 os::PlatformMonitor::PlatformMonitor() {
@@ -2343,8 +2341,6 @@ void os::PlatformMonitor::notify_all() {
   int status = pthread_cond_broadcast(&_cond);
   assert_status(status == 0, status, "cond_broadcast");
 }
-
-#endif // INCLUDE_ZGC
 
 
 #endif // !SOLARIS

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -219,7 +219,6 @@ class PlatformParker : public CHeapObj<mtSynchronizer> {
   PlatformParker();
 };
 
-#if INCLUDE_ZGC
 // Platform specific implementation that underpins VM Monitor/Mutex class
 class PlatformMonitor : public CHeapObj<mtInternal> {
  private:
@@ -236,7 +235,6 @@ class PlatformMonitor : public CHeapObj<mtInternal> {
   void notify();
   void notify_all();
 };
-#endif // INCLUDE_ZGC
 
 #endif // !SOLARIS
 

--- a/src/hotspot/os/solaris/os_solaris.cpp
+++ b/src/hotspot/os/solaris/os_solaris.cpp
@@ -5287,6 +5287,72 @@ void Parker::unpark() {
   }
 }
 
+// Platform Monitor implementation
+
+os::PlatformMonitor::PlatformMonitor() {
+  int status = os::Solaris::cond_init(&_cond);
+  assert_status(status == 0, status, "cond_init");
+  status = os::Solaris::mutex_init(&_mutex);
+  assert_status(status == 0, status, "mutex_init");
+}
+
+os::PlatformMonitor::~PlatformMonitor() {
+  int status = os::Solaris::cond_destroy(&_cond);
+  assert_status(status == 0, status, "cond_destroy");
+  status = os::Solaris::mutex_destroy(&_mutex);
+  assert_status(status == 0, status, "mutex_destroy");
+}
+
+void os::PlatformMonitor::lock() {
+  int status = os::Solaris::mutex_lock(&_mutex);
+  assert_status(status == 0, status, "mutex_lock");
+}
+
+void os::PlatformMonitor::unlock() {
+  int status = os::Solaris::mutex_unlock(&_mutex);
+  assert_status(status == 0, status, "mutex_unlock");
+}
+
+bool os::PlatformMonitor::try_lock() {
+  int status = os::Solaris::mutex_trylock(&_mutex);
+  assert_status(status == 0 || status == EBUSY, status, "mutex_trylock");
+  return status == 0;
+}
+
+// Must already be locked
+int os::PlatformMonitor::wait(jlong millis) {
+  assert(millis >= 0, "negative timeout");
+  if (millis > 0) {
+    timestruc_t abst;
+    int ret = OS_TIMEOUT;
+    compute_abstime(&abst, millis);
+    int status = os::Solaris::cond_timedwait(&_cond, &_mutex, &abst);
+    assert_status(status == 0 || status == EINTR ||
+                  status == ETIME || status == ETIMEDOUT,
+                  status, "cond_timedwait");
+    // EINTR acts as spurious wakeup - which is permitted anyway
+    if (status == 0 || status == EINTR) {
+      ret = OS_OK;
+    }
+    return ret;
+  } else {
+    int status = os::Solaris::cond_wait(&_cond, &_mutex);
+    assert_status(status == 0 || status == EINTR,
+                  status, "cond_wait");
+    return OS_OK;
+  }
+}
+
+void os::PlatformMonitor::notify() {
+  int status = os::Solaris::cond_signal(&_cond);
+  assert_status(status == 0, status, "cond_signal");
+}
+
+void os::PlatformMonitor::notify_all() {
+  int status = os::Solaris::cond_broadcast(&_cond);
+  assert_status(status == 0, status, "cond_broadcast");
+}
+
 extern char** environ;
 
 // Run the specified command in a separate process. Return its exit value,

--- a/src/hotspot/os/solaris/os_solaris.hpp
+++ b/src/hotspot/os/solaris/os_solaris.hpp
@@ -335,4 +335,21 @@ class PlatformParker : public CHeapObj<mtSynchronizer> {
   }
 };
 
+// Platform specific implementation that underpins VM Monitor/Mutex class
+class PlatformMonitor : public CHeapObj<mtInternal> {
+ private:
+  mutex_t _mutex; // Native mutex for locking
+  cond_t  _cond;  // Native condition variable for blocking
+
+ public:
+  PlatformMonitor();
+  ~PlatformMonitor();
+  void lock();
+  void unlock();
+  bool try_lock();
+  int wait(jlong millis);
+  void notify();
+  void notify_all();
+};
+
 #endif // OS_SOLARIS_VM_OS_SOLARIS_HPP

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -631,6 +631,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     case os::vm_thread:
     case os::pgc_thread:
     case os::cgc_thread:
+    case os::asynclog_thread:
     case os::watcher_thread:
       if (VMThreadStackSize > 0) stack_size = (size_t)(VMThreadStackSize * K);
       break;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5456,6 +5456,55 @@ void Parker::unpark() {
   SetEvent(_ParkEvent);
 }
 
+// Platform Monitor implementation
+
+os::PlatformMonitor::PlatformMonitor() {
+  InitializeConditionVariable(&_cond);
+  InitializeCriticalSection(&_mutex);
+}
+
+os::PlatformMonitor::~PlatformMonitor() {
+  DeleteCriticalSection(&_mutex);
+}
+
+void os::PlatformMonitor::lock() {
+  EnterCriticalSection(&_mutex);
+}
+
+void os::PlatformMonitor::unlock() {
+  LeaveCriticalSection(&_mutex);
+}
+
+bool os::PlatformMonitor::try_lock() {
+  return TryEnterCriticalSection(&_mutex);
+}
+
+// Must already be locked
+int os::PlatformMonitor::wait(jlong millis) {
+  assert(millis >= 0, "negative timeout");
+  int ret = OS_TIMEOUT;
+  int status = SleepConditionVariableCS(&_cond, &_mutex,
+                                        millis == 0 ? INFINITE : millis);
+  if (status != 0) {
+    ret = OS_OK;
+  }
+  #ifndef PRODUCT
+  else {
+    DWORD err = GetLastError();
+    assert(err == ERROR_TIMEOUT, "SleepConditionVariableCS: %ld:", err);
+  }
+  #endif
+  return ret;
+}
+
+void os::PlatformMonitor::notify() {
+  WakeConditionVariable(&_cond);
+}
+
+void os::PlatformMonitor::notify_all() {
+  WakeAllConditionVariable(&_cond);
+}
+
 // Run the specified command in a separate process. Return its exit value,
 // or -1 on failure (e.g. can't create a new process).
 int os::fork_and_exec(char* cmd, bool use_vfork_if_available) {

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -206,4 +206,21 @@ class PlatformParker : public CHeapObj<mtSynchronizer> {
 
 } ;
 
+// Platform specific implementation that underpins VM Monitor/Mutex class
+class PlatformMonitor : public CHeapObj<mtInternal> {
+ private:
+  CRITICAL_SECTION   _mutex; // Native mutex for locking
+  CONDITION_VARIABLE _cond;  // Native condition variable for blocking
+
+ public:
+  PlatformMonitor();
+  ~PlatformMonitor();
+  void lock();
+  void unlock();
+  bool try_lock();
+  int wait(jlong millis);
+  void notify();
+  void notify_all();
+};
+
 #endif // OS_WINDOWS_VM_OS_WINDOWS_HPP

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -44,7 +44,7 @@ static const char vm_error_filename_fmt[] = "hs_err_pid%p.jfr";
 static const char vm_oom_filename_fmt[] = "hs_oom_pid%p.jfr";
 static const char vm_soe_filename_fmt[] = "hs_soe_pid%p.jfr";
 static const char chunk_file_jfr_ext[] = ".jfr";
-static const size_t iso8601_len = 19; // "YYYY-MM-DDTHH:MM:SS"
+static const size_t iso8601_len = 19; // "YYYY-MM-DDTHH:MM:SS" (note: we just use a subset of the full timestamp)
 
 static fio_fd open_exclusivly(const char* path) {
   return os::open(path, O_CREAT | O_RDWR, S_IREAD | S_IWRITE);

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -32,11 +32,11 @@ class AsyncLogWriter::AsyncLogLocker : public StackObj {
  public:
   AsyncLogLocker() {
     assert(_instance != NULL, "AsyncLogWriter::_lock is unavailable");
-    _instance->_lock.wait();
+    _instance->_lock.lock();
   }
 
   ~AsyncLogLocker() {
-    _instance->_lock.signal();
+    _instance->_lock.unlock();
   }
 };
 
@@ -51,7 +51,8 @@ void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
   }
 
   _buffer.push_back(msg);
-  _sem.signal();
+  _data_available = true;
+  _lock.notify();
 }
 
 void AsyncLogWriter::enqueue(LogFileOutput& output, const LogDecorations& decorations, const char* msg) {
@@ -75,7 +76,7 @@ void AsyncLogWriter::enqueue(LogFileOutput& output, LogMessageBuffer::Iterator m
 }
 
 AsyncLogWriter::AsyncLogWriter()
-  : _lock(1), _sem(0), _flush_sem(0),
+  : _flush_sem(0), _lock(), _data_available(false),
     _initialized(false),
     _stats(17 /*table_size*/),
     _buffer_max_size(AsyncLogBufferSize / (sizeof(AsyncLogMessage) + vwrite_buffer_size)) {
@@ -126,6 +127,7 @@ void AsyncLogWriter::write() {
     // append meta-messages of dropped counters
     AsyncLogMapIterator dropped_counters_iter(logs);
     _stats.iterate(&dropped_counters_iter);
+    _data_available = false;
   }
 
   LinkedListIterator<AsyncLogMessage> it(logs.head());
@@ -153,9 +155,14 @@ void AsyncLogWriter::write() {
 
 void AsyncLogWriter::run() {
   while (true) {
-    // The value of a semphore cannot be negative. Therefore, the current thread falls asleep
-    // when its value is zero. It will be waken up when new messages are enqueued.
-    _sem.wait();
+    {
+      AsyncLogLocker locker;
+
+      while (!_data_available) {
+        _lock.wait(0/* no timeout */);
+      }
+    }
+
     write();
   }
 }
@@ -198,7 +205,8 @@ void AsyncLogWriter::flush() {
 
       // Push directly in-case we are at logical max capacity, as this must not get dropped.
       _instance->_buffer.push_back(token);
-      _instance->_sem.signal();
+      _instance->_data_available = true;
+      _instance->_lock.notify();
     }
 
     _instance->_flush_sem.wait();

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -46,6 +46,7 @@ void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
     uint32_t* counter = _stats.add_if_absent(msg.output(), 0, &p_created);
     *counter = *counter + 1;
     // drop the enqueueing message.
+    os::free(msg.message());
     return;
   }
 

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -28,23 +28,17 @@
 #include "logging/logHandle.hpp"
 #include "runtime/atomic.hpp"
 
-Semaphore AsyncLogWriter::_sem(0);
-Semaphore AsyncLogWriter::_io_sem(1);
-
-class AsyncLogLocker : public StackObj {
- private:
-  static Semaphore _lock;
+class AsyncLogWriter::AsyncLogLocker : public StackObj {
  public:
   AsyncLogLocker() {
-    _lock.wait();
+    assert(_instance != NULL, "AsyncLogWriter::_lock is unavailable");
+    _instance->_lock.wait();
   }
 
   ~AsyncLogLocker() {
-    _lock.signal();
+    _instance->_lock.signal();
   }
 };
-
-Semaphore AsyncLogLocker::_lock(1);
 
 void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
   if (_buffer.size() >= _buffer_max_size)  {
@@ -64,7 +58,7 @@ void AsyncLogWriter::enqueue(LogFileOutput& output, const LogDecorations& decora
   AsyncLogMessage m(output, decorations, os::strdup(msg));
 
   { // critical area
-    AsyncLogLocker lock;
+    AsyncLogLocker locker;
     enqueue_locked(m);
   }
 }
@@ -72,7 +66,7 @@ void AsyncLogWriter::enqueue(LogFileOutput& output, const LogDecorations& decora
 // LogMessageBuffer consists of a multiple-part/multiple-line messsage.
 // The lock here guarantees its integrity.
 void AsyncLogWriter::enqueue(LogFileOutput& output, LogMessageBuffer::Iterator msg_iterator) {
-  AsyncLogLocker lock;
+  AsyncLogLocker locker;
 
   for (; !msg_iterator.is_at_end(); msg_iterator++) {
     AsyncLogMessage m(output, msg_iterator.decorations(), os::strdup(msg_iterator.message()));
@@ -81,7 +75,8 @@ void AsyncLogWriter::enqueue(LogFileOutput& output, LogMessageBuffer::Iterator m
 }
 
 AsyncLogWriter::AsyncLogWriter()
-  : _initialized(false),
+  : _lock(1), _sem(0), _io_sem(1),
+    _initialized(false),
     _stats(17 /*table_size*/),
     _buffer_max_size(AsyncLogBufferSize / (sizeof(AsyncLogMessage) + vwrite_buffer_size)) {
   if (os::create_thread(this, os::asynclog_thread)) {
@@ -126,7 +121,7 @@ void AsyncLogWriter::write() {
   bool own_io = false;
 
   { // critical region
-    AsyncLogLocker lock;
+    AsyncLogLocker locker;
 
     _buffer.pop_all(&logs);
     // append meta-messages of dropped counters

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -41,7 +41,7 @@ class AsyncLogWriter::AsyncLogLocker : public StackObj {
 };
 
 void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
-  if (_buffer.size() >= _buffer_max_size)  {
+  if (_buffer.size() >= _buffer_max_size) {
     bool p_created;
     uint32_t* counter = _stats.add_if_absent(msg.output(), 0, &p_created);
     *counter = *counter + 1;
@@ -50,13 +50,12 @@ void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
     return;
   }
 
-  assert(_buffer.size() < _buffer_max_size, "_buffer is over-sized.");
   _buffer.push_back(msg);
   _sem.signal();
 }
 
 void AsyncLogWriter::enqueue(LogFileOutput& output, const LogDecorations& decorations, const char* msg) {
-  AsyncLogMessage m(output, decorations, os::strdup(msg));
+  AsyncLogMessage m(&output, decorations, os::strdup(msg));
 
   { // critical area
     AsyncLogLocker locker;
@@ -70,13 +69,13 @@ void AsyncLogWriter::enqueue(LogFileOutput& output, LogMessageBuffer::Iterator m
   AsyncLogLocker locker;
 
   for (; !msg_iterator.is_at_end(); msg_iterator++) {
-    AsyncLogMessage m(output, msg_iterator.decorations(), os::strdup(msg_iterator.message()));
+    AsyncLogMessage m(&output, msg_iterator.decorations(), os::strdup(msg_iterator.message()));
     enqueue_locked(m);
   }
 }
 
 AsyncLogWriter::AsyncLogWriter()
-  : _lock(1), _sem(0), _io_sem(1),
+  : _lock(1), _sem(0), _flush_sem(0),
     _initialized(false),
     _stats(17 /*table_size*/),
     _buffer_max_size(AsyncLogBufferSize / (sizeof(AsyncLogMessage) + vwrite_buffer_size)) {
@@ -99,10 +98,10 @@ class AsyncLogMapIterator {
     //using none = LogTagSetMapping<LogTag::__NO_TAG>;
 
     if (*counter > 0) {
-      LogDecorations decorations(LogLevel::Warning, LogTagSetMapping<LogTag::__NO_TAG>::tagset(), output->decorators());
+      LogDecorations decorations(LogLevel::Warning, LogTagSetMapping<LogTag::__NO_TAG>::tagset(), LogDecorators::All);
       stringStream ss;
       ss.print(UINT32_FORMAT_W(6) " messages dropped due to async logging", *counter);
-      AsyncLogMessage msg(*output, decorations, ss.as_string(true /*c_heap*/));
+      AsyncLogMessage msg(output, decorations, ss.as_string(true /*c_heap*/));
       _logs.push_back(msg);
       *counter = 0;
     }
@@ -119,7 +118,6 @@ void AsyncLogWriter::write() {
   // The operation 'pop_all()' is done in O(1). All I/O jobs are then performed without
   // lock protection. This guarantees I/O jobs don't block logsites.
   AsyncLogBuffer logs;
-  bool own_io = false;
 
   { // critical region
     AsyncLogLocker locker;
@@ -128,14 +126,11 @@ void AsyncLogWriter::write() {
     // append meta-messages of dropped counters
     AsyncLogMapIterator dropped_counters_iter(logs);
     _stats.iterate(&dropped_counters_iter);
-    own_io = _io_sem.trywait();
   }
 
   LinkedListIterator<AsyncLogMessage> it(logs.head());
-  if (!own_io) {
-    _io_sem.wait();
-  }
-  //differs from 8229517, replace is_empty with has_next
+
+  int req = 0;
   while (!it.has_next()) {
     const AsyncLogMessage* e = it.next();
     char* msg = e->message();
@@ -143,9 +138,17 @@ void AsyncLogWriter::write() {
     if (msg != NULL) {
       e->output()->write_blocking(e->decorations(), msg);
       os::free(msg);
+    } else if (e->output() == NULL) {
+      // This is a flush token. Record that we found it and then
+      // signal the flushing thread after the loop.
+      req++;
     }
   }
-  _io_sem.signal();
+
+  if (req > 0) {
+    assert(req == 1, "AsyncLogWriter::flush() is NOT MT-safe!");
+    _flush_sem.signal(req);
+  }
 }
 
 void AsyncLogWriter::run() {
@@ -182,10 +185,22 @@ AsyncLogWriter* AsyncLogWriter::instance() {
   return _instance;
 }
 
-// write() acquires and releases _io_sem even _buffer is empty.
-// This guarantees all logging I/O of dequeued messages are done when it returns.
+// Inserts a flush token into the async output buffer and waits until the AsyncLog thread
+// signals that it has seen it and completed all dequeued message processing.
+// This method is not MT-safe in itself, but is guarded by another lock in the usual
+// usecase - see the comments in the header file for more details.
 void AsyncLogWriter::flush() {
   if (_instance != NULL) {
-    _instance->write();
+    {
+      AsyncLogLocker locker;
+      LogDecorations d(LogLevel::Off, LogTagSetMapping<LogTag::__NO_TAG>::tagset(), LogDecorators::None);
+      AsyncLogMessage token(NULL, d, NULL);
+
+      // Push directly in-case we are at logical max capacity, as this must not get dropped.
+      _instance->_buffer.push_back(token);
+      _instance->_sem.signal();
+    }
+
+    _instance->_flush_sem.wait();
   }
 }

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#include "precompiled.hpp"
+#include "logging/logAsyncWriter.hpp"
+#include "logging/logConfiguration.hpp"
+#include "logging/logFileOutput.hpp"
+#include "logging/logHandle.hpp"
+#include "runtime/atomic.hpp"
+
+Semaphore AsyncLogWriter::_sem(0);
+Semaphore AsyncLogWriter::_io_sem(1);
+
+class AsyncLogLocker : public StackObj {
+ private:
+  static Semaphore _lock;
+ public:
+  AsyncLogLocker() {
+    _lock.wait();
+  }
+
+  ~AsyncLogLocker() {
+    _lock.signal();
+  }
+};
+
+Semaphore AsyncLogLocker::_lock(1);
+
+void AsyncLogWriter::enqueue_locked(const AsyncLogMessage& msg) {
+  if (_buffer.size() >= _buffer_max_size)  {
+    bool p_created;
+    uint32_t* counter = _stats.add_if_absent(msg.output(), 0, &p_created);
+    *counter = *counter + 1;
+    // drop the enqueueing message.
+    return;
+  }
+
+  assert(_buffer.size() < _buffer_max_size, "_buffer is over-sized.");
+  _buffer.push_back(msg);
+  _sem.signal();
+}
+
+void AsyncLogWriter::enqueue(LogFileOutput& output, const LogDecorations& decorations, const char* msg) {
+  AsyncLogMessage m(output, decorations, os::strdup(msg));
+
+  { // critical area
+    AsyncLogLocker lock;
+    enqueue_locked(m);
+  }
+}
+
+// LogMessageBuffer consists of a multiple-part/multiple-line messsage.
+// The lock here guarantees its integrity.
+void AsyncLogWriter::enqueue(LogFileOutput& output, LogMessageBuffer::Iterator msg_iterator) {
+  AsyncLogLocker lock;
+
+  for (; !msg_iterator.is_at_end(); msg_iterator++) {
+    AsyncLogMessage m(output, msg_iterator.decorations(), os::strdup(msg_iterator.message()));
+    enqueue_locked(m);
+  }
+}
+
+AsyncLogWriter::AsyncLogWriter()
+  : _initialized(false),
+    _stats(17 /*table_size*/),
+    _buffer_max_size(AsyncLogBufferSize / (sizeof(AsyncLogMessage) + vwrite_buffer_size)) {
+  if (os::create_thread(this, os::asynclog_thread)) {
+    _initialized = true;
+  } else {
+    log_warning(logging, thread)("AsyncLogging failed to create thread. Falling back to synchronous logging.");
+  }
+
+  log_info(logging)("The maximum entries of AsyncLogBuffer: " SIZE_FORMAT ", estimated memory use: " SIZE_FORMAT " bytes",
+                    _buffer_max_size, AsyncLogBufferSize);
+}
+
+class AsyncLogMapIterator {
+  AsyncLogBuffer& _logs;
+
+ public:
+  AsyncLogMapIterator(AsyncLogBuffer& logs) :_logs(logs) {}
+  bool do_entry(LogFileOutput* output, uint32_t* counter) {
+    //using none = LogTagSetMapping<LogTag::__NO_TAG>;
+
+    if (*counter > 0) {
+      LogDecorations decorations(LogLevel::Warning, LogTagSetMapping<LogTag::__NO_TAG>::tagset(), output->decorators());
+      stringStream ss;
+      ss.print(UINT32_FORMAT_W(6) " messages dropped due to async logging", *counter);
+      AsyncLogMessage msg(*output, decorations, ss.as_string(true /*c_heap*/));
+      _logs.push_back(msg);
+      *counter = 0;
+    }
+
+    return true;
+  }
+};
+
+void AsyncLogWriter::write() {
+  // Use kind of copy-and-swap idiom here.
+  // Empty 'logs' swaps the content with _buffer.
+  // Along with logs destruction, all processed messages are deleted.
+  //
+  // The operation 'pop_all()' is done in O(1). All I/O jobs are then performed without
+  // lock protection. This guarantees I/O jobs don't block logsites.
+  AsyncLogBuffer logs;
+  bool own_io = false;
+
+  { // critical region
+    AsyncLogLocker lock;
+
+    _buffer.pop_all(&logs);
+    // append meta-messages of dropped counters
+    AsyncLogMapIterator dropped_counters_iter(logs);
+    _stats.iterate(&dropped_counters_iter);
+    own_io = _io_sem.trywait();
+  }
+
+  LinkedListIterator<AsyncLogMessage> it(logs.head());
+  if (!own_io) {
+    _io_sem.wait();
+  }
+  //differs from 8229517, replace is_empty with has_next
+  while (!it.has_next()) {
+    const AsyncLogMessage* e = it.next();
+    char* msg = e->message();
+
+    if (msg != NULL) {
+      e->output()->write_blocking(e->decorations(), msg);
+      os::free(msg);
+    }
+  }
+  _io_sem.signal();
+}
+
+void AsyncLogWriter::run() {
+  while (true) {
+    // The value of a semphore cannot be negative. Therefore, the current thread falls asleep
+    // when its value is zero. It will be waken up when new messages are enqueued.
+    _sem.wait();
+    write();
+  }
+}
+
+AsyncLogWriter* AsyncLogWriter::_instance = NULL;
+
+void AsyncLogWriter::initialize() {
+  if (!LogConfiguration::is_async_mode()) return;
+
+  assert(_instance == NULL, "initialize() should only be invoked once.");
+
+  AsyncLogWriter* self = new AsyncLogWriter();
+  if (self->_initialized) {
+    OrderAccess::release_store_fence(&AsyncLogWriter::_instance, self);
+    // All readers of _instance after the fence see non-NULL.
+    // We use LogOutputList's RCU counters to ensure all synchronous logsites have completed.
+    // After that, we start AsyncLog Thread and it exclusively takes over all logging I/O.
+    for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+      ts->wait_until_no_readers();
+    }
+    os::start_thread(self);
+    log_debug(logging, thread)("Async logging thread started.");
+  }
+}
+
+AsyncLogWriter* AsyncLogWriter::instance() {
+  return _instance;
+}
+
+// write() acquires and releases _io_sem even _buffer is empty.
+// This guarantees all logging I/O of dequeued messages are done when it returns.
+void AsyncLogWriter::flush() {
+  if (_instance != NULL) {
+    _instance->write();
+  }
+}

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -133,12 +133,16 @@ typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
 // times. It is no-op if async logging is not established.
 //
 class AsyncLogWriter : public NonJavaThread {
+  class AsyncLogLocker;
+
   static AsyncLogWriter* _instance;
+  // _lock(1) denotes a critional region.
+  Semaphore _lock;
   // _sem is a semaphore whose value denotes how many messages have been enqueued.
   // It decreases in AsyncLogWriter::run()
-  static Semaphore _sem;
+  Semaphore _sem;
   // A lock of IO
-  static Semaphore _io_sem;
+  Semaphore _io_sem;
 
   volatile bool _initialized;
   AsyncLogMap _stats; // statistics for dropped messages

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -135,13 +135,10 @@ class AsyncLogWriter : public NonJavaThread {
   class AsyncLogLocker;
 
   static AsyncLogWriter* _instance;
-  // _lock(1) denotes a critional region.
-  Semaphore _lock;
-  // _sem is a semaphore whose value denotes how many messages have been enqueued.
-  // It decreases in AsyncLogWriter::run()
-  Semaphore _sem;
   Semaphore _flush_sem;
-
+  // Can't use a Monitor here as we need a low-level API that can be used without Thread::current().
+  os::PlatformMonitor _lock;
+  bool _data_available;
   volatile bool _initialized;
   AsyncLogMap _stats; // statistics for dropped messages
   AsyncLogBuffer _buffer;

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -25,10 +25,10 @@
 #define SHARE_LOGGING_LOGASYNCWRITER_HPP
 #include "logging/log.hpp"
 #include "logging/logDecorations.hpp"
-#include "logging/logFileOutput.hpp"
 #include "logging/logMessageBuffer.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/thread.hpp"
+#include "runtime/semaphore.hpp"
 #include "utilities/hashtable.hpp"
 #include "utilities/linkedlist.hpp"
 
@@ -90,25 +90,34 @@ class LinkedListDeque : private LinkedListImpl<E, ResourceObj::C_HEAP, F> {
   }
 };
 
+// Forward declaration
+class LogFileStreamOutput;
+
 class AsyncLogMessage {
-  LogFileOutput* _output;
+  LogFileStreamOutput* _output;
   const LogDecorations _decorations;
   char* _message;
 
 public:
-  AsyncLogMessage(LogFileOutput* output, const LogDecorations& decorations, char* msg)
+  AsyncLogMessage(LogFileStreamOutput* output, const LogDecorations& decorations, char* msg)
     : _output(output), _decorations(decorations), _message(msg) {}
 
   // placeholder for LinkedListImpl.
   bool equals(const AsyncLogMessage& o) const { return false; }
 
-  LogFileOutput* output() const { return _output; }
+  LogFileStreamOutput* output() const { return _output; }
   const LogDecorations& decorations() const { return _decorations; }
   char* message() const { return _message; }
 };
 
 typedef LinkedListDeque<AsyncLogMessage, mtLogging> AsyncLogBuffer;
-typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
+typedef ResourceHashtable<LogFileStreamOutput*,
+                          uint32_t,
+                          primitive_hash<LogFileStreamOutput*>,
+                          primitive_equals<LogFileStreamOutput*>,
+                          17, /*table_size*/
+                          ResourceObj::C_HEAP,
+                          mtLogging> AsyncLogMap;
 
 //
 // ASYNC LOGGING SUPPORT
@@ -159,8 +168,8 @@ class AsyncLogWriter : public NonJavaThread {
     Thread::print_on(st);
     st->cr();
   }
-  void enqueue(LogFileOutput& output, const LogDecorations& decorations, const char* msg);
-  void enqueue(LogFileOutput& output, LogMessageBuffer::Iterator msg_iterator);
+  void enqueue(LogFileStreamOutput& output, const LogDecorations& decorations, const char* msg);
+  void enqueue(LogFileStreamOutput& output, LogMessageBuffer::Iterator msg_iterator);
 
   static AsyncLogWriter* instance();
   static void initialize();

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#ifndef SHARE_LOGGING_LOGASYNCWRITER_HPP
+#define SHARE_LOGGING_LOGASYNCWRITER_HPP
+#include "logging/log.hpp"
+#include "logging/logDecorations.hpp"
+#include "logging/logFileOutput.hpp"
+#include "logging/logMessageBuffer.hpp"
+#include "memory/resourceArea.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/hashtable.hpp"
+#include "utilities/linkedlist.hpp"
+
+template <typename E, MEMFLAGS F>
+class LinkedListDeque : private LinkedListImpl<E, ResourceObj::C_HEAP, F> {
+ private:
+  LinkedListNode<E>* _tail;
+    size_t _size;
+
+ public:
+  LinkedListDeque() : _tail(NULL), _size(0) {}
+  void push_back(const E& e) {
+    if (!_tail) {
+      _tail = this->add(e);
+    } else {
+      _tail = this->insert_after(e, _tail);
+    }
+
+    ++_size;
+  }
+
+  // pop all elements to logs.
+  void pop_all(LinkedList<E>* logs) {
+    logs->move(static_cast<LinkedList<E>* >(this));
+    _tail = NULL;
+    _size = 0;
+  }
+
+  void pop_all(LinkedListDeque<E, F>* logs) {
+    logs->_size = _size;
+    logs->_tail = _tail;
+    pop_all(static_cast<LinkedList<E>* >(logs));
+  }
+
+  void pop_front() {
+    LinkedListNode<E>* h = this->unlink_head();
+    if (h == _tail) {
+      _tail = NULL;
+    }
+
+    if (h != NULL) {
+      --_size;
+      this->delete_node(h);
+    }
+  }
+
+  size_t size() const { return _size; }
+
+  const E* front() const {
+    return this->_head == NULL ? NULL : this->_head->peek();
+  }
+
+  const E* back() const {
+    return _tail == NULL ? NULL : _tail->peek();
+  }
+
+  LinkedListNode<E>* head() const {
+    return this->_head;
+  }
+};
+
+class AsyncLogMessage {
+  LogFileOutput& _output;
+  const LogDecorations _decorations;
+  char* _message;
+
+public:
+  AsyncLogMessage(LogFileOutput& output, const LogDecorations& decorations, char* msg)
+    : _output(output), _decorations(decorations), _message(msg) {}
+
+  // placeholder for LinkedListImpl.
+  bool equals(const AsyncLogMessage& o) const { return false; }
+
+  LogFileOutput* output() const { return &_output; }
+  const LogDecorations& decorations() const { return _decorations; }
+  char* message() const { return _message; }
+};
+
+typedef LinkedListDeque<AsyncLogMessage, mtLogging> AsyncLogBuffer;
+typedef KVHashtable<LogFileOutput*, uint32_t, mtLogging> AsyncLogMap;
+
+//
+// ASYNC LOGGING SUPPORT
+//
+// Summary:
+// Async Logging is working on the basis of singleton AsyncLogWriter, which manages an intermediate buffer and a flushing thread.
+//
+// Interface:
+//
+// initialize() is called once when JVM is initialized. It creates and initializes the singleton instance of AsyncLogWriter.
+// Once async logging is established, there's no way to turn it off.
+//
+// instance() is MT-safe and returns the pointer of the singleton instance if and only if async logging is enabled and has well
+// initialized. Clients can use its return value to determine async logging is established or not.
+//
+// The basic operation of AsyncLogWriter is enqueue(). 2 overloading versions of it are provided to match LogOutput::write().
+// They are both MT-safe and non-blocking. Derived classes of LogOutput can invoke the corresponding enqueue() in write() and
+// return 0. AsyncLogWriter is responsible of copying neccessary data.
+//
+// The static member function flush() is designated to flush out all pending messages when JVM is terminating.
+// In normal JVM termination, flush() is invoked in LogConfiguration::finalize(). flush() is MT-safe and can be invoked arbitrary
+// times. It is no-op if async logging is not established.
+//
+class AsyncLogWriter : public NonJavaThread {
+  static AsyncLogWriter* _instance;
+  // _sem is a semaphore whose value denotes how many messages have been enqueued.
+  // It decreases in AsyncLogWriter::run()
+  static Semaphore _sem;
+  // A lock of IO
+  static Semaphore _io_sem;
+
+  volatile bool _initialized;
+  AsyncLogMap _stats; // statistics for dropped messages
+  AsyncLogBuffer _buffer;
+
+  // The memory use of each AsyncLogMessage (payload) consists of itself and a variable-length c-str message.
+  // A regular logging message is smaller than vwrite_buffer_size, which is defined in logtagset.cpp
+  const size_t _buffer_max_size;
+
+  AsyncLogWriter();
+  void enqueue_locked(const AsyncLogMessage& msg);
+  void write();
+  void run();
+  char* name() const { return (char*)"AsyncLog Thread"; }
+  bool is_Named_thread() const { return true; }
+
+ public:
+  void print_on(outputStream* st) const {
+    st->print("\"%s\" ", name());
+    Thread::print_on(st);
+    st->cr();
+  }
+  void enqueue(LogFileOutput& output, const LogDecorations& decorations, const char* msg);
+  void enqueue(LogFileOutput& output, LogMessageBuffer::Iterator msg_iterator);
+
+  static AsyncLogWriter* instance();
+  static void initialize();
+  static void flush();
+};
+
+#endif // SHARE_LOGGING_LOGASYNCWRITER_HPP

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -153,7 +153,6 @@ class AsyncLogWriter : public NonJavaThread {
   void write();
   void run();
   char* name() const { return (char*)"AsyncLog Thread"; }
-  bool is_Named_thread() const { return true; }
 
  public:
   void print_on(outputStream* st) const {

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -111,9 +111,7 @@ void LogConfiguration::initialize(jlong vm_start_time) {
 }
 
 void LogConfiguration::finalize() {
-  for (size_t i = _n_outputs; i > 0; i--) {
-    disable_output(i - 1);
-  }
+  disable_outputs();
   FREE_C_HEAP_ARRAY(LogOutput*, _outputs);
 }
 
@@ -273,28 +271,31 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
   assert(strlen(output->config_string()) > 0, "should always have a config description");
 }
 
-void LogConfiguration::disable_output(size_t idx) {
-  assert(idx < _n_outputs, "invalid index: " SIZE_FORMAT " (_n_outputs: " SIZE_FORMAT ")", idx, _n_outputs);
-  LogOutput* out = _outputs[idx];
+void LogConfiguration::disable_outputs() {
+  size_t idx = _n_outputs;
 
-  // Remove the output from all tagsets.
+  // Remove all outputs from all tagsets.
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
-    ts->set_output_level(out, LogLevel::Off);
-    ts->update_decorators();
+    ts->disable_outputs();
   }
 
-  // Delete the output unless stdout or stderr (idx 0 or 1)
-  if (idx > 1) {
-    delete_output(idx);
-  } else {
-    out->set_config_string("all=off");
+  while (idx > 0) {
+    LogOutput* out = _outputs[--idx];
+    // Delete the output unless stdout or stderr (idx 0 or 1)
+    if (idx > 1) {
+      delete_output(idx);
+    } else {
+      out->set_config_string("all=off");
+    }
   }
 }
 
 void LogConfiguration::disable_logging() {
   ConfigurationLock cl;
-  for (size_t i = _n_outputs; i > 0; i--) {
-    disable_output(i - 1);
+  disable_outputs();
+  // Update the decorators on all tagsets to get rid of unused decorators
+  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+    ts->update_decorators();
   }
   notify_update_listeners();
 }

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -212,6 +212,21 @@ void LogConfiguration::delete_output(size_t idx) {
   delete output;
 }
 
+// MT-SAFETY
+//
+// The ConfigurationLock guarantees that only one thread is performing reconfiguration. This function still needs
+// to be MT-safe because logsites in other threads may be executing in parallel. Reconfiguration means unified
+// logging allows users to dynamically change tags and decorators of a log output via DCMD(logDiagnosticCommand.hpp).
+//
+// A RCU-style synchronization 'wait_until_no_readers()' is used inside of 'ts->set_output_level(output, level)'
+// if a setting has changed. It guarantees that all logs, either synchronous writes or enqueuing to the async buffer
+// see the new tags and decorators. It's worth noting that the synchronization occurs even if the level does not change.
+//
+// LogDecorator is a set of decorators represented in a uint. ts->update_decorators(decorators) is a union of the
+// current decorators and new_decorators. It's safe to do output->set_decorators(decorators) because new_decorators
+// is a subset of relevant tagsets decorators. After updating output's decorators, it is still safe to shrink all
+// decorators of tagsets.
+//
 void LogConfiguration::configure_output(size_t idx, const LogSelectionList& selections, const LogDecorators& decorators) {
   assert(ConfigurationLock::current_thread_has_lock(), "Must hold configuration lock to call this function.");
   assert(idx < _n_outputs, "Invalid index, idx = " SIZE_FORMAT " and _n_outputs = " SIZE_FORMAT, idx, _n_outputs);
@@ -254,6 +269,10 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
     on_level[level]++;
   }
 
+  // For async logging we have to ensure that all enqueued messages, which may refer to previous decorators,
+  // or a soon-to-be-deleted output, are written out first. The flush() call ensures this.
+  AsyncLogWriter::flush();
+
   // It is now safe to set the new decorators for the actual output
   output->set_decorators(decorators);
 
@@ -263,10 +282,6 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
   }
 
   if (!enabled && idx > 1) {
-    // User may disable a logOuput like this:
-    // LogConfiguration::parse_log_arguments(filename, "all=off", "", "", &stream);
-    // Just be conservative. Flush them all before deleting idx.
-    AsyncLogWriter::flush();
     // Output is unused and should be removed, unless it is stdout/stderr (idx < 2)
     delete_output(idx);
     return;
@@ -284,10 +299,10 @@ void LogConfiguration::disable_outputs() {
     ts->disable_outputs();
   }
 
-  // Handle jcmd VM.log disable
-  // ts->disable_outputs() above has deleted output_list with RCU synchronization.
-  // Therefore, no new logging entry can enter AsyncLog buffer for the time being.
-  // flush pending entries before LogOutput instances die.
+  // Handle 'jcmd VM.log disable' and JVM termination.
+  // ts->disable_outputs() above has disabled all output_lists with RCU synchronization.
+  // Therefore, no new logging message can enter the async buffer for the time being.
+  // flush out all pending messages before LogOutput instances die.
   AsyncLogWriter::flush();
 
   while (idx > 0) {

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "jvm.h"
 #include "logging/log.hpp"
+#include "logging/logAsyncWriter.hpp"
 #include "logging/logConfiguration.hpp"
 #include "logging/logDecorations.hpp"
 #include "logging/logDecorators.hpp"
@@ -262,6 +263,10 @@ void LogConfiguration::configure_output(size_t idx, const LogSelectionList& sele
   }
 
   if (!enabled && idx > 1) {
+    // User may disable a logOuput like this:
+    // LogConfiguration::parse_log_arguments(filename, "all=off", "", "", &stream);
+    // Just be conservative. Flush them all before deleting idx.
+    AsyncLogWriter::flush();
     // Output is unused and should be removed, unless it is stdout/stderr (idx < 2)
     delete_output(idx);
     return;
@@ -278,6 +283,12 @@ void LogConfiguration::disable_outputs() {
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     ts->disable_outputs();
   }
+
+  // Handle jcmd VM.log disable
+  // ts->disable_outputs() above has deleted output_list with RCU synchronization.
+  // Therefore, no new logging entry can enter AsyncLog buffer for the time being.
+  // flush pending entries before LogOutput instances die.
+  AsyncLogWriter::flush();
 
   while (idx > 0) {
     LogOutput* out = _outputs[--idx];
@@ -539,6 +550,13 @@ void LogConfiguration::print_command_line_help(outputStream* out) {
                                     " This will cause existing log files to be overwritten.");
   out->cr();
 
+  out->print_cr("\nAsynchronous logging (off by default):");
+  out->print_cr(" -Xlog:async");
+  out->print_cr("  All log messages are written to an intermediate buffer first and will then be flushed"
+                " to the corresponding log outputs by a standalone thread. Write operations at logsites are"
+                " guaranteed non-blocking.");
+  out->cr();
+
   out->print_cr("Some examples:");
   out->print_cr(" -Xlog");
   out->print_cr("\t Log all messages up to 'info' level to stdout with 'uptime', 'levels' and 'tags' decorations.");
@@ -580,6 +598,10 @@ void LogConfiguration::print_command_line_help(outputStream* out) {
   out->print_cr(" -Xlog:disable -Xlog:safepoint=trace:safepointtrace.txt");
   out->print_cr("\t Turn off all logging, including warnings and errors,");
   out->print_cr("\t and then enable messages tagged with 'safepoint' up to 'trace' level to file 'safepointtrace.txt'.");
+
+  out->print_cr(" -Xlog:async -Xlog:gc=debug:file=gc.log -Xlog:safepoint=trace");
+  out->print_cr("\t Write logs asynchronously. Enable messages tagged with 'safepoint' up to 'trace' level to stdout ");
+  out->print_cr("\t and messages tagged with 'gc' up to 'debug' level to file 'gc.log'.");
 }
 
 void LogConfiguration::rotate_all_outputs() {
@@ -606,3 +628,5 @@ void LogConfiguration::notify_update_listeners() {
     _listener_callbacks[i]();
   }
 }
+
+bool LogConfiguration::_async_mode = false;

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -69,8 +69,8 @@ class LogConfiguration : public AllStatic {
   // Output should be completely disabled before it is deleted.
   static void delete_output(size_t idx);
 
-  // Disable all logging to the specified output and then delete it (unless it is stdout/stderr).
-  static void disable_output(size_t idx);
+  // Disable all logging to all outputs. All outputs except stdout/stderr will be deleted.
+  static void disable_outputs();
 
   // Get output index by name. Returns SIZE_MAX if output not found.
   static size_t find_output(const char* name);

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -58,6 +58,7 @@ class LogConfiguration : public AllStatic {
 
   static UpdateListenerFunction*    _listener_callbacks;
   static size_t                     _n_listener_callbacks;
+  static bool                       _async_mode;
 
   // Create a new output. Returns NULL if failed.
   static LogOutput* new_output(const char* name, const char* options, outputStream* errstream);
@@ -123,6 +124,11 @@ class LogConfiguration : public AllStatic {
 
   // Rotates all LogOutput
   static void rotate_all_outputs();
+
+  static bool is_async_mode() { return _async_mode; }
+  static void set_async_mode(bool value) {
+    _async_mode = value;
+  }
 };
 
 #endif // SHARE_VM_LOGGING_LOGCONFIGURATION_HPP

--- a/src/hotspot/share/logging/logDecorations.cpp
+++ b/src/hotspot/share/logging/logDecorations.cpp
@@ -29,108 +29,106 @@
 #include "runtime/thread.inline.hpp"
 #include "services/management.hpp"
 
-jlong LogDecorations::_vm_start_time_millis = 0;
 const char* LogDecorations::_host_name = "";
 
-LogDecorations::LogDecorations(LogLevelType level, const LogTagSet &tagset, const LogDecorators &decorators)
-    : _level(level), _tagset(tagset), _millis(-1) {
-  create_decorations(decorators);
-}
+const int LogDecorations::_pid = os::current_process_id(); // This is safe to call during dynamic initialization.
 
 void LogDecorations::initialize(jlong vm_start_time) {
   char buffer[1024];
   if (os::get_host_name(buffer, sizeof(buffer))){
     _host_name = os::strdup_check_oom(buffer);
   }
-  _vm_start_time_millis = vm_start_time;
 }
 
-void LogDecorations::create_decorations(const LogDecorators &decorators) {
-  char* position = _decorations_buffer;
-  #define DECORATOR(full_name, abbr) \
-  if (decorators.is_decorator(LogDecorators::full_name##_decorator)) { \
-    _decoration_offset[LogDecorators::full_name##_decorator] = position; \
-    position = create_##full_name##_decoration(position) + 1; \
-  } else { \
-    _decoration_offset[LogDecorators::full_name##_decorator] = NULL; \
-  }
+LogDecorations::LogDecorations(LogLevelType level, const LogTagSet &tagset, const LogDecorators &decorators) :
+  // When constructing the LogDecorations we resolve values for the requested decorators.
+  //
+  // _millis: needed for "time", "utctime", "timemillis":
+  _millis(
+      (decorators.is_decorator(LogDecorators::time_decorator) ||
+       decorators.is_decorator(LogDecorators::utctime_decorator) ||
+       decorators.is_decorator(LogDecorators::timemillis_decorator)) ? os::javaTimeMillis() : 0),
+  // _nanos: needed for "timenanos"
+  _nanos(decorators.is_decorator(LogDecorators::timenanos_decorator) ? os::javaTimeNanos() : 0),
+  // _elapsed_seconds: needed for "uptime", "uptimemillis", "uptimenanos"
+  _elapsed_seconds(
+      (decorators.is_decorator(LogDecorators::uptime_decorator) ||
+       decorators.is_decorator(LogDecorators::uptimemillis_decorator) ||
+       decorators.is_decorator(LogDecorators::uptimenanos_decorator)) ? os::elapsedTime() : 0),
+  // tid
+  _tid(decorators.is_decorator(LogDecorators::tid_decorator) ? os::current_thread_id() : 0),
+  // the rest is handed down by the caller
+  _level(level), _tagset(tagset)
+#ifdef ASSERT
+  , _decorators(decorators)
+#endif
+{
+}
+
+void LogDecorations::print_decoration(LogDecorators::Decorator decorator, outputStream* st) const {
+  assert(_decorators.is_decorator(decorator), "decorator was not part of the decorator set specified at creation.");
+  switch(decorator) {
+#define DECORATOR(name, abbr) case LogDecorators:: name##_decorator: print_##name##_decoration(st); break;
   DECORATOR_LIST
 #undef DECORATOR
-}
-
-jlong LogDecorations::java_millis() {
-  if (_millis < 0) {
-    _millis = os::javaTimeMillis();
+    default: ShouldNotReachHere();
   }
-  return _millis;
 }
 
-#define ASSERT_AND_RETURN(written, pos) \
-    assert(written >= 0, "Decorations buffer overflow"); \
-    return pos + written;
-
-char* LogDecorations::create_time_decoration(char* pos) {
-  char* buf = os::iso8601_time(pos, 29);
-  int written = buf == NULL ? -1 : 29;
-  ASSERT_AND_RETURN(written, pos)
+const char* LogDecorations::decoration(LogDecorators::Decorator decorator, char* buf, size_t buflen) const {
+  stringStream ss(buf, buflen);
+  print_decoration(decorator, &ss);
+  return buf;
 }
 
-char* LogDecorations::create_utctime_decoration(char* pos) {
-  char* buf = os::iso8601_time(pos, 29, true);
-  int written = buf == NULL ? -1 : 29;
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_time_decoration(outputStream* st) const {
+  char buf[os::iso8601_timestamp_size];
+  char* result = os::iso8601_time(_millis, buf, sizeof(buf), false);
+  st->print_raw(result ? result : "");
 }
 
-char * LogDecorations::create_uptime_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer), "%.3fs", os::elapsedTime());
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_utctime_decoration(outputStream* st) const {
+  char buf[os::iso8601_timestamp_size];
+  char* result = os::iso8601_time(_millis, buf, sizeof(buf), true);
+  st->print_raw(result ? result : "");
 }
 
-char * LogDecorations::create_timemillis_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer), INT64_FORMAT "ms", java_millis());
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_uptime_decoration(outputStream* st) const {
+  st->print("%.3fs", _elapsed_seconds);
 }
 
-char * LogDecorations::create_uptimemillis_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer),
-                             INT64_FORMAT "ms", java_millis() - _vm_start_time_millis);
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_timemillis_decoration(outputStream* st) const {
+  st->print(INT64_FORMAT "ms", (int64_t)_millis);
 }
 
-char * LogDecorations::create_timenanos_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer), INT64_FORMAT "ns", os::javaTimeNanos());
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_uptimemillis_decoration(outputStream* st) const {
+  st->print(INT64_FORMAT "ms", (int64_t)(_elapsed_seconds * MILLIUNITS));
 }
 
-char * LogDecorations::create_uptimenanos_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer), INT64_FORMAT "ns", os::elapsed_counter());
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_timenanos_decoration(outputStream* st) const {
+  st->print(INT64_FORMAT "ns", (int64_t)_nanos);
 }
 
-char * LogDecorations::create_pid_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer), "%d", os::current_process_id());
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_uptimenanos_decoration(outputStream* st) const {
+  st->print(INT64_FORMAT "ns", (int64_t)(_elapsed_seconds * NANOUNITS));
 }
 
-char * LogDecorations::create_tid_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer),
-                             INTX_FORMAT, os::current_thread_id());
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_pid_decoration(outputStream* st) const {
+  st->print("%d", _pid);
 }
 
-char* LogDecorations::create_level_decoration(char* pos) {
-  // Avoid generating the level decoration because it may change.
-  // The decoration() method has a special case for level decorations.
-  return pos;
+void LogDecorations::print_tid_decoration(outputStream* st) const {
+  st->print(INTX_FORMAT, _tid);
 }
 
-char* LogDecorations::create_tags_decoration(char* pos) {
-  int written = _tagset.label(pos, DecorationsBufferSize - (pos - _decorations_buffer));
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_level_decoration(outputStream* st) const {
+  st->print_raw(LogLevel::name(_level));
 }
 
-char* LogDecorations::create_hostname_decoration(char* pos) {
-  int written = jio_snprintf(pos, DecorationsBufferSize - (pos - _decorations_buffer), "%s", _host_name);
-  ASSERT_AND_RETURN(written, pos)
+void LogDecorations::print_tags_decoration(outputStream* st) const {
+  _tagset.label(st);
 }
 
+void LogDecorations::print_hostname_decoration(outputStream* st) const {
+  st->print_raw(_host_name);
+}

--- a/src/hotspot/share/logging/logDecorations.hpp
+++ b/src/hotspot/share/logging/logDecorations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ class LogDecorations {
   LogLevelType _level;            // for "level" (needs to be nonconst)
   const LogTagSet& _tagset;       // for "tags"
   // In debug mode we keep the decorators around for sanity checking when printing
-  DEBUG_ONLY(const LogDecorators& _decorators;)
+  DEBUG_ONLY(const LogDecorators _decorators;)
 
   static const char* _host_name;
   static const int _pid;

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -25,7 +25,19 @@
 #include "logging/logDecorators.hpp"
 #include "runtime/os.inline.hpp"
 
+template <LogDecorators::Decorator d>
+struct AllBitmask {
+  // Use recursive template deduction to calculate the bitmask of all decorations.
+  static const uint _value = (1 << d) | AllBitmask<static_cast<LogDecorators::Decorator>(d + 1)>::_value;
+};
+
+template<>
+struct AllBitmask<LogDecorators::Count> {
+  static const uint _value = 0;
+};
+
 const LogDecorators LogDecorators::None = LogDecorators(0);
+const LogDecorators LogDecorators::All  = LogDecorators(AllBitmask<time_decorator>::_value);
 
 const char* LogDecorators::_name[][2] = {
 #define DECORATOR(n, a) {#n, #a},

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ class LogDecorators {
   static const LogDecorators None;
 
   LogDecorators() : _decorators(DefaultDecoratorsMask) {
-  };
+  }
 
   void clear() {
     _decorators = 0;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -80,6 +80,7 @@ class LogDecorators {
 
  public:
   static const LogDecorators None;
+  static const LogDecorators All;
 
   LogDecorators() : _decorators(DefaultDecoratorsMask) {
   }

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "jvm.h"
 #include "logging/log.hpp"
+#include "logging/logAsyncWriter.hpp"
 #include "logging/logConfiguration.hpp"
 #include "logging/logFileOutput.hpp"
 #include "memory/allocation.inline.hpp"
@@ -275,12 +276,7 @@ bool LogFileOutput::initialize(const char* options, outputStream* errstream) {
   return true;
 }
 
-int LogFileOutput::write(const LogDecorations& decorations, const char* msg) {
-  if (_stream == NULL) {
-    // An error has occurred with this output, avoid writing to it.
-    return 0;
-  }
-
+int LogFileOutput::write_blocking(const LogDecorations& decorations, const char* msg) {
   _rotation_semaphore.wait();
   int written = LogFileStreamOutput::write(decorations, msg);
   if (written > 0) {
@@ -295,9 +291,30 @@ int LogFileOutput::write(const LogDecorations& decorations, const char* msg) {
   return written;
 }
 
+int LogFileOutput::write(const LogDecorations& decorations, const char* msg) {
+  if (_stream == NULL) {
+    // An error has occurred with this output, avoid writing to it.
+    return 0;
+  }
+
+  AsyncLogWriter* aio_writer = AsyncLogWriter::instance();
+  if (aio_writer != NULL) {
+    aio_writer->enqueue(*this, decorations, msg);
+    return 0;
+  }
+
+  return write_blocking(decorations, msg);
+}
+
 int LogFileOutput::write(LogMessageBuffer::Iterator msg_iterator) {
   if (_stream == NULL) {
     // An error has occurred with this output, avoid writing to it.
+    return 0;
+  }
+
+  AsyncLogWriter* aio_writer = AsyncLogWriter::instance();
+  if (aio_writer != NULL) {
+    aio_writer->enqueue(*this, msg_iterator);
     return 0;
   }
 
@@ -452,7 +469,8 @@ void LogFileOutput::describe(outputStream *out) {
   LogOutput::describe(out);
   out->print(" ");
 
-  out->print("filecount=%u,filesize=" SIZE_FORMAT "%s", _file_count,
+  out->print("filecount=%u,filesize=" SIZE_FORMAT "%s,async=%s", _file_count,
              byte_size_in_proper_unit(_rotate_size),
-             proper_unit_for_byte_size(_rotate_size));
+             proper_unit_for_byte_size(_rotate_size),
+             LogConfiguration::is_async_mode() ? "true" : "false");
 }

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -283,10 +283,12 @@ int LogFileOutput::write(const LogDecorations& decorations, const char* msg) {
 
   _rotation_semaphore.wait();
   int written = LogFileStreamOutput::write(decorations, msg);
-  _current_size += written;
+  if (written > 0) {
+    _current_size += written;
 
-  if (should_rotate()) {
-    rotate();
+    if (should_rotate()) {
+      rotate();
+    }
   }
   _rotation_semaphore.signal();
 
@@ -301,10 +303,12 @@ int LogFileOutput::write(LogMessageBuffer::Iterator msg_iterator) {
 
   _rotation_semaphore.wait();
   int written = LogFileStreamOutput::write(msg_iterator);
-  _current_size += written;
+  if (written > 0) {
+    _current_size += written;
 
-  if (should_rotate()) {
-    rotate();
+    if (should_rotate()) {
+      rotate();
+    }
   }
   _rotation_semaphore.signal();
 

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -296,7 +296,9 @@ int LogFileOutput::write_blocking(const LogDecorations& decorations, const char*
     return 0;
   }
 
-  int written = LogFileStreamOutput::write(decorations, msg);
+  int written = write_internal(decorations, msg);
+  // Need to flush to the filesystem before should_rotate()
+  written = flush() ? written : -1;
   if (written > 0) {
     _current_size += written;
 

--- a/src/hotspot/share/logging/logFileOutput.hpp
+++ b/src/hotspot/share/logging/logFileOutput.hpp
@@ -85,7 +85,7 @@ class LogFileOutput : public LogFileStreamOutput {
   virtual bool initialize(const char* options, outputStream* errstream);
   virtual int write(const LogDecorations& decorations, const char* msg);
   virtual int write(LogMessageBuffer::Iterator msg_iterator);
-  int write_blocking(const LogDecorations& decorations, const char* msg);
+  virtual int write_blocking(const LogDecorations& decorations, const char* msg);
   virtual void force_rotate();
   virtual void describe(outputStream* out);
 

--- a/src/hotspot/share/logging/logFileOutput.hpp
+++ b/src/hotspot/share/logging/logFileOutput.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,6 +85,7 @@ class LogFileOutput : public LogFileStreamOutput {
   virtual bool initialize(const char* options, outputStream* errstream);
   virtual int write(const LogDecorations& decorations, const char* msg);
   virtual int write(LogMessageBuffer::Iterator msg_iterator);
+  int write_blocking(const LogDecorations& decorations, const char* msg);
   virtual void force_rotate();
   virtual void describe(outputStream* out);
 

--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -53,6 +53,7 @@ LogFileStreamInitializer::LogFileStreamInitializer() {
 
 int LogFileStreamOutput::write_decorations(const LogDecorations& decorations) {
   int total_written = 0;
+  char buf[LogDecorations::max_decoration_size + 1];
 
   for (uint i = 0; i < LogDecorators::Count; i++) {
     LogDecorators::Decorator decorator = static_cast<LogDecorators::Decorator>(i);
@@ -62,7 +63,7 @@ int LogFileStreamOutput::write_decorations(const LogDecorations& decorations) {
 
     int written = jio_fprintf(_stream, "[%-*s]",
                               _decorator_padding[decorator],
-                              decorations.decoration(decorator));
+                              decorations.decoration(decorator, buf, sizeof(buf)));
     if (written <= 0) {
       return -1;
     } else if (static_cast<size_t>(written - 2) > _decorator_padding[decorator]) {

--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -23,6 +23,7 @@
  */
 #include "precompiled.hpp"
 #include "jvm.h"
+#include "logging/logAsyncWriter.hpp"
 #include "logging/logDecorators.hpp"
 #include "logging/logDecorations.hpp"
 #include "logging/logFileStreamOutput.hpp"
@@ -117,32 +118,62 @@ bool LogFileStreamOutput::flush() {
   total += result;                                            \
 }
 
-int LogFileStreamOutput::write(const LogDecorations& decorations, const char* msg) {
+int LogFileStreamOutput::write_internal(const LogDecorations& decorations, const char* msg) {
+  int written = 0;
   const bool use_decorations = !_decorators.is_empty();
 
-  int written = 0;
-  FileLocker flocker(_stream);
   if (use_decorations) {
     WRITE_LOG_WITH_RESULT_CHECK(write_decorations(decorations), written);
     WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, " "), written);
   }
-  WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%s\n", msg), written);
 
+  char *dupstr = os::strdup_check_oom(msg, mtLogging);
+  char *cur = dupstr;
+  char *next;
+  do {
+    next = strpbrk(cur, "\n\\");
+    if (next == NULL) {
+      WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%s\n", cur), written);
+    } else {
+      const char *found = (*next == '\n') ? "\\n" : "\\\\";
+      *next = '\0';
+      WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%s%s", cur, found), written);
+      cur = next + 1;
+    }
+  } while (next != NULL);
+  os::free(dupstr);
+
+  return written;
+}
+
+int LogFileStreamOutput::write_blocking(const LogDecorations& decorations, const char* msg) {
+  int written = write_internal(decorations, msg);
+  return flush() ? written : -1;
+}
+
+int LogFileStreamOutput::write(const LogDecorations& decorations, const char* msg) {
+  AsyncLogWriter* aio_writer = AsyncLogWriter::instance();
+  if (aio_writer != NULL) {
+    aio_writer->enqueue(*this, decorations, msg);
+    return 0;
+  }
+
+  FileLocker flocker(_stream);
+  int written = write_internal(decorations, msg);
   return flush() ? written : -1;
 }
 
 int LogFileStreamOutput::write(LogMessageBuffer::Iterator msg_iterator) {
-  const bool use_decorations = !_decorators.is_empty();
+  AsyncLogWriter* aio_writer = AsyncLogWriter::instance();
+  if (aio_writer != NULL) {
+    aio_writer->enqueue(*this, msg_iterator);
+    return 0;
+  }
 
   int written = 0;
   FileLocker flocker(_stream);
   for (; !msg_iterator.is_at_end(); msg_iterator++) {
-    if (use_decorations) {
-      WRITE_LOG_WITH_RESULT_CHECK(write_decorations(msg_iterator.decorations()), written);
-      WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, " "), written);
-    }
-    WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%s\n", msg_iterator.message()), written);
+    written += write_internal(msg_iterator.decorations(), msg_iterator.message());
   }
-
   return flush() ? written : -1;
 }

--- a/src/hotspot/share/logging/logFileStreamOutput.hpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.hpp
@@ -53,11 +53,14 @@ class LogFileStreamOutput : public LogOutput {
   }
 
   int write_decorations(const LogDecorations& decorations);
+  int write_internal(const LogDecorations& decorations, const char* msg);
   bool flush();
 
  public:
   virtual int write(const LogDecorations& decorations, const char* msg);
   virtual int write(LogMessageBuffer::Iterator msg_iterator);
+  // Write API used by AsyncLogWriter
+  virtual int write_blocking(const LogDecorations& decorations, const char* msg);
 };
 
 class LogStdoutOutput : public LogFileStreamOutput {

--- a/src/hotspot/share/logging/logFileStreamOutput.hpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,17 +40,20 @@ static LogFileStreamInitializer log_stream_initializer;
 
 // Base class for all FileStream-based log outputs.
 class LogFileStreamOutput : public LogOutput {
+ private:
+  bool                _write_error_is_shown;
  protected:
   FILE*               _stream;
   size_t              _decorator_padding[LogDecorators::Count];
 
-  LogFileStreamOutput(FILE *stream) : _stream(stream) {
+  LogFileStreamOutput(FILE *stream) : _write_error_is_shown(false), _stream(stream) {
     for (size_t i = 0; i < LogDecorators::Count; i++) {
       _decorator_padding[i] = 0;
     }
   }
 
   int write_decorations(const LogDecorations& decorations);
+  bool flush();
 
  public:
   virtual int write(const LogDecorations& decorations, const char* msg);

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -68,6 +68,25 @@ LogOutputList::LogOutputNode* LogOutputList::find(const LogOutput* output) const
   return NULL;
 }
 
+void LogOutputList::clear() {
+
+  // Grab the linked list
+  LogOutputNode* cur = _level_start[LogLevel::Last];
+
+  // Clear _level_start
+  for (uint level = LogLevel::First; level < LogLevel::Count; level++) {
+    _level_start[level] = NULL;
+  }
+
+  // Delete all nodes from the linked list
+  wait_until_no_readers();
+  while (cur != NULL) {
+    LogOutputNode* next = cur->_next;
+    delete cur;
+    cur = next;
+  }
+}
+
 void LogOutputList::remove_output(LogOutputList::LogOutputNode* node) {
   assert(node != NULL, "Node must be non-null");
 

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -43,9 +43,12 @@ jint LogOutputList::decrease_readers() {
 
 void LogOutputList::wait_until_no_readers() const {
   OrderAccess::storeload();
-  while (_active_readers != 0) {
+  while (Atomic::load(&_active_readers) != 0) {
     // Busy wait
   }
+  // Prevent mutations to the output list to float above the active reader check.
+  // Such a reordering would lead to readers loading faulty data.
+  OrderAccess::loadstore();
 }
 
 void LogOutputList::set_output_level(LogOutput* output, LogLevelType level) {

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -88,6 +88,10 @@ class LogOutputList {
   // Set (add/update/remove) the output to the specified level.
   void set_output_level(LogOutput* output, LogLevelType level);
 
+  // Removes all outputs. Equivalent of set_output_level(out, Off)
+  // for all outputs.
+  void clear();
+
   class Iterator {
     friend class LogOutputList;
    private:

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -26,6 +26,7 @@
 
 #include "logging/logLevel.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/orderAccess.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class LogOutput;
@@ -48,11 +49,11 @@ class LogOutputList {
  private:
   struct LogOutputNode : public CHeapObj<mtLogging> {
     LogOutput*      _value;
-    LogOutputNode*  _next;
+    LogOutputNode* volatile _next;
     LogLevelType    _level;
   };
 
-  LogOutputNode*  _level_start[LogLevel::Count];
+  LogOutputNode* volatile _level_start[LogLevel::Count];
   volatile jint   _active_readers;
 
   LogOutputNode* find(const LogOutput* output) const;
@@ -125,7 +126,9 @@ class LogOutputList {
     }
 
     void operator++(int) {
-      _current = _current->_next;
+      // FIXME: memory_order_consume could be used here.
+      // Atomic access on the reading side for LogOutputList.
+      _current = OrderAccess::load_acquire(&_current->_next);
     }
 
     bool operator!=(const LogOutputNode *ref) const {
@@ -139,7 +142,9 @@ class LogOutputList {
 
   Iterator iterator(LogLevelType level = LogLevel::Last) {
     increase_readers();
-    return Iterator(this, _level_start[level]);
+    // FIXME: memory_order_consume could be used here.
+    // Atomic access on the reading side for LogOutputList.
+    return Iterator(this, OrderAccess::load_acquire(&_level_start[level]));
   }
 
   LogOutputNode* end() const {

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -63,7 +63,6 @@ class LogOutputList {
   // Bookkeeping functions to keep track of number of active readers/iterators for the list.
   jint increase_readers();
   jint decrease_readers();
-  void wait_until_no_readers() const;
 
  public:
   LogOutputList() : _active_readers(0) {
@@ -87,6 +86,8 @@ class LogOutputList {
 
   // Set (add/update/remove) the output to the specified level.
   void set_output_level(LogOutput* output, LogLevelType level);
+
+  void wait_until_no_readers() const;
 
   // Removes all outputs. Equivalent of set_output_level(out, Off)
   // for all outputs.

--- a/src/hotspot/share/logging/logTagSet.cpp
+++ b/src/hotspot/share/logging/logTagSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,15 +73,24 @@ bool LogTagSet::has_output(const LogOutput* output) {
 }
 
 void LogTagSet::log(LogLevelType level, const char* msg) {
+  // Increasing the atomic reader counter in iterator(level) must
+  // happen before the creation of LogDecorations instance so
+  // wait_until_no_readers() in LogConfiguration::configure_output()
+  // synchronizes _decorations as well. The order is guaranteed by
+  // the implied memory order of Atomic::add().
+  LogOutputList::Iterator it = _output_list.iterator(level);
   LogDecorations decorations(level, *this, _decorators);
-  for (LogOutputList::Iterator it = _output_list.iterator(level); it != _output_list.end(); it++) {
+
+  for (; it != _output_list.end(); it++) {
     (*it)->write(decorations, msg);
   }
 }
 
 void LogTagSet::log(const LogMessageBuffer& msg) {
+  LogOutputList::Iterator it = _output_list.iterator(msg.least_detailed_level());
   LogDecorations decorations(LogLevel::Invalid, *this, _decorators);
-  for (LogOutputList::Iterator it = _output_list.iterator(msg.least_detailed_level()); it != _output_list.end(); it++) {
+
+  for (; it != _output_list.end(); it++) {
     (*it)->write(msg.iterator(it.level(), decorations));
   }
 }

--- a/src/hotspot/share/logging/logTagSet.cpp
+++ b/src/hotspot/share/logging/logTagSet.cpp
@@ -86,18 +86,20 @@ void LogTagSet::log(const LogMessageBuffer& msg) {
   }
 }
 
-int LogTagSet::label(char* buf, size_t len, const char* separator) const {
-  int tot_written = 0;
+void LogTagSet::label(outputStream* st, const char* separator) const {
   for (size_t i = 0; i < _ntags; i++) {
-    int written = jio_snprintf(buf + tot_written, len - tot_written, "%s%s",
-                               (i == 0 ? "" : separator),
-                               LogTag::name(_tag[i]));
-    if (written < 0) {
-      return -1;
-    }
-    tot_written += written;
+    st->print("%s%s", (i == 0 ? "" : separator), LogTag::name(_tag[i]));
   }
-  return tot_written;
+}
+
+int LogTagSet::label(char* buf, size_t len, const char* separator) const {
+  stringStream ss(buf, len);
+  label(&ss, separator);
+  size_t written = ss.size();
+  if (written >= len - 1) {
+    return -1; // truncation
+  }
+  return (int)written;
 }
 
 void LogTagSet::write(LogLevelType level, const char* fmt, ...) {
@@ -143,9 +145,9 @@ static const size_t TagSetBufferSize = 128;
 void LogTagSet::describe_tagsets(outputStream* out) {
   out->print_cr("Described tag sets:");
   for (const LogTagSetDescription* d = tagset_descriptions; d->tagset != NULL; d++) {
-    char buf[TagSetBufferSize];
-    d->tagset->label(buf, sizeof(buf), "+");
-    out->print_cr(" %s: %s", buf, d->descr);
+    out->sp();
+    d->tagset->label(out, "+");
+    out->print_cr(": %s", d->descr);
   }
 }
 

--- a/src/hotspot/share/logging/logTagSet.hpp
+++ b/src/hotspot/share/logging/logTagSet.hpp
@@ -33,6 +33,8 @@
 
 class LogMessageBuffer;
 
+class outputStream;
+
 // The tagset represents a combination of tags that occur in a log call somewhere.
 // Tagsets are created automatically by the LogTagSetMappings and should never be
 // instantiated directly somewhere else.
@@ -110,6 +112,7 @@ class LogTagSet {
   // of its current outputs combined with the given decorators.
   void update_decorators(const LogDecorators& decorator = LogDecorators::None);
 
+  void label(outputStream* st, const char* separator = ",") const;
   int label(char *buf, size_t len, const char* separator = ",") const;
   bool has_output(const LogOutput* output);
 

--- a/src/hotspot/share/logging/logTagSet.hpp
+++ b/src/hotspot/share/logging/logTagSet.hpp
@@ -98,6 +98,10 @@ class LogTagSet {
     return _output_list.level_for(output);
   }
 
+  void disable_outputs() {
+    _output_list.clear();
+  }
+
   void set_output_level(LogOutput* output, LogLevelType level) {
     _output_list.set_output_level(output, level);
   }

--- a/src/hotspot/share/logging/logTagSet.hpp
+++ b/src/hotspot/share/logging/logTagSet.hpp
@@ -67,6 +67,10 @@ class LogTagSet {
   static void describe_tagsets(outputStream* out);
   static void list_all_tagsets(outputStream* out);
 
+  void wait_until_no_readers() const {
+    _output_list.wait_until_no_readers();
+  }
+
   static LogTagSet* first() {
     return _list;
   }
@@ -163,4 +167,5 @@ public:
 template <LogTagType T0, LogTagType T1, LogTagType T2, LogTagType T3, LogTagType T4, LogTagType GuardTag>
 LogTagSet LogTagSetMapping<T0, T1, T2, T3, T4, GuardTag>::_tagset(&LogPrefix<T0, T1, T2, T3, T4>::prefix, T0, T1, T2, T3, T4);
 
+extern const size_t vwrite_buffer_size;
 #endif // SHARE_VM_LOGGING_LOGTAGSET_HPP

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2863,6 +2863,9 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       } else if (strcmp(tail, ":disable") == 0) {
         LogConfiguration::disable_logging();
         ret = true;
+      } else if (strcmp(tail, ":async") == 0) {
+        LogConfiguration::set_async_mode(true);
+        ret = true;
       } else if (*tail == '\0') {
         ret = LogConfiguration::parse_command_line_arguments();
         assert(ret, "-Xlog without arguments should never fail to parse");

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2632,6 +2632,11 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
              "Use the FP register for holding the frame pointer "           \
              "and not as a general purpose register.")                      \
                                                                             \
+  product(size_t, AsyncLogBufferSize, 2*M,                                  \
+          "Memory budget (in bytes) for the buffer of Asynchronous "        \
+          "Logging (-Xlog:async).")                                         \
+          range(100*K, 50*M)                                                \
+                                                                            \
   diagnostic(bool, CheckIntrinsics, true,                                   \
              "When a class C is loaded, check that "                        \
              "(1) all intrinsics defined by the VM for class C are present "\

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -28,6 +28,9 @@
 #include "code/icBuffer.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "interpreter/bytecodes.hpp"
+#include "logging/log.hpp"
+#include "logging/logAsyncWriter.hpp"
+#include "logging/logTag.hpp"
 #include "memory/universe.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/flags/jvmFlag.hpp"
@@ -113,6 +116,7 @@ jint init_globals() {
   if (status != JNI_OK)
     return status;
 
+  AsyncLogWriter::initialize();
   gc_barrier_stubs_init();   // depends on universe_init, must be before interpreter_init
   interpreter_init();        // before any methods loaded
   invocationCounter_init();  // before any methods loaded

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -103,6 +103,14 @@ int os::snprintf(char* buf, size_t len, const char* fmt, ...) {
 }
 
 // Fill in buffer with current local time as an ISO-8601 string.
+// E.g., YYYY-MM-DDThh:mm:ss.mmm+zzzz.
+// Returns buffer, or NULL if it failed.
+char* os::iso8601_time(char* buffer, size_t buffer_length, bool utc) {
+  const jlong now = javaTimeMillis();
+  return os::iso8601_time(now, buffer, buffer_length, utc);
+}
+
+// Fill in buffer with an ISO-8601 string corresponding to the given javaTimeMillis value
 // E.g., yyyy-mm-ddThh:mm:ss-zzzz.
 // Returns buffer, or NULL if it failed.
 // This would mostly be a call to
@@ -110,24 +118,18 @@ int os::snprintf(char* buf, size_t len, const char* fmt, ...) {
 // except that on Windows the %z behaves badly, so we do it ourselves.
 // Also, people wanted milliseconds on there,
 // and strftime doesn't do milliseconds.
-char* os::iso8601_time(char* buffer, size_t buffer_length, bool utc) {
+char* os::iso8601_time(jlong milliseconds_since_19700101, char* buffer, size_t buffer_length, bool utc) {
   // Output will be of the form "YYYY-MM-DDThh:mm:ss.mmm+zzzz\0"
-  //                                      1         2
-  //                             12345678901234567890123456789
-  // format string: "%04d-%02d-%02dT%02d:%02d:%02d.%03d%c%02d%02d"
-  static const size_t needed_buffer = 29;
 
   // Sanity check the arguments
   if (buffer == NULL) {
     assert(false, "NULL buffer");
     return NULL;
   }
-  if (buffer_length < needed_buffer) {
+  if (buffer_length < os::iso8601_timestamp_size) {
     assert(false, "buffer_length too small");
     return NULL;
   }
-  // Get the current time
-  jlong milliseconds_since_19700101 = javaTimeMillis();
   const int milliseconds_per_microsecond = 1000;
   const time_t seconds_since_19700101 =
     milliseconds_since_19700101 / milliseconds_per_microsecond;

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -223,6 +223,16 @@ class os: AllStatic {
   static char*      local_time_string(char *buf, size_t buflen);
   static struct tm* localtime_pd     (const time_t* clock, struct tm*  res);
   static struct tm* gmtime_pd        (const time_t* clock, struct tm*  res);
+
+  // "YYYY-MM-DDThh:mm:ss.mmm+zzzz" incl. terminating zero
+  static const size_t iso8601_timestamp_size = 29;
+
+  // Fill in buffer with an ISO-8601 string corresponding to the given javaTimeMillis value
+  // E.g., YYYY-MM-DDThh:mm:ss.mmm+zzzz.
+  // Returns buffer, or NULL if it failed.
+  static char* iso8601_time(jlong milliseconds_since_19700101, char* buffer,
+                            size_t buffer_length, bool utc = false);
+
   // Fill in buffer with current local time as an ISO-8601 string.
   // E.g., YYYY-MM-DDThh:mm:ss.mmm+zzzz.
   // Returns buffer, or NULL if it failed.

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -501,6 +501,7 @@ class os: AllStatic {
     java_thread,       // Java, CodeCacheSweeper, JVMTIAgent and Service threads.
     compiler_thread,
     watcher_thread,
+    asynclog_thread,
     os_thread
   };
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -44,6 +44,7 @@
 #include "jfr/jfrEvents.hpp"
 #include "jvmtifiles/jvmtiEnv.hpp"
 #include "logging/log.hpp"
+#include "logging/logAsyncWriter.hpp"
 #include "logging/logConfiguration.hpp"
 #include "logging/logStream.hpp"
 #include "memory/allocation.inline.hpp"
@@ -4896,6 +4897,12 @@ void Threads::print_on(outputStream* st, bool print_stacks,
     st->cr();
   }
 
+  AsyncLogWriter* aw = AsyncLogWriter::instance();
+  if (aw != NULL) {
+    aw->print_on(st);
+    st->cr();
+  }
+
   st->flush();
 }
 
@@ -4948,6 +4955,7 @@ void Threads::print_on_error(outputStream* st, Thread* current, char* buf,
   st->print_cr("Other Threads:");
   print_on_error(VMThread::vm_thread(), st, current, buf, buflen, &found_current);
   print_on_error(WatcherThread::watcher_thread(), st, current, buf, buflen, &found_current);
+  print_on_error(AsyncLogWriter::instance(), st, current, buf, buflen, &found_current);
 
   if (Universe::heap() != NULL) {
     PrintOnErrorClosure print_closure(st, current, buf, buflen, &found_current);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -944,7 +944,9 @@ void Thread::print_on_error(outputStream* st, char* buf, int buflen) const {
   else if (is_GC_task_thread())       { st->print("GCTaskThread"); }
   else if (is_Watcher_thread())       { st->print("WatcherThread"); }
   else if (is_ConcurrentGC_thread())  { st->print("ConcurrentGCThread"); }
-  else                                { st->print("Thread"); }
+  else if (this == AsyncLogWriter::instance()) {
+    st->print("%s", this->name());
+  } else                                { st->print("Thread"); }
 
   if (is_Named_thread()) {
     st->print(" \"%s\"", name());

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -111,6 +111,7 @@ class WispThread;
 //         - GCTaskThread
 //     - WatcherThread
 //     - JfrThreadSampler
+//     - LogAsyncWriter
 //
 // All Thread subclasses must be either JavaThread or NonJavaThread.
 // This means !t->is_Java_thread() iff t is a NonJavaThread, or t is

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -48,6 +48,7 @@
 #include "interpreter/bytecodeInterpreter.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "interpreter/interpreter.hpp"
+#include "logging/logAsyncWriter.hpp"
 #include "memory/allocation.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/heap.hpp"
@@ -1388,6 +1389,7 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
       declare_type(NonJavaThread, Thread)                                 \
         declare_type(NamedThread, NonJavaThread)                          \
         declare_type(WatcherThread, NonJavaThread)                        \
+        declare_type(AsyncLogWriter, NonJavaThread)                       \
       declare_type(JavaThread, Thread)                                    \
         declare_type(JvmtiAgentThread, JavaThread)                        \
         declare_type(ServiceThread, JavaThread)                           \

--- a/src/hotspot/share/utilities/autoRestore.hpp
+++ b/src/hotspot/share/utilities/autoRestore.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_AUTORESTORE_HPP
+#define SHARE_UTILITIES_AUTORESTORE_HPP
+
+#include "memory/allocation.hpp"
+
+ // A simplistic template providing a general save-restore pattern through a
+// local auto/stack object (scope).
+//
+template<typename T> class AutoSaveRestore : public StackObj {
+public:
+  AutoSaveRestore(T &loc) : _loc(loc) {
+    _value = loc;
+  }
+  ~AutoSaveRestore() {
+    _loc = _value;
+  }
+private:
+  T &_loc;
+  T _value;
+};
+
+// A simplistic template providing a general modify-restore pattern through a
+// local auto/stack object (scope).
+//
+template<typename T> class AutoModifyRestore : private AutoSaveRestore<T> {
+public:
+  AutoModifyRestore(T &loc, T value) : AutoSaveRestore<T>(loc) {
+    loc = value;
+  }
+};
+
+#endif // SHARE_UTILITIES_AUTORESTORE_HPP

--- a/src/hotspot/share/utilities/hashtable.cpp
+++ b/src/hotspot/share/utilities/hashtable.cpp
@@ -493,6 +493,7 @@ template class BasicHashtable<mtCode>;
 template class BasicHashtable<mtInternal>;
 template class BasicHashtable<mtModule>;
 template class BasicHashtable<mtCompiler>;
+template class BasicHashtable<mtLogging>;
 
 template void BasicHashtable<mtClass>::verify_table<DictionaryEntry>(char const*);
 template void BasicHashtable<mtModule>::verify_table<ModuleEntry>(char const*);

--- a/src/hotspot/share/utilities/hashtable.hpp
+++ b/src/hotspot/share/utilities/hashtable.hpp
@@ -372,6 +372,44 @@ public:
     }
     return NULL;
   }
+
+  // Look up the key.
+  // If an entry for the key exists, leave map unchanged and return a pointer to its value.
+  // If no entry for the key exists, create a new entry from key and value and return a
+  //  pointer to the value.
+  // *p_created is true if entry was created, false if entry pre-existed.
+  V* add_if_absent(K key, V value, bool* p_created) {
+    unsigned int hash = HASH(key);
+    int index = BasicHashtable<F>::hash_to_index(hash);
+    for (KVHashtableEntry* e = bucket(index); e != NULL; e = e->next()) {
+      if (e->hash() == hash && EQUALS(e->_key, key)) {
+        *p_created = false;
+        return &(e->_value);
+      }
+    }
+
+    KVHashtableEntry* entry = new_entry(hash, key, value);
+    BasicHashtable<F>::add_entry(BasicHashtable<F>::hash_to_index(hash), entry);
+    *p_created = true;
+    return &(entry->_value);
+  }
+
+  int table_size() const {
+    return BasicHashtable<F>::table_size();
+  }
+
+  // ITER contains bool do_entry(K, V const&), which will be
+  // called for each entry in the table.  If do_entry() returns false,
+  // the iteration is cancelled.
+  template<class ITER>
+  void iterate(ITER* iter) const {
+    for (int index = 0; index < table_size(); index++) {
+      for (KVHashtableEntry* e = bucket(index); e != NULL; e = e->next()) {
+        bool cont = iter->do_entry(e->_key, &e->_value);
+        if (!cont) { return; }
+      }
+    }
+  }
 };
 
 

--- a/src/hotspot/share/utilities/linkedlist.hpp
+++ b/src/hotspot/share/utilities/linkedlist.hpp
@@ -416,6 +416,9 @@ template <class E> class LinkedListIterator : public StackObj {
     _p = _p->next();
     return e;
   }
+
+  //provided for logAsyncWriter.cpp to iterate AsyncLogMessage
+  bool has_next() const { return _p == NULL; }
 };
 
 #endif

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -394,10 +394,16 @@ void stringStream::reset() {
   zero_terminate();
 }
 
-char* stringStream::as_string() const {
-  char* copy = NEW_RESOURCE_ARRAY(char, _written + 1);
+char* stringStream::as_string(bool c_heap) const {
+  char* copy = c_heap ?
+    NEW_C_HEAP_ARRAY(char, _written + 1, mtInternal) : NEW_RESOURCE_ARRAY(char, _written + 1);
   ::memcpy(copy, _buffer, _written);
   copy[_written] = 0;  // terminating null
+  if (c_heap) {
+    // Need to ensure our content is written to memory before we return
+    // the pointer to it.
+    OrderAccess::storestore();
+  }
   return copy;
 }
 

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -217,7 +217,7 @@ class stringStream : public outputStream {
   size_t      size() const { return _written; }
   const char* base() const { return _buffer; }
   void  reset();
-  char* as_string() const;
+  char* as_string(bool c_heap = false) const;
 };
 
 class fileStream : public outputStream {

--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -45,7 +45,6 @@ LogTestFixture::LogTestFixture() : _configuration_snapshot(NULL), _n_snapshots(0
 }
 
 LogTestFixture::~LogTestFixture() {
-  AsyncLogWriter::flush();
   restore_config();
   clear_snapshot();
   delete_file(TestLogFileName);

--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,14 +96,15 @@ void LogTestFixture::restore_config() {
 
     char* decorators = str;
 
-    char* options = NULL;
     str = strchr(str, ' ');
     if (str != NULL) {
+      // This output has options. However, UL doesn't allow the options of any
+      // output to be changed, so they cannot be modified by the tests,
+      // and also we cannot change them here. So just mark the end of the
+      // decorators.
       *str++ = '\0';
-      options = str;
     }
-
-    set_log_config(name, selection, decorators, options != NULL ? options : "");
+    set_log_config(name, selection, decorators, /* options = */ NULL);
   }
 }
 

--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -45,6 +45,7 @@ LogTestFixture::LogTestFixture() : _configuration_snapshot(NULL), _n_snapshots(0
 }
 
 LogTestFixture::~LogTestFixture() {
+  AsyncLogWriter::flush();
   restore_config();
   clear_snapshot();
   delete_file(TestLogFileName);

--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -22,6 +22,7 @@
  */
 
 #include "logging/log.hpp"
+#include "logging/logAsyncWriter.hpp"
 #include "logging/logConfiguration.hpp"
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
@@ -46,6 +47,7 @@ static inline bool file_exists(const char* filename) {
 }
 
 static inline void delete_file(const char* filename) {
+  AsyncLogWriter::flush();
   if (!file_exists(filename)) {
     return;
   }
@@ -111,6 +113,7 @@ static inline char* read_line(FILE* fp) {
 }
 
 static bool file_contains_substrings_in_order(const char* filename, const char* substrs[]) {
+  AsyncLogWriter::flush();
   FILE* fp = fopen(filename, "r");
   assert(fp != NULL, "error opening file %s: %s", filename, strerror(errno));
 

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -94,6 +94,38 @@ LOG_LEVEL_LIST
     log_trace(logging)("log_trace-test");
     log_debug(logging)("log_debug-test");
   }
+
+   void test_asynclog_drop_messages() {
+    if (AsyncLogWriter::instance() != NULL) {
+      const size_t sz = 100;
+
+      // shrink async buffer.
+      AutoModifyRestore<size_t> saver(AsyncLogBufferSize, sz * 1024 /*in byte*/);
+      LogMessage(logging) lm;
+
+      // write 100x more messages than its capacity in burst
+      for (size_t i = 0; i < sz * 100; ++i) {
+        lm.debug("a lot of log...");
+      }
+      lm.flush();
+    }
+  }
+
+  // stdout/stderr support
+  bool write_to_file(const std::string& output) {
+    FILE* f = fopen(TestLogFileName, "w");
+
+    if (f != NULL) {
+      size_t sz = output.size();
+      size_t written = fwrite(output.c_str(), sizeof(char), output.size(), f);
+
+      if (written == sz * sizeof(char)) {
+        return fclose(f) == 0;
+      }
+    }
+
+    return false;
+  }
 };
 
 TEST_VM(AsyncLogBufferTest, fifo) {
@@ -224,19 +256,48 @@ TEST_VM_F(AsyncLogTest, logMessage) {
 
 TEST_VM_F(AsyncLogTest, droppingMessage) {
   set_log_config(TestLogFileName, "logging=debug");
-  const size_t sz = 100;
+  test_asynclog_drop_messages();
+
+  AsyncLogWriter::flush();
+  if (AsyncLogWriter::instance() != NULL) {
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+  }
+}
+
+TEST_VM_F(AsyncLogTest, stdoutOutput) {
+  testing::internal::CaptureStdout();
+  set_log_config("stdout", "logging=debug");
+
+  test_asynclog_ls();
+  test_asynclog_drop_messages();
+
+  AsyncLogWriter::flush();
+  EXPECT_TRUE(write_to_file(testing::internal::GetCapturedStdout()));
+
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
   if (AsyncLogWriter::instance() != NULL) {
-    // shrink async buffer.
-    AutoModifyRestore<size_t> saver(AsyncLogBufferSize, sz * 1024 /*in byte*/);
-    LogMessage(logging) lm;
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+  }
+}
 
-    // write 100x more messages than its capacity in burst
-    for (size_t i = 0; i < sz * 100; ++i) {
-      lm.debug("a lot of log...");
-    }
-    lm.flush();
-    AsyncLogWriter::flush();
+TEST_VM_F(AsyncLogTest, stderrOutput) {
+  testing::internal::CaptureStderr();
+  set_log_config("stderr", "logging=debug");
+
+  test_asynclog_ls();
+  test_asynclog_drop_messages();
+
+  AsyncLogWriter::flush();
+  EXPECT_TRUE(write_to_file(testing::internal::GetCapturedStderr()));
+
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+
+  if (AsyncLogWriter::instance() != NULL) {
     EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
   }
 }

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#include "precompiled.hpp"
+#include "jvm.h"
+#include "logging/log.hpp"
+#include "logging/logAsyncWriter.hpp"
+#include "logging/logMessage.hpp"
+#include "logTestFixture.hpp"
+#include "logTestUtils.inline.hpp"
+#include "unittest.hpp"
+#include "utilities/autoRestore.hpp"
+#include "utilities/linkedlist.hpp"
+
+ class Integer : public StackObj {
+ private:
+  int _value;
+ public:
+  Integer() : _value(0) {
+  }
+  Integer(int i) : _value(i) {
+  }
+
+  int value() const {
+    return _value;
+  }
+
+  bool equals(const Integer& i) const {
+    return _value == i.value();
+  }
+
+  static int compare(const Integer& i1, const Integer& i2) {
+    return i1.value() - i2.value();
+  }
+
+  void setValue(int v){
+    _value = v;
+  }
+};
+
+class AsyncLogTest : public LogTestFixture {
+ public:
+  AsyncLogTest() {
+    if(!LogConfiguration::is_async_mode()) {
+      fprintf(stderr, "Warning: asynclog is OFF.\n");
+    }
+  }
+
+  void test_asynclog_ls() {
+    LogStream ls(Log(logging)::info());
+    outputStream* os = &ls;
+    os->print_cr("LogStreamWithAsyncLogImpl");
+    os->print_cr("LogStreamWithAsyncLogImpl secondline");
+
+    //multi-lines
+    os->print("logStream msg1-");
+    os->print("msg2-");
+    os->print("msg3\n");
+    os->print_cr("logStream newline");
+  }
+
+  void test_asynclog_raw() {
+    Log(logging) logger;
+#define LOG_LEVEL(level, name) logger.name("1" #level);
+LOG_LEVEL_LIST
+#undef LOG_LEVEL
+
+    LogTarget(Trace, logging) t;
+    LogTarget(Debug, logging) d;
+    EXPECT_FALSE(t.is_enabled());
+    EXPECT_TRUE(d.is_enabled());
+
+    d.print("AsyncLogTarget.print = %d", 1);
+    log_trace(logging)("log_trace-test");
+    log_debug(logging)("log_debug-test");
+  }
+};
+
+TEST_VM(AsyncLogBufferTest, fifo) {
+  LinkedListDeque<Integer, mtLogging> fifo;
+  LinkedListImpl<Integer, ResourceObj::C_HEAP, mtLogging> result;
+
+  fifo.push_back(1);
+  EXPECT_EQ((size_t)1, fifo.size());
+  EXPECT_EQ(1, (*(fifo.back())).value());
+
+  fifo.pop_all(&result);
+  EXPECT_EQ((size_t)0, fifo.size());
+  EXPECT_EQ(NULL, fifo.back());
+  EXPECT_EQ((size_t)1, result.size());
+  EXPECT_EQ(1, (*(result.head()->data())).value());
+  result.clear();
+
+  fifo.push_back(2);
+  fifo.push_back(1);
+  fifo.pop_all(&result);
+  EXPECT_EQ((size_t)2, result.size());
+  EXPECT_EQ(2,( *(result.head()->data())).value());
+  EXPECT_EQ(1, (*(result.head()->next()->data())).value());
+  result.clear();
+  const int N = 1000;
+  for (int i=0; i<N; ++i) {
+    fifo.push_back(i);
+  }
+  fifo.pop_all(&result);
+
+  EXPECT_EQ((size_t)N, result.size());
+  LinkedListIterator<Integer> it(result.head());
+  for (int i=0; i<N; ++i) {
+    const Integer* e = it.next();
+    EXPECT_EQ(i, (*e).value());
+  }
+}
+
+TEST_VM(AsyncLogBufferTest, deque) {
+  LinkedListDeque<Integer, mtLogging> deque;
+  const int N = 10;
+  Integer num[10];
+  EXPECT_EQ(NULL, deque.front());
+  EXPECT_EQ(NULL, deque.back());
+  for (int i = 0; i < N; ++i) {
+    num[i].setValue(i);
+    deque.push_back(num[i]);
+  }
+
+  EXPECT_EQ(0, (*(deque.front())).value());
+  EXPECT_EQ(N-1, (*(deque.back())).value());
+  EXPECT_EQ((size_t)N, deque.size());
+
+  deque.pop_front();
+  EXPECT_EQ((size_t)(N - 1), deque.size());
+  EXPECT_EQ(1, (*(deque.front())).value());
+  EXPECT_EQ(N - 1, (*(deque.back())).value());
+
+  deque.pop_front();
+  EXPECT_EQ((size_t)(N - 2), deque.size());
+  EXPECT_EQ(2, (*(deque.front())).value());
+  EXPECT_EQ(N - 1, (*(deque.back())).value());
+
+  for (int i=2; i < N-1; ++i) {
+    deque.pop_front();
+  }
+  EXPECT_EQ((size_t)1, deque.size());
+  EXPECT_EQ(N - 1, (*(deque.back())).value());
+  EXPECT_EQ(deque.back()->value(), deque.front()->value());
+
+  deque.pop_front();
+  EXPECT_EQ((size_t)0, deque.size());
+}
+
+TEST_VM_F(AsyncLogTest, asynclog) {
+  set_log_config(TestLogFileName, "logging=debug");
+  test_asynclog_ls();
+  test_asynclog_raw();
+  AsyncLogWriter::flush();
+
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "1Debug"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "1Info"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "1Warning"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "1Error"));
+  EXPECT_FALSE(file_contains_substring(TestLogFileName, "1Trace")); // trace message is masked out
+
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "AsyncLogTarget.print = 1"));
+  EXPECT_FALSE(file_contains_substring(TestLogFileName, "log_trace-test")); // trace message is masked out
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "log_debug-test"));
+}
+
+TEST_VM_F(AsyncLogTest, logMessage) {
+  set_log_config(TestLogFileName, "logging=debug");
+  const int MULTI_LINES = 20;
+  {
+
+    LogMessage(logging) msg;
+    Log(logging) logger;
+
+    for (int i = 0; i < MULTI_LINES; ++i) {
+      msg.debug("nonbreakable log message line-%02d", i);
+
+      if (0 == (i % 4)) {
+        logger.debug("a noisy message from other logger");
+      }
+    }
+    logger.debug("a noisy message from other logger");
+  }
+  AsyncLogWriter::flush();
+
+  ResourceMark rm;
+  LogMessageBuffer buffer;
+  const char* strs[MULTI_LINES + 1];
+  strs[MULTI_LINES] = NULL;
+  for (int i = 0; i < MULTI_LINES; ++i) {
+    stringStream ss;
+    ss.print_cr("nonbreakable log message line-%02d", i);
+    strs[i] = ss.as_string();
+  }
+  // check nonbreakable log messages are consecutive
+  EXPECT_TRUE(file_contains_substrings_in_order(TestLogFileName, strs));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "a noisy message from other logger"));
+}
+
+TEST_VM_F(AsyncLogTest, droppingMessage) {
+  set_log_config(TestLogFileName, "logging=debug");
+  const size_t sz = 100;
+
+  if (AsyncLogWriter::instance() != NULL) {
+    // shrink async buffer.
+    AutoModifyRestore<size_t> saver(AsyncLogBufferSize, sz * 1024 /*in byte*/);
+    LogMessage(logging) lm;
+
+    // write 100x more messages than its capacity in burst
+    for (size_t i = 0; i < sz * 100; ++i) {
+      lm.debug("a lot of log...");
+    }
+    lm.flush();
+    AsyncLogWriter::flush();
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+  }
+}

--- a/test/hotspot/gtest/logging/test_log.cpp
+++ b/test/hotspot/gtest/logging/test_log.cpp
@@ -58,6 +58,7 @@ TEST_VM_F(LogTest, large_message) {
   memset(big_msg, Xchar, sizeof(big_msg) - 1);
   log_trace(logging)("%s", big_msg);
 
+  AsyncLogWriter::flush();
   ResourceMark rm;
   FILE* fp = fopen(TestLogFileName, "r");
   ASSERT_NE((void*)NULL, fp);

--- a/test/hotspot/gtest/logging/test_logConfiguration.cpp
+++ b/test/hotspot/gtest/logging/test_logConfiguration.cpp
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "jvm.h"
+#include "utilities/utilitiesHelper.inline.hpp"
 #include "logTestFixture.hpp"
 #include "logTestUtils.inline.hpp"
 #include "logging/logConfiguration.hpp"
@@ -226,6 +227,91 @@ TEST_VM_F(LogConfigurationTest, reconfigure_decorators) {
   // Now reconfigure logging on stderr with no decorators
   set_log_config("stderr", "all=off", "none");
   EXPECT_TRUE(is_described("#1: stderr all=off none (reconfigured)\n")) << "Expecting no decorators";
+}
+
+class ConcurrentLogsite : public TestRunnable {
+  int _id;
+
+ public:
+  ConcurrentLogsite(int id) : _id(id) {}
+  void runUnitTest() const {
+    log_debug(logging)("ConcurrentLogsite %d emits a log", _id);
+  }
+};
+
+// Dynamically change decorators while loggings are emitting.
+TEST_VM_F(LogConfigurationTest, reconfigure_decorators_MT) {
+  const int nrOfThreads = 2;
+  ConcurrentLogsite logsites[nrOfThreads] = {0, 1};
+  Semaphore done(0);
+  const long testDurationMillis = 1000;
+  UnitTestThread* t[nrOfThreads];
+
+  set_log_config(TestLogFileName, "logging=debug", "none", "filecount=0");
+  set_log_config("stdout", "all=off", "none");
+  set_log_config("stderr", "all=off", "none");
+  for (int i = 0; i < nrOfThreads; ++i) {
+    t[i] = new UnitTestThread(&logsites[i], &done, testDurationMillis);
+  }
+
+  for (int i = 0; i < nrOfThreads; i++) {
+    t[i]->doit();
+  }
+
+  jlong time_start = os::elapsed_counter();
+  while (true) {
+    jlong elapsed = (jlong)TimeHelper::counter_to_millis(os::elapsed_counter() - time_start);
+    if (elapsed > testDurationMillis) {
+      break;
+    }
+
+    // Take turn logging with different decorators, either None or All.
+    set_log_config(TestLogFileName, "logging=debug", "none");
+    set_log_config(TestLogFileName, "logging=debug", _all_decorators);
+  }
+
+  for (int i = 0; i < nrOfThreads; ++i) {
+    done.wait();
+  }
+}
+
+// Dynamically change tags while loggings are emitting.
+TEST_VM_F(LogConfigurationTest, reconfigure_tags_MT) {
+  const int nrOfThreads = 2;
+  ConcurrentLogsite logsites[nrOfThreads] = {0, 1};
+  Semaphore done(0);
+  const long testDurationMillis = 1000;
+  UnitTestThread* t[nrOfThreads];
+
+  set_log_config(TestLogFileName, "logging=debug", "", "filecount=0");
+  set_log_config("stdout", "all=off", "none");
+  set_log_config("stderr", "all=off", "none");
+
+  for (int i = 0; i < nrOfThreads; ++i) {
+    t[i] = new UnitTestThread(&logsites[i], &done, testDurationMillis);
+  }
+
+  for (int i = 0; i < nrOfThreads; i++) {
+    t[i]->doit();
+  }
+
+  jlong time_start = os::elapsed_counter();
+  while (true) {
+    jlong elapsed = (jlong)TimeHelper::counter_to_millis(os::elapsed_counter() - time_start);
+    if (elapsed > testDurationMillis) {
+      break;
+    }
+
+    // turn on/off the tagset 'logging'.
+    set_log_config(TestLogFileName, "logging=off");
+    set_log_config(TestLogFileName, "logging=debug", "", "filecount=0");
+    // sleep a prime number milliseconds to allow concurrent logsites to write logs
+    os::naked_short_nanosleep(37);
+  }
+
+  for (int i = 0; i < nrOfThreads; ++i) {
+    done.wait();
+  }
 }
 
 // Test that invalid options cause configuration errors

--- a/test/hotspot/gtest/logging/test_logDecorations.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorations.cpp
@@ -32,12 +32,13 @@ static const LogTagSet& tagset = LogTagSetMapping<LOG_TAGS(logging, safepoint)>:
 static const LogDecorators default_decorators;
 
 TEST_VM(LogDecorations, level) {
+  char buf[LogDecorations::max_decoration_size + 1];
   for (uint l = LogLevel::First; l <= LogLevel::Last; l++) {
     LogLevelType level = static_cast<LogLevelType>(l);
     // Create a decorations object for the current level
     LogDecorations decorations(level, tagset, default_decorators);
     // Verify that the level decoration matches the specified level
-    EXPECT_STREQ(LogLevel::name(level), decorations.decoration(LogDecorators::level_decorator));
+    EXPECT_STREQ(LogLevel::name(level), decorations.decoration(LogDecorators::level_decorator, buf, sizeof(buf)));
 
     // Test changing level after object creation time
     LogLevelType other_level;
@@ -47,17 +48,18 @@ TEST_VM(LogDecorations, level) {
       other_level = static_cast<LogLevelType>(LogLevel::First);
     }
     decorations.set_level(other_level);
-    EXPECT_STREQ(LogLevel::name(other_level), decorations.decoration(LogDecorators::level_decorator))
+    EXPECT_STREQ(LogLevel::name(other_level), decorations.decoration(LogDecorators::level_decorator, buf, sizeof(buf)))
         << "Decoration reports incorrect value after changing the level";
   }
 }
 
 TEST_VM(LogDecorations, uptime) {
+  char buf[LogDecorations::max_decoration_size + 1];
   // Verify the format of the decoration
   int a, b;
   char decimal_point;
   LogDecorations decorations(LogLevel::Info, tagset, default_decorators);
-  const char* uptime = decorations.decoration(LogDecorators::uptime_decorator);
+  const char* uptime = decorations.decoration(LogDecorators::uptime_decorator, buf, sizeof(buf));
   int read = sscanf(uptime, "%d%c%ds", &a, &decimal_point, &b);
   EXPECT_EQ(3, read) << "Invalid uptime decoration: " << uptime;
   EXPECT_TRUE(decimal_point == '.' || decimal_point == ',') << "Invalid uptime decoration: " << uptime;
@@ -67,22 +69,24 @@ TEST_VM(LogDecorations, uptime) {
   for (int i = 0; i < 3; i++) {
     os::naked_short_sleep(10);
     LogDecorations d(LogLevel::Info, tagset, default_decorators);
-    double cur = strtod(d.decoration(LogDecorators::uptime_decorator), NULL);
+    double cur = strtod(d.decoration(LogDecorators::uptime_decorator, buf, sizeof(buf)), NULL);
     ASSERT_LT(prev, cur);
     prev = cur;
   }
 }
 
 TEST_VM(LogDecorations, tags) {
+  char buf[LogDecorations::max_decoration_size + 1];
   char expected_tags[1 * K];
   tagset.label(expected_tags, sizeof(expected_tags));
   // Verify that the expected tags are included in the tags decoration
   LogDecorations decorations(LogLevel::Info, tagset, default_decorators);
-  EXPECT_STREQ(expected_tags, decorations.decoration(LogDecorators::tags_decorator));
+  EXPECT_STREQ(expected_tags, decorations.decoration(LogDecorators::tags_decorator, buf, sizeof(buf)));
 }
 
 // Test each variation of the different timestamp decorations (ms, ns, uptime ms, uptime ns)
 TEST_VM(LogDecorations, timestamps) {
+  char buf[LogDecorations::max_decoration_size + 1];
   struct {
     const LogDecorators::Decorator decorator;
     const char* suffix;
@@ -100,7 +104,7 @@ TEST_VM(LogDecorations, timestamps) {
 
     // Create decorations with the decorator we want to test included
     LogDecorations decorations(LogLevel::Info, tagset, decorator_selection);
-    const char* decoration = decorations.decoration(decorator);
+    const char* decoration = decorations.decoration(decorator, buf, sizeof(buf));
 
     // Verify format of timestamp
     const char* suffix;
@@ -114,7 +118,7 @@ TEST_VM(LogDecorations, timestamps) {
     for (int i = 0; i < 3; i++) {
       os::naked_short_sleep(5);
       LogDecorations d(LogLevel::Info, tagset, decorator_selection);
-      julong val = strtoull(d.decoration(decorator), NULL, 10);
+      julong val = strtoull(d.decoration(decorator, buf, sizeof(buf)), NULL, 10);
       ASSERT_LT(prev, val);
       prev = val;
     }
@@ -123,11 +127,12 @@ TEST_VM(LogDecorations, timestamps) {
 
 // Test the time decoration
 TEST(LogDecorations, iso8601_time) {
+  char buf[LogDecorations::max_decoration_size + 1];
   LogDecorators decorator_selection;
   ASSERT_TRUE(decorator_selection.parse("time"));
   LogDecorations decorations(LogLevel::Info, tagset, decorator_selection);
 
-  const char *timestr = decorations.decoration(LogDecorators::time_decorator);
+  const char *timestr = decorations.decoration(LogDecorators::time_decorator, buf, sizeof(buf));
   time_t expected_ts = time(NULL);
 
   // Verify format
@@ -157,11 +162,12 @@ TEST(LogDecorations, iso8601_time) {
 
 // Test the utctime decoration
 TEST(LogDecorations, iso8601_utctime) {
+  char buf[LogDecorations::max_decoration_size + 1];
   LogDecorators decorator_selection;
   ASSERT_TRUE(decorator_selection.parse("utctime"));
   LogDecorations decorations(LogLevel::Info, tagset, decorator_selection);
 
-  const char *timestr = decorations.decoration(LogDecorators::utctime_decorator);
+  const char *timestr = decorations.decoration(LogDecorators::utctime_decorator, buf, sizeof(buf));
   time_t expected_ts = time(NULL);
 
   // Verify format
@@ -198,6 +204,7 @@ TEST(LogDecorations, iso8601_utctime) {
 
 // Test the pid and tid decorations
 TEST(LogDecorations, identifiers) {
+  char buf[LogDecorations::max_decoration_size + 1];
   LogDecorators decorator_selection;
   ASSERT_TRUE(decorator_selection.parse("pid,tid"));
   LogDecorations decorations(LogLevel::Info, tagset, decorator_selection);
@@ -211,7 +218,7 @@ TEST(LogDecorations, identifiers) {
   };
 
   for (uint i = 0; i < ARRAY_SIZE(ids); i++) {
-    const char* reported = decorations.decoration(ids[i].decorator);
+    const char* reported = decorations.decoration(ids[i].decorator, buf, sizeof(buf));
 
     // Verify format
     const char* str;

--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,6 +207,13 @@ TEST(LogDecorators, none) {
   LogDecorators dec = LogDecorators::None;
   for (size_t i = 0; i < LogDecorators::Count; i++) {
     EXPECT_FALSE(dec.is_decorator(decorator_array[i]));
+  }
+}
+
+TEST(LogDecorators, all) {
+  LogDecorators dec = LogDecorators::All;
+  for (size_t i = 0; i < LogDecorators::Count; i++) {
+    EXPECT_TRUE(dec.is_decorator(decorator_array[i]));
   }
 }
 

--- a/test/hotspot/gtest/logging/test_logTagSet.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSet.cpp
@@ -27,6 +27,7 @@
 #include "logging/logOutput.hpp"
 #include "logging/logTag.hpp"
 #include "logging/logTagSet.hpp"
+#include "utilities/ostream.hpp"
 #include "unittest.hpp"
 
 // Test the default level for each tagset
@@ -119,6 +120,11 @@ TEST(LogTagSet, label) {
   ASSERT_NE(-1, ts.label(buf, sizeof(buf), "++"));
   EXPECT_STREQ("logging++safepoint", buf);
 
+  // Test with a stream too
+  stringStream ss(buf, sizeof(buf));
+  ts.label(&ss, "*-*");
+  EXPECT_STREQ("logging*-*safepoint", buf);
+
   // Verify with three tags
   const LogTagSet& ts1 = LogTagSetMapping<LOG_TAGS(logging, safepoint, jni)>::tagset();
   ASSERT_NE(-1, ts1.label(buf, sizeof(buf)));
@@ -128,6 +134,7 @@ TEST(LogTagSet, label) {
   const LogTagSet& ts2 = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   ASSERT_NE(-1, ts2.label(buf, sizeof(buf)));
   EXPECT_STREQ("logging", buf);
+
 }
 
 TEST(LogTagSet, duplicates) {

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -355,3 +355,57 @@ TEST_VM(os, is_first_C_frame) {
   EXPECT_FALSE(os::is_first_C_frame(&cur_frame));
 #endif // _WIN32
 }
+
+// Not a regex! Very primitive, just match:
+// "d" - digit
+// "a" - ascii
+// "." - everything
+// rest must match
+static bool very_simple_string_matcher(const char* pattern, const char* s) {
+  const size_t lp = strlen(pattern);
+  const size_t ls = strlen(s);
+  if (ls < lp) {
+    return false;
+  }
+  for (size_t i = 0; i < lp; i ++) {
+    switch (pattern[i]) {
+      case '.': continue;
+      case 'd': if (!isdigit(s[i])) return false; break;
+      case 'a': if (!isascii(s[i])) return false; break;
+      default: if (s[i] != pattern[i]) return false; break;
+    }
+  }
+  return true;
+}
+
+TEST_VM(os, iso8601_time) {
+  char buffer[os::iso8601_timestamp_size + 1]; // + space for canary
+  buffer[os::iso8601_timestamp_size] = 'X'; // canary
+  const char* result = NULL;
+  // YYYY-MM-DDThh:mm:ss.mmm+zzzz
+  const char* const pattern = "dddd-dd-dd.dd:dd:dd.ddd+dddd";
+
+  result = os::iso8601_time(buffer, sizeof(buffer), true);
+  tty->print_cr("%s", result);
+  EXPECT_EQ(result, buffer);
+  EXPECT_TRUE(very_simple_string_matcher(pattern, result));
+
+  result = os::iso8601_time(buffer, sizeof(buffer), false);
+  tty->print_cr("%s", result);
+  EXPECT_EQ(result, buffer);
+  EXPECT_TRUE(very_simple_string_matcher(pattern, result));
+
+  // Test with explicit timestamps
+  result = os::iso8601_time(0, buffer, sizeof(buffer), true);
+  tty->print_cr("%s", result);
+  EXPECT_EQ(result, buffer);
+  EXPECT_TRUE(very_simple_string_matcher("1970-01-01.00:00:00.000+dddd", result));
+
+  result = os::iso8601_time(17, buffer, sizeof(buffer), true);
+  tty->print_cr("%s", result);
+  EXPECT_EQ(result, buffer);
+  EXPECT_TRUE(very_simple_string_matcher("1970-01-01.00:00:00.017+dddd", result));
+
+  // Canary should still be intact
+  EXPECT_EQ(buffer[os::iso8601_timestamp_size], 'X');
+}

--- a/test/hotspot/gtest/utilities/utilitiesHelper.inline.hpp
+++ b/test/hotspot/gtest/utilities/utilitiesHelper.inline.hpp
@@ -152,4 +152,31 @@ static void mt_test_doer() {
   vmt_done.wait();
 }
 
+// Base class for test runnable. Override runUnitTest() to specify what to run.
+class TestRunnable {
+public:
+  virtual void runUnitTest() const = 0;
+};
+
+// This class represents a thread for a unit test.
+class UnitTestThread : public JavaTestThread {
+public:
+  // runnableArg - what to run
+  // doneArg - a semaphore to notify when the thread is done running
+  // testDurationArg - how long to run (in milliseconds)
+  UnitTestThread(TestRunnable* const runnableArg, Semaphore* doneArg, const long testDurationArg) :
+    JavaTestThread(doneArg), runnable(runnableArg), testDuration(testDurationArg) {}
+
+  // from JavaTestThread
+  void main_run() {
+    long stopTime = os::javaTimeMillis() + testDuration;
+    while (os::javaTimeMillis() < stopTime) {
+      runnable->runUnitTest();
+    }
+  }
+private:
+  TestRunnable* const runnable;
+  const long testDuration;
+};
+
 #endif // include guard

--- a/test/hotspot/jtreg/gtest/AsyncLogGtest.java
+++ b/test/hotspot/jtreg/gtest/AsyncLogGtest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * Note: This runs the unified logging part of gtest in async mode.
+ * The reason is that hotspot can't safely turn off asynclogging dyanmically.
+ * There's no TEST_OTHER_VM_F.
+ */
+
+/* @test
+ * @summary Run logging gtest in async mode.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.xml
+ * @run main/native GTestWrapper --gtest_filter=AsyncLogTest* -Xlog:async
+ * @run main/native GTestWrapper --gtest_filter=Log*Test* -Xlog:async
+ */


### PR DESCRIPTION
Solution of #529. Backport of [8288904: Incorrect memory ordering in UL](https://github.com/openjdk/jdk/pull/9225) and [8305819: LogConfigurationTest intermittently fails on AArch64](https://github.com/openjdk/jdk/pull/13421).