### PR TITLE
speed up : UUID#toString

### DIFF
--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -69,6 +69,18 @@ public final class Long extends Number implements Comparable<Long> {
      */
     @Native public static final long MAX_VALUE = 0x7fffffffffffffffL;
 
+    static final char[] HEX256;
+
+    static {
+        HEX256 = new char[256];
+        for (int i = 0; i < 256; i++) {
+            int hi = (i >> 4) & 15;
+            int lo = i & 15;
+            HEX256[i] = (char) (((hi < 10 ? '0' + hi : 'a' + hi - 10) << 8)
+                    + (lo < 10 ? '0' + lo : 'a' + lo - 10));
+        }
+    }
+
     /**
      * The {@code Class} instance representing the primitive type
      * {@code long}.
@@ -425,33 +437,102 @@ public final class Long extends Number implements Comparable<Long> {
     }
 
     static String fastUUID(long lsb, long msb) {
+        final char[] hex256 = HEX256;
+        char i = hex256[((int) (msb >> 56)) & 255];
+        char i1 = hex256[((int) (msb >> 48)) & 255];
+        char i2 = hex256[((int) (msb >> 40)) & 255];
+        char i3 = hex256[((int) (msb >> 32)) & 255];
+        char i4 = hex256[(((int) msb) >> 24) & 255];
+        char i5 = hex256[(((int) msb) >> 16) & 255];
+        char i6 = hex256[(((int) msb) >> 8) & 255];
+        char i7 = hex256[((int) msb) & 255];
+        char i8 = hex256[(((int) (lsb >> 56))) & 255];
+        char i9 = hex256[(((int) (lsb >> 48))) & 255];
+        char i10 = hex256[(((int) (lsb >> 40))) & 255];
+        char i11 = hex256[((int) (lsb >> 32)) & 255];
+        char i12 = hex256[(((int) lsb) >> 24) & 255];
+        char i13 = hex256[(((int) lsb) >> 16) & 255];
+        char i14 = hex256[(((int) lsb) >> 8) & 255];
+        char i15 = hex256[((int) lsb) & 255];
+
         if (COMPACT_STRINGS) {
             byte[] buf = new byte[36];
-            formatUnsignedLong0(lsb,        4, buf, 24, 12);
-            formatUnsignedLong0(lsb >>> 48, 4, buf, 19, 4);
-            formatUnsignedLong0(msb,        4, buf, 14, 4);
-            formatUnsignedLong0(msb >>> 16, 4, buf, 9,  4);
-            formatUnsignedLong0(msb >>> 32, 4, buf, 0,  8);
-
-            buf[23] = '-';
-            buf[18] = '-';
+            buf[0] = (byte) (i >> 8);
+            buf[1] = (byte) i;
+            buf[2] = (byte) (i1 >> 8);
+            buf[3] = (byte) i1;
+            buf[4] = (byte) (i2 >> 8);
+            buf[5] = (byte) i2;
+            buf[6] = (byte) (i3 >> 8);
+            buf[7] = (byte) i3;
+            buf[8] = '-';
+            buf[9] = (byte) (i4 >> 8);
+            buf[10] = (byte) i4;
+            buf[11] = (byte) (i5 >> 8);
+            buf[12] = (byte) i5;
             buf[13] = '-';
-            buf[8]  = '-';
-
+            buf[14] = (byte) (i6 >> 8);
+            buf[15] = (byte) i6;
+            buf[16] = (byte) (i7 >> 8);
+            buf[17] = (byte) i7;
+            buf[18] = '-';
+            buf[19] = (byte) (i8 >> 8);
+            buf[20] = (byte) i8;
+            buf[21] = (byte) (i9 >> 8);
+            buf[22] = (byte) i9;
+            buf[23] = '-';
+            buf[24] = (byte) (i10 >> 8);
+            buf[25] = (byte) i10;
+            buf[26] = (byte) (i11 >> 8);
+            buf[27] = (byte) i11;
+            buf[28] = (byte) (i12 >> 8);
+            buf[29] = (byte) i12;
+            buf[30] = (byte) (i13 >> 8);
+            buf[31] = (byte) i13;
+            buf[32] = (byte) (i14 >> 8);
+            buf[33] = (byte) i14;
+            buf[34] = (byte) (i15 >> 8);
+            buf[35] = (byte) i15;
             return new String(buf, LATIN1);
         } else {
             byte[] buf = new byte[72];
 
-            formatUnsignedLong0UTF16(lsb,        4, buf, 24, 12);
-            formatUnsignedLong0UTF16(lsb >>> 48, 4, buf, 19, 4);
-            formatUnsignedLong0UTF16(msb,        4, buf, 14, 4);
-            formatUnsignedLong0UTF16(msb >>> 16, 4, buf, 9,  4);
-            formatUnsignedLong0UTF16(msb >>> 32, 4, buf, 0,  8);
-
-            StringUTF16.putChar(buf, 23, '-');
-            StringUTF16.putChar(buf, 18, '-');
+            StringUTF16.putChar(buf, 0, (byte) (i >> 8));
+            StringUTF16.putChar(buf, 1, (byte) i);
+            StringUTF16.putChar(buf, 2, (byte) (i1 >> 8));
+            StringUTF16.putChar(buf, 3, (byte) i1);
+            StringUTF16.putChar(buf, 4, (byte) (i2 >> 8));
+            StringUTF16.putChar(buf, 5, (byte) i2);
+            StringUTF16.putChar(buf, 6, (byte) (i3 >> 8));
+            StringUTF16.putChar(buf, 7, (byte) i3);
+            StringUTF16.putChar(buf, 8, '-');
+            StringUTF16.putChar(buf, 9, (byte) (i4 >> 8));
+            StringUTF16.putChar(buf, 10, (byte) i4);
+            StringUTF16.putChar(buf, 11, (byte) (i5 >> 8));
+            StringUTF16.putChar(buf, 12, (byte) i5);
             StringUTF16.putChar(buf, 13, '-');
-            StringUTF16.putChar(buf,  8, '-');
+            StringUTF16.putChar(buf, 14, (byte) (i6 >> 8));
+            StringUTF16.putChar(buf, 15, (byte) i6);
+            StringUTF16.putChar(buf, 16, (byte) (i7 >> 8));
+            StringUTF16.putChar(buf, 17, (byte) i7);
+            StringUTF16.putChar(buf, 18, '-');
+            StringUTF16.putChar(buf, 19, (byte) (i8 >> 8));
+            StringUTF16.putChar(buf, 20, (byte) i8);
+            StringUTF16.putChar(buf, 21, (byte) (i9 >> 8));
+            StringUTF16.putChar(buf, 22, (byte) i9);
+            StringUTF16.putChar(buf, 23, '-');
+            StringUTF16.putChar(buf, 24, (byte) (i10 >> 8));
+            StringUTF16.putChar(buf, 25, (byte) i10);
+            StringUTF16.putChar(buf, 26, (byte) (i11 >> 8));
+            StringUTF16.putChar(buf, 27, (byte) i11);
+            StringUTF16.putChar(buf, 28, (byte) (i12 >> 8));
+            StringUTF16.putChar(buf, 29, (byte) i12);
+            StringUTF16.putChar(buf, 30, (byte) (i13 >> 8));
+            StringUTF16.putChar(buf, 31, (byte) i13);
+            StringUTF16.putChar(buf, 32, (byte) (i14 >> 8));
+            StringUTF16.putChar(buf, 33, (byte) i14);
+            StringUTF16.putChar(buf, 34, (byte) (i15 >> 8));
+            StringUTF16.putChar(buf, 35, (byte) i15);
 
             return new String(buf, UTF16);
         }

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -30,6 +30,7 @@ import java.math.*;
 import java.util.Objects;
 import jdk.internal.util.ByteArray;
 import jdk.internal.HotSpotIntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 import static java.lang.String.COMPACT_STRINGS;
 import static java.lang.String.LATIN1;

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -28,6 +28,7 @@ package java.lang;
 import java.lang.annotation.Native;
 import java.math.*;
 import java.util.Objects;
+import jdk.internal.util.ByteArray;
 import jdk.internal.HotSpotIntrinsicCandidate;
 
 import static java.lang.String.COMPACT_STRINGS;
@@ -437,105 +438,112 @@ public final class Long extends Number implements Comparable<Long> {
     }
 
     static String fastUUID(long lsb, long msb) {
-        final char[] hex256 = HEX256;
-        char i = hex256[((int) (msb >> 56)) & 255];
-        char i1 = hex256[((int) (msb >> 48)) & 255];
-        char i2 = hex256[((int) (msb >> 40)) & 255];
-        char i3 = hex256[((int) (msb >> 32)) & 255];
-        char i4 = hex256[(((int) msb) >> 24) & 255];
-        char i5 = hex256[(((int) msb) >> 16) & 255];
-        char i6 = hex256[(((int) msb) >> 8) & 255];
-        char i7 = hex256[((int) msb) & 255];
-        char i8 = hex256[(((int) (lsb >> 56))) & 255];
-        char i9 = hex256[(((int) (lsb >> 48))) & 255];
-        char i10 = hex256[(((int) (lsb >> 40))) & 255];
-        char i11 = hex256[((int) (lsb >> 32)) & 255];
-        char i12 = hex256[(((int) lsb) >> 24) & 255];
-        char i13 = hex256[(((int) lsb) >> 16) & 255];
-        char i14 = hex256[(((int) lsb) >> 8) & 255];
-        char i15 = hex256[((int) lsb) & 255];
+        byte[] buf = new byte[36];
+        char[] H256 = DigitCache.HEX256;
 
-        if (COMPACT_STRINGS) {
-            byte[] buf = new byte[36];
-            buf[0] = (byte) (i >> 8);
-            buf[1] = (byte) i;
-            buf[2] = (byte) (i1 >> 8);
-            buf[3] = (byte) i1;
-            buf[4] = (byte) (i2 >> 8);
-            buf[5] = (byte) i2;
-            buf[6] = (byte) (i3 >> 8);
-            buf[7] = (byte) i3;
-            buf[8] = '-';
-            buf[9] = (byte) (i4 >> 8);
-            buf[10] = (byte) i4;
-            buf[11] = (byte) (i5 >> 8);
-            buf[12] = (byte) i5;
-            buf[13] = '-';
-            buf[14] = (byte) (i6 >> 8);
-            buf[15] = (byte) i6;
-            buf[16] = (byte) (i7 >> 8);
-            buf[17] = (byte) i7;
-            buf[18] = '-';
-            buf[19] = (byte) (i8 >> 8);
-            buf[20] = (byte) i8;
-            buf[21] = (byte) (i9 >> 8);
-            buf[22] = (byte) i9;
-            buf[23] = '-';
-            buf[24] = (byte) (i10 >> 8);
-            buf[25] = (byte) i10;
-            buf[26] = (byte) (i11 >> 8);
-            buf[27] = (byte) i11;
-            buf[28] = (byte) (i12 >> 8);
-            buf[29] = (byte) i12;
-            buf[30] = (byte) (i13 >> 8);
-            buf[31] = (byte) i13;
-            buf[32] = (byte) (i14 >> 8);
-            buf[33] = (byte) i14;
-            buf[34] = (byte) (i15 >> 8);
-            buf[35] = (byte) i15;
-            return new String(buf, LATIN1);
-        } else {
-            byte[] buf = new byte[72];
+        ByteArray.setLong(
+                buf,
+                0,
+                ((long) H256[((int) (msb >> 56)) & 0xff] << 48)
+                        | ((long) H256[((int) (msb >> 48)) & 0xff] << 32)
+                        | ((long) H256[((int) (msb >> 40)) & 0xff] << 16)
+                        | H256[((int) (msb >> 32)) & 0xff]);
+        buf[8] = '-';
+        ByteArray.setInt(
+                buf,
+                9,
+                (H256[(((int) msb) >> 24) & 0xff] << 16)
+                        | H256[(((int) msb) >> 16) & 0xff]);
+        buf[13] = '-';
+        ByteArray.setInt(
+                buf,
+                14,
+                (H256[(((int) msb) >> 8) & 0xff] << 16)
+                        | H256[((int) msb) & 0xff]);
+        buf[18] = '-';
+        ByteArray.setInt(
+                buf,
+                19,
+                (H256[(((int) (lsb >> 56))) & 0xff] << 16)
+                        | H256[(((int) (lsb >> 48))) & 0xff]);
+        buf[23] = '-';
+        ByteArray.setLong(
+                buf,
+                24,
+                ((long) H256[(((int) (lsb >> 40))) & 0xff] << 48)
+                        | ((long) H256[((int) (lsb >> 32)) & 0xff] << 32)
+                        | ((long) H256[(((int) lsb) >> 24) & 0xff] << 16)
+                        | H256[(((int) lsb) >> 16) & 0xff]);
+        ByteArray.setInt(
+                buf,
+                32,
+                (H256[(((int) lsb) >> 8) & 0xff] << 16)
+                        | H256[((int) lsb) & 0xff]);
 
-            StringUTF16.putChar(buf, 0, (byte) (i >> 8));
-            StringUTF16.putChar(buf, 1, (byte) i);
-            StringUTF16.putChar(buf, 2, (byte) (i1 >> 8));
-            StringUTF16.putChar(buf, 3, (byte) i1);
-            StringUTF16.putChar(buf, 4, (byte) (i2 >> 8));
-            StringUTF16.putChar(buf, 5, (byte) i2);
-            StringUTF16.putChar(buf, 6, (byte) (i3 >> 8));
-            StringUTF16.putChar(buf, 7, (byte) i3);
-            StringUTF16.putChar(buf, 8, '-');
-            StringUTF16.putChar(buf, 9, (byte) (i4 >> 8));
-            StringUTF16.putChar(buf, 10, (byte) i4);
-            StringUTF16.putChar(buf, 11, (byte) (i5 >> 8));
-            StringUTF16.putChar(buf, 12, (byte) i5);
-            StringUTF16.putChar(buf, 13, '-');
-            StringUTF16.putChar(buf, 14, (byte) (i6 >> 8));
-            StringUTF16.putChar(buf, 15, (byte) i6);
-            StringUTF16.putChar(buf, 16, (byte) (i7 >> 8));
-            StringUTF16.putChar(buf, 17, (byte) i7);
-            StringUTF16.putChar(buf, 18, '-');
-            StringUTF16.putChar(buf, 19, (byte) (i8 >> 8));
-            StringUTF16.putChar(buf, 20, (byte) i8);
-            StringUTF16.putChar(buf, 21, (byte) (i9 >> 8));
-            StringUTF16.putChar(buf, 22, (byte) i9);
-            StringUTF16.putChar(buf, 23, '-');
-            StringUTF16.putChar(buf, 24, (byte) (i10 >> 8));
-            StringUTF16.putChar(buf, 25, (byte) i10);
-            StringUTF16.putChar(buf, 26, (byte) (i11 >> 8));
-            StringUTF16.putChar(buf, 27, (byte) i11);
-            StringUTF16.putChar(buf, 28, (byte) (i12 >> 8));
-            StringUTF16.putChar(buf, 29, (byte) i12);
-            StringUTF16.putChar(buf, 30, (byte) (i13 >> 8));
-            StringUTF16.putChar(buf, 31, (byte) i13);
-            StringUTF16.putChar(buf, 32, (byte) (i14 >> 8));
-            StringUTF16.putChar(buf, 33, (byte) i14);
-            StringUTF16.putChar(buf, 34, (byte) (i15 >> 8));
-            StringUTF16.putChar(buf, 35, (byte) i15);
+        return new String(buf, LATIN1);
+    }
 
-            return new String(buf, UTF16);
-        }
+    static String fastUUIDUTF16(long lsb, long msb) {
+        char[] H256 = DigitCache.HEX256;
+
+        char i0 = H256[((int) (msb >> 56)) & 0xff];
+        char i1 = H256[((int) (msb >> 48)) & 0xff];
+        char i2 = H256[((int) (msb >> 40)) & 0xff];
+        char i3 = H256[((int) (msb >> 32)) & 0xff];
+        char i4 = H256[(((int) msb) >> 24) & 0xff];
+        char i5 = H256[(((int) msb) >> 16) & 0xff];
+        char i6 = H256[(((int) msb) >> 8) & 0xff];
+        char i7 = H256[((int) msb) & 0xff];
+        char i8 = H256[(((int) (lsb >> 56))) & 0xff];
+        char i9 = H256[(((int) (lsb >> 48))) & 0xff];
+        char i10 = H256[(((int) (lsb >> 40))) & 0xff];
+        char i11 = H256[((int) (lsb >> 32)) & 0xff];
+        char i12 = H256[(((int) lsb) >> 24) & 0xff];
+        char i13 = H256[(((int) lsb) >> 16) & 0xff];
+        char i14 = H256[(((int) lsb) >> 8) & 0xff];
+        char i15 = H256[((int) lsb) & 0xff];
+
+        byte[] buf = new byte[72];
+        int off = StringUTF16.isBigEndian() ? 1 : 0;
+
+        buf[0 + off] = (byte) (i0 >> 8);
+        buf[2 + off] = (byte) i0;
+        buf[4 + off] = (byte) (i1 >> 8);
+        buf[6 + off] = (byte) i1;
+        buf[8 + off] = (byte) (i2 >> 8);
+        buf[10 + off] = (byte) i2;
+        buf[12 + off] = (byte) (i3 >> 8);
+        buf[14 + off] = (byte) i3;
+        buf[16 + off] = '-';
+        buf[18 + off] = (byte) (i4 >> 8);
+        buf[20 + off] = (byte) i4;
+        buf[22 + off] = (byte) (i5 >> 8);
+        buf[24 + off] = (byte) i5;
+        buf[26 + off] = '-';
+        buf[28 + off] = (byte) (i6 >> 8);
+        buf[30 + off] = (byte) i6;
+        buf[32 + off] = (byte) (i7 >> 8);
+        buf[34 + off] = (byte) i7;
+        buf[36 + off] = '-';
+        buf[38 + off] = (byte) (i8 >> 8);
+        buf[40 + off] = (byte) i8;
+        buf[42 + off] = (byte) (i9 >> 8);
+        buf[44 + off] = (byte) i9;
+        buf[46 + off] = '-';
+        buf[48 + off] = (byte) (i10 >> 8);
+        buf[50 + off] = (byte) i10;
+        buf[52 + off] = (byte) (i11 >> 8);
+        buf[54 + off] = (byte) i11;
+        buf[56 + off] = (byte) (i12 >> 8);
+        buf[58 + off] = (byte) i12;
+        buf[60 + off] = (byte) (i13 >> 8);
+        buf[62 + off] = (byte) i13;
+        buf[64 + off] = (byte) (i14 >> 8);
+        buf[66 + off] = (byte) i14;
+        buf[68 + off] = (byte) (i15 >> 8);
+        buf[70 + off] = (byte) i15;
+
+        return new String(buf, UTF16);
     }
 
     /**
@@ -1233,6 +1241,20 @@ public final class Long extends Number implements Comparable<Long> {
         static {
             for(int i = 0; i < cache.length; i++)
                 cache[i] = new Long(i - 128);
+        }
+    }
+
+    static final class DigitCache {
+        @Stable
+        static final char[] HEX256;
+        static {
+            HEX256 = new char[256];
+            for (int i = 0; i < 256; i++) {
+                int hi = (i >> 4) & 15;
+                int lo = i & 15;
+                HEX256[i] = (char) (((hi < 10 ? '0' + hi : 'a' + hi - 10) << 8)
+                        + (lo < 10 ? '0' + lo : 'a' + lo - 10));
+            }
         }
     }
 

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1348,7 +1348,7 @@ final class StringUTF16 {
 
     ////////////////////////////////////////////////////////////////
 
-    private static native boolean isBigEndian();
+    static native boolean isBigEndian();
 
     static final int HI_BYTE_SHIFT;
     static final int LO_BYTE_SHIFT;

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2140,7 +2140,7 @@ public final class System {
                 return cl.definePackage(name, module);
             }
             public String fastUUID(long lsb, long msb) {
-                return Long.fastUUID(lsb, msb);
+                return String.COMPACT_STRINGS ? Long.fastUUID(lsb, msb) : Long.fastUUIDUTF16(lsb, msb);
             }
             public void addNonExportedPackages(ModuleLayer layer) {
                 SecurityManager.addNonExportedPackages(layer);

--- a/src/java.base/share/classes/jdk/internal/util/ByteArray.java
+++ b/src/java.base/share/classes/jdk/internal/util/ByteArray.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.util;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+/**
+ * Utility methods for packing/unpacking primitive values in/out of byte arrays
+ * using {@linkplain ByteOrder#BIG_ENDIAN big endian order} (aka. "network order").
+ * <p>
+ * All methods in this class will throw an {@linkplain NullPointerException} if {@code null} is
+ * passed in as a method parameter for a byte array.
+ */
+public final class ByteArray {
+
+    private ByteArray() {
+    }
+
+    private static final VarHandle SHORT = create(short[].class);
+    private static final VarHandle CHAR = create(char[].class);
+    private static final VarHandle INT = create(int[].class);
+    private static final VarHandle FLOAT = create(float[].class);
+    private static final VarHandle LONG = create(long[].class);
+    private static final VarHandle DOUBLE = create(double[].class);
+
+    /*
+     * Methods for unpacking primitive values from byte arrays starting at
+     * a given offset.
+     */
+
+    /**
+     * {@return a {@code boolean} from the provided {@code array} at the given {@code offset}}.
+     *
+     * @param array  to read a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 1]
+     * @see #setBoolean(byte[], int, boolean)
+     */
+    public static boolean getBoolean(byte[] array, int offset) {
+        return array[offset] != 0;
+    }
+
+    /**
+     * {@return a {@code char} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #setChar(byte[], int, char)
+     */
+    public static char getChar(byte[] array, int offset) {
+        return (char) CHAR.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code short} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @return a {@code short} from the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #setShort(byte[], int, short)
+     */
+    public static short getShort(byte[] array, int offset) {
+        return (short) SHORT.get(array, offset);
+    }
+
+    /**
+     * {@return an {@code unsigned short} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @return an {@code int} representing an unsigned short from the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #setUnsignedShort(byte[], int, int)
+     */
+    public static int getUnsignedShort(byte[] array, int offset) {
+        return Short.toUnsignedInt((short) SHORT.get(array, offset));
+    }
+
+    /**
+     * {@return an {@code int} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #setInt(byte[], int, int)
+     */
+    public static int getInt(byte[] array, int offset) {
+        return (int) INT.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code float} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #setFloat(byte[], int, float)
+     */
+    public static float getFloat(byte[] array, int offset) {
+        // Using Float.intBitsToFloat collapses NaN values to a single
+        // "canonical" NaN value
+        return Float.intBitsToFloat((int) INT.get(array, offset));
+    }
+
+    /**
+     * {@return a {@code float} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are silently read according
+     * to their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #setFloatRaw(byte[], int, float)
+     */
+    public static float getFloatRaw(byte[] array, int offset) {
+        // Just gets the bits as they are
+        return (float) FLOAT.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code long} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 8]
+     * @see #setLong(byte[], int, long)
+     */
+    public static long getLong(byte[] array, int offset) {
+        return (long) LONG.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code double} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 8]
+     * @see #setDouble(byte[], int, double)
+     */
+    public static double getDouble(byte[] array, int offset) {
+        // Using Double.longBitsToDouble collapses NaN values to a single
+        // "canonical" NaN value
+        return Double.longBitsToDouble((long) LONG.get(array, offset));
+    }
+
+    /**
+     * {@return a {@code double} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are silently read according to
+     * their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 8]
+     * @see #setDoubleRaw(byte[], int, double)
+     */
+    public static double getDoubleRaw(byte[] array, int offset) {
+        // Just gets the bits as they are
+        return (double) DOUBLE.get(array, offset);
+    }
+
+    /*
+     * Methods for packing primitive values into byte arrays starting at a given
+     * offset.
+     */
+
+    /**
+     * Sets (writes) the provided {@code value} into
+     * the provided {@code array} beginning at the given {@code offset}.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length]
+     * @see #getBoolean(byte[], int)
+     */
+    public static void setBoolean(byte[] array, int offset, boolean value) {
+        array[offset] = (byte) (value ? 1 : 0);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getChar(byte[], int)
+     */
+    public static void setChar(byte[] array, int offset, char value) {
+        CHAR.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getShort(byte[], int)
+     */
+    public static void setShort(byte[] array, int offset, short value) {
+        SHORT.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getUnsignedShort(byte[], int)
+     */
+    public static void setUnsignedShort(byte[] array, int offset, int value) {
+        SHORT.set(array, offset, (short) (char) value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #getInt(byte[], int)
+     */
+    public static void setInt(byte[] array, int offset, int value) {
+        INT.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getFloat(byte[], int)
+     */
+    public static void setFloat(byte[] array, int offset, float value) {
+        // Using Float.floatToIntBits collapses NaN values to a single
+        // "canonical" NaN value
+        INT.set(array, offset, Float.floatToIntBits(value));
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are silently written according to
+     * their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getFloatRaw(byte[], int)
+     */
+    public static void setFloatRaw(byte[] array, int offset, float value) {
+        // Just sets the bits as they are
+        FLOAT.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #getLong(byte[], int)
+     */
+    public static void setLong(byte[] array, int offset, long value) {
+        LONG.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getDouble(byte[], int)
+     */
+    public static void setDouble(byte[] array, int offset, double value) {
+        // Using Double.doubleToLongBits collapses NaN values to a single
+        // "canonical" NaN value
+        LONG.set(array, offset, Double.doubleToLongBits(value));
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are silently written according to
+     * their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getDoubleRaw(byte[], int)
+     */
+    public static void setDoubleRaw(byte[] array, int offset, double value) {
+        // Just sets the bits as they are
+        DOUBLE.set(array, offset, value);
+    }
+
+    private static VarHandle create(Class<?> viewArrayClass) {
+        return MethodHandles.byteArrayViewVarHandle(viewArrayClass, ByteOrder.BIG_ENDIAN);
+    }
+
+}


### PR DESCRIPTION
Latest benchmark result:

* [aliyun_c8i.xlarge](https://help.aliyun.com/document_detail/25378.html#c8i) (+32.17% )
cpu : intel xeon sapphire rapids (x64)
``` diff
 Benchmark           (size)   Mode  Cnt   Score   Error   Units
-UUIDBench.toString   20000  thrpt   15  62.457 ± 0.226  ops/us
+UUIDBench.toString   20000  thrpt   15  82.550 ± 0.704  ops/us
```

* [aliyun_c8a.xlarge](https://help.aliyun.com/document_detail/25378.html#c8a) (+46.88%)
cpu : amd epc genoa (x64)
``` diff
 Benchmark           (size)   Mode  Cnt   Score   Error   Units
-UUIDBench.toString   20000  thrpt   15  65.673 ± 0.110  ops/us
+UUIDBench.toString   20000  thrpt   15  96.461 ± 0.293  ops/us
```

* [aliyun_c8y.xlarge](https://help.aliyun.com/document_detail/25378.html#c8y) (+57.97%)
cpu : aliyun yitian 710 (aarch64)
``` diff
 Benchmark           (size)   Mode  Cnt   Score   Error   Units
-UUIDBench.toString   20000  thrpt   15  32.198 ± 0.907  ops/us
+UUIDBench.toString   20000  thrpt   15  50.864 ± 1.305  ops/us
```

* aws_c5.xlarge (+49.42% )
aws x64
``` diff
 Benchmark           (size)   Mode  Cnt   Score   Error   Units
-UUIDBench.toString   20000  thrpt   15  46.003 ± 0.291  ops/us
+UUIDBench.toString   20000  thrpt   15  68.741 ± 0.199  ops/us
```

* MacBook Pro M1 Pro (+201.14%)
``` diff
 Benchmark           (size)   Mode  Cnt   Score    Error   Units
-UUIDBench.toString   20000  thrpt   15   36.875 ± 0.902  ops/us
+UUIDBench.toString   20000  thrpt   15  111.049 ± 0.783  ops/us
```

* [Orange Pi 5 Plus](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5-plus.html) (+64.97%)
cpu : RK3588 (aarch64)
``` diff
 Benchmark           (size)   Mode  Cnt   Score   Error   Units
-UUIDBench.toString   20000  thrpt   15  21.691 ± 0.204  ops/us
+UUIDBench.toString   20000  thrpt   15  35.785 ± 0.447  ops/us
```