### PR TITLE
[Backport] Fix incorrect memory order in UL

### DIFF
--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -43,9 +43,12 @@ jint LogOutputList::decrease_readers() {
 
 void LogOutputList::wait_until_no_readers() const {
   OrderAccess::storeload();
-  while (_active_readers != 0) {
+  while (Atomic::load(&_active_readers) != 0) {
     // Busy wait
   }
+  // Prevent mutations to the output list to float above the active reader check.
+  // Such a reordering would lead to readers loading faulty data.
+  OrderAccess::loadstore();
 }
 
 void LogOutputList::set_output_level(LogOutput* output, LogLevelType level) {

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -26,6 +26,7 @@
 
 #include "logging/logLevel.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/orderAccess.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class LogOutput;
@@ -48,11 +49,11 @@ class LogOutputList {
  private:
   struct LogOutputNode : public CHeapObj<mtLogging> {
     LogOutput*      _value;
-    LogOutputNode*  _next;
+    LogOutputNode* volatile _next;
     LogLevelType    _level;
   };
 
-  LogOutputNode*  _level_start[LogLevel::Count];
+  LogOutputNode* volatile _level_start[LogLevel::Count];
   volatile jint   _active_readers;
 
   LogOutputNode* find(const LogOutput* output) const;
@@ -125,7 +126,9 @@ class LogOutputList {
     }
 
     void operator++(int) {
-      _current = _current->_next;
+      // FIXME: memory_order_consume could be used here.
+      // Atomic access on the reading side for LogOutputList.
+      _current = OrderAccess::load_acquire(&_current->_next);
     }
 
     bool operator!=(const LogOutputNode *ref) const {
@@ -139,7 +142,9 @@ class LogOutputList {
 
   Iterator iterator(LogLevelType level = LogLevel::Last) {
     increase_readers();
-    return Iterator(this, _level_start[level]);
+    // FIXME: memory_order_consume could be used here.
+    // Atomic access on the reading side for LogOutputList.
+    return Iterator(this, OrderAccess::load_acquire(&_level_start[level]));
   }
 
   LogOutputNode* end() const {


### PR DESCRIPTION
Solution of #529. Backport of [8288904: Incorrect memory ordering in UL](https://github.com/openjdk/jdk/pull/9225) and [8305819: LogConfigurationTest intermittently fails on AArch64](https://github.com/openjdk/jdk/pull/13421).