### PR TITLE
optimization for Integer.toString & StringBuilder.append(int)

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ByteArray.java
+++ b/src/java.base/share/classes/jdk/internal/util/ByteArray.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.util;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+/**
+ * Utility methods for packing/unpacking primitive values in/out of byte arrays
+ * using {@linkplain ByteOrder#BIG_ENDIAN big endian order} (aka. "network order").
+ * <p>
+ * All methods in this class will throw an {@linkplain NullPointerException} if {@code null} is
+ * passed in as a method parameter for a byte array.
+ */
+public final class ByteArray {
+
+    private ByteArray() {
+    }
+
+    private static final VarHandle SHORT = create(short[].class);
+    private static final VarHandle CHAR = create(char[].class);
+    private static final VarHandle INT = create(int[].class);
+    private static final VarHandle FLOAT = create(float[].class);
+    private static final VarHandle LONG = create(long[].class);
+    private static final VarHandle DOUBLE = create(double[].class);
+
+    /*
+     * Methods for unpacking primitive values from byte arrays starting at
+     * a given offset.
+     */
+
+    /**
+     * {@return a {@code boolean} from the provided {@code array} at the given {@code offset}}.
+     *
+     * @param array  to read a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 1]
+     * @see #setBoolean(byte[], int, boolean)
+     */
+    public static boolean getBoolean(byte[] array, int offset) {
+        return array[offset] != 0;
+    }
+
+    /**
+     * {@return a {@code char} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #setChar(byte[], int, char)
+     */
+    public static char getChar(byte[] array, int offset) {
+        return (char) CHAR.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code short} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @return a {@code short} from the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #setShort(byte[], int, short)
+     */
+    public static short getShort(byte[] array, int offset) {
+        return (short) SHORT.get(array, offset);
+    }
+
+    /**
+     * {@return an {@code unsigned short} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @return an {@code int} representing an unsigned short from the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #setUnsignedShort(byte[], int, int)
+     */
+    public static int getUnsignedShort(byte[] array, int offset) {
+        return Short.toUnsignedInt((short) SHORT.get(array, offset));
+    }
+
+    /**
+     * {@return an {@code int} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #setInt(byte[], int, int)
+     */
+    public static int getInt(byte[] array, int offset) {
+        return (int) INT.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code float} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #setFloat(byte[], int, float)
+     */
+    public static float getFloat(byte[] array, int offset) {
+        // Using Float.intBitsToFloat collapses NaN values to a single
+        // "canonical" NaN value
+        return Float.intBitsToFloat((int) INT.get(array, offset));
+    }
+
+    /**
+     * {@return a {@code float} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are silently read according
+     * to their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #setFloatRaw(byte[], int, float)
+     */
+    public static float getFloatRaw(byte[] array, int offset) {
+        // Just gets the bits as they are
+        return (float) FLOAT.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code long} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 8]
+     * @see #setLong(byte[], int, long)
+     */
+    public static long getLong(byte[] array, int offset) {
+        return (long) LONG.get(array, offset);
+    }
+
+    /**
+     * {@return a {@code double} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 8]
+     * @see #setDouble(byte[], int, double)
+     */
+    public static double getDouble(byte[] array, int offset) {
+        // Using Double.longBitsToDouble collapses NaN values to a single
+        // "canonical" NaN value
+        return Double.longBitsToDouble((long) LONG.get(array, offset));
+    }
+
+    /**
+     * {@return a {@code double} from the provided {@code array} at the given {@code offset}
+     * using big endian order}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are silently read according to
+     * their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to get a value from.
+     * @param offset where extraction in the array should begin
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 8]
+     * @see #setDoubleRaw(byte[], int, double)
+     */
+    public static double getDoubleRaw(byte[] array, int offset) {
+        // Just gets the bits as they are
+        return (double) DOUBLE.get(array, offset);
+    }
+
+    /*
+     * Methods for packing primitive values into byte arrays starting at a given
+     * offset.
+     */
+
+    /**
+     * Sets (writes) the provided {@code value} into
+     * the provided {@code array} beginning at the given {@code offset}.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length]
+     * @see #getBoolean(byte[], int)
+     */
+    public static void setBoolean(byte[] array, int offset, boolean value) {
+        array[offset] = (byte) (value ? 1 : 0);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getChar(byte[], int)
+     */
+    public static void setChar(byte[] array, int offset, char value) {
+        CHAR.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getShort(byte[], int)
+     */
+    public static void setShort(byte[] array, int offset, short value) {
+        SHORT.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getUnsignedShort(byte[], int)
+     */
+    public static void setUnsignedShort(byte[] array, int offset, int value) {
+        SHORT.set(array, offset, (short) (char) value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #getInt(byte[], int)
+     */
+    public static void setInt(byte[] array, int offset, int value) {
+        INT.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getFloat(byte[], int)
+     */
+    public static void setFloat(byte[] array, int offset, float value) {
+        // Using Float.floatToIntBits collapses NaN values to a single
+        // "canonical" NaN value
+        INT.set(array, offset, Float.floatToIntBits(value));
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Float#NaN } values are silently written according to
+     * their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getFloatRaw(byte[], int)
+     */
+    public static void setFloatRaw(byte[] array, int offset, float value) {
+        // Just sets the bits as they are
+        FLOAT.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 4]
+     * @see #getLong(byte[], int)
+     */
+    public static void setLong(byte[] array, int offset, long value) {
+        LONG.set(array, offset, value);
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are canonized to a single NaN value.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getDouble(byte[], int)
+     */
+    public static void setDouble(byte[] array, int offset, double value) {
+        // Using Double.doubleToLongBits collapses NaN values to a single
+        // "canonical" NaN value
+        LONG.set(array, offset, Double.doubleToLongBits(value));
+    }
+
+    /**
+     * Sets (writes) the provided {@code value} using big endian order into
+     * the provided {@code array} beginning at the given {@code offset}.
+     * <p>
+     * Variants of {@linkplain Double#NaN } values are silently written according to
+     * their bit patterns.
+     * <p>
+     * There are no access alignment requirements.
+     *
+     * @param array  to set (write) a value into
+     * @param offset where setting (writing) in the array should begin
+     * @param value  value to set in the array
+     * @throws IndexOutOfBoundsException if the provided {@code offset} is outside
+     *                                   the range [0, array.length - 2]
+     * @see #getDoubleRaw(byte[], int)
+     */
+    public static void setDoubleRaw(byte[] array, int offset, double value) {
+        // Just sets the bits as they are
+        DOUBLE.set(array, offset, value);
+    }
+
+    private static VarHandle create(Class<?> viewArrayClass) {
+        return MethodHandles.byteArrayViewVarHandle(viewArrayClass, ByteOrder.BIG_ENDIAN);
+    }
+
+}

--- a/src/java.base/share/classes/jdk/internal/util/DecDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecDigits.java
@@ -1,0 +1,26 @@
+package jdk.internal.util;
+
+import jdk.internal.vm.annotation.Stable;
+
+public class DecDigits {
+    @Stable
+    public static final int[] DIGITS;
+
+    static {
+        int[] digits = new int[1000];
+        for (int i = 0; i < 10; i++) {
+            int i100 = i * 100;
+            for (int j = 0; j < 10; j++) {
+                int j10 = j * 10;
+                for (int k = 0; k < 10; k++) {
+                    digits[i100 + j10 + k]
+                            = ((i == 0 && j == 0) ? 2 : (i == 0) ? 1 : 0) << 24
+                            | ((i + '0') << 16)
+                            | ((j + '0') << 8)
+                            | (k + '0');
+                }
+            }
+        }
+        DIGITS = digits;
+    }
+}


### PR DESCRIPTION
optimization for:
Integer.toString(int)
StringBuilder#append(int)
StringBuffer#append(int)

# 1. Commands

* branch [optimize_to_string](https://github.com/wenshao/jdk/tree/optimize_to_string)

```
git clone https://github.com/wenshao/jdk
cd jdk
git checkout optimize_to_string
bash configure
make images
sh make/devkit/createJMHBundle.sh
bash configure --with-jmh=build/jmh/jars
make test TEST="micro:java.lang.Integers.toString*" 
make test TEST="micro:java.lang.StringBuilders.toStringCharWithInt*"
```

# 2. MacBookPro M1 Pro

* Integers.toStringTiny (-17.29%)
``` diff
 Benchmark              (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringTiny     500  avgt   15  2.338 ± 0.033  us/op
+Integers.toStringTiny     500  avgt   15  2.827 ± 0.035  us/op
```

* Integers.toStringSmall (+22.06%)
``` diff
 Benchmark               (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringSmall     500  avgt   15  4.465 ± 0.057  us/op
+Integers.toStringSmall     500  avgt   15  3.658 ± 0.296  us/op
```

* Integers.toStringBig (+266.63%)
``` diff
 Benchmark             (size)  Mode  Cnt   Score   Error  Units
-Integers.toStringBig     500  avgt   15  17.866 ± 4.029  us/op
+Integers.toStringBig     500  avgt   15   4.873 ± 0.049  us/op
```

* StringBuilders.toStringCharWithInt8 (+848.31%)
``` diff
 Benchmark                               Mode  Cnt     Score     Error  Units
-StringBuilders.toStringCharWithInt8      avgt   15   133.475 ±  81.002  ns/op
+StringBuilders.toStringCharWithInt8      avgt   15    14.075 ±  0.045  ns/op
```

* StringBuilders.toStringCharWithIntTiny (+1.38%)
``` diff
 Benchmark                               Mode  Cnt     Score     Error  Units
-StringBuilders.toStringCharWithIntTiny  avgt   15   1512.647 ±  25.371  ns/op
+StringBuilders.toStringCharWithIntTiny   avgt   15  1491.986 ±  3.917  ns/op
```

* StringBuilders.toStringCharWithIntSmall (+78.29%)
``` diff
 Benchmark                               Mode  Cnt     Score     Error  Units
-StringBuilders.toStringCharWithIntSmall avgt   15   4068.938 ±  25.371  ns/op
+StringBuilders.toStringCharWithIntSmall  avgt   15  2281.476 ±  6.398  ns/op
```

* StringBuilders.toStringCharWithIntBig (+46.30%)
``` diff
 Benchmark                                Mode  Cnt    Score     Error  Units
-StringBuilders.toStringCharWithIntBig    avgt   15  6470.144 ± 255.504  ns/op
+StringBuilders.toStringCharWithIntBig    avgt   15  4422.480 ± 18.456  ns/op
```

# 3. [aliyun_c8i.xlarge](https://help.aliyun.com/document_detail/25378.html#c8i)
cpu : intel xeon sapphire rapids (x64)

* Integers.toStringTiny (+6.73%)
``` diff
 Benchmark              (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringTiny     500  avgt   15  3.770 ± 0.060  us/op
+Integers.toStringTiny     500  avgt   15  3.532 ± 0.074  us/op
```

* Integers.toStringSmall (+22.41%)
``` diff
 Benchmark               (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringSmall     500  avgt   15  4.708 ± 0.013  us/op
+Integers.toStringSmall     500  avgt   15  3.846 ± 0.019  us/op
```

* Integers.toStringBig (+30.98%) 
``` diff
 Benchmark             (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringBig     500  avgt   15  6.747 ± 0.018  us/op
+Integers.toStringBig     500  avgt   15  5.151 ± 0.018  us/op
```
* StringBuilders.toStringCharWithInt8 (+187.46%)
``` diff
 Benchmark                                Mode  Cnt     Score    Error  Units
-StringBuilders.toStringCharWithInt8      avgt   15    88.928 ±  1.044  ns/op
+StringBuilders.toStringCharWithInt8      avgt   15    30.935 ±  18.380  ns/op
```

* StringBuilders.toStringCharWithIntTiny (-28.43%)
``` diff
 Benchmark                                Mode  Cnt     Score    Error  Units
-StringBuilders.toStringCharWithIntTiny   avgt   15  1761.961 ± 44.235  ns/op
+StringBuilders.toStringCharWithIntTiny   avgt   15  2462.206 ±  1.777  ns/op
```

* StringBuilders.toStringCharWithIntSmall (+72.88%)
``` diff
 Benchmark                                Mode  Cnt     Score    Error  Units
-StringBuilders.toStringCharWithIntSmall  avgt   15  5652.977 ± 44.235  ns/op
+StringBuilders.toStringCharWithIntTiny   avgt   15  3269.803 ±   6.171  ns/op
```

* StringBuilders.toStringCharWithIntBig (+43.93%)
``` diff
 Benchmark                                Mode  Cnt     Score    Error  Units
-StringBuilders.toStringCharWithIntBig    avgt   15  9861.697 ± 44.235  ns/op
+StringBuilders.toStringCharWithIntBig    avgt   15  6851.668 ± 41.018  ns/op
```

# 4. [aliyun_c8a.xlarge](https://help.aliyun.com/document_detail/25378.html#c8a)
cpu : amd epc genoa (x64)

* Integers.toStringTiny (+3.10%)
``` diff
 Benchmark              (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringTiny     500  avgt   15  2.754 ± 0.007  us/op
+Integers.toStringTiny     500  avgt   15  2.671 ± 0.146  us/op
```

* Integers.toStringSmall (+27.86%)
``` diff
 Benchmark               (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringSmall     500  avgt   15  4.483 ± 0.005  us/op
+Integers.toStringSmall     500  avgt   15  3.506 ± 0.075  us/op
```

* Integers.toStringBig (+35.50%)
``` diff
 Benchmark             (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringBig     500  avgt   15  6.759 ± 0.008  us/op
+Integers.toStringBig     500  avgt   15  4.988 ± 0.024  us/op
```

* StringBuilders.toStringCharWithInt8 (+134.39%)
``` diff
 Benchmark                                Mode  Cnt     Score    Error  Units
-StringBuilders.toStringCharWithInt8      avgt   15    93.225 ±   2.948  ns/op
+StringBuilders.toStringCharWithInt8      avgt   15    39.773 ±  0.249  ns/op
```

* StringBuilders.toStringCharWithIntTiny (-27.31%)
``` diff
 Benchmark                                Mode  Cnt     Score     Error  Units
-StringBuilders.toStringCharWithIntTiny  avgt   15  1746.719 ± 0.893  ns/op
+StringBuilders.toStringCharWithIntTiny  avgt   15  2403.254 ± 3.055  ns/op
```

* StringBuilders.toStringCharWithIntSmall (+104.05%)
``` diff
 Benchmark                                Mode  Cnt     Score     Error  Units
-StringBuilders.toStringCharWithIntSmall  avgt   15  5493.827 ± 0.893  ns/op
+StringBuilders.toStringCharWithIntSmall  avgt   15  2692.291 ± 3.055  ns/op
```

* StringBuilders.toStringCharWithIntBig (+50.79%)
``` diff
 Benchmark                              Mode  Cnt     Score   Error  Units
-StringBuilders.toStringCharWithIntBig  avgt   15  8731.999 ± 0.893  ns/op
+StringBuilders.toStringCharWithIntBig  avgt   15  5790.750 ± 3.055  ns/op
```


# 5. [aliyun_c8y.xlarge](https://help.aliyun.com/document_detail/25378.html#c8y)
cpu : aliyun yitian 710 (aarch64)

* Integers.toStringTiny (-11.37%)
``` diff
 Benchmark              (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringTiny     500  avgt   15  6.200 ± 0.112  us/op
+Integers.toStringTiny     500  avgt   15  6.996 ± 0.162  us/op
```

* Integers.toStringSmall (+0.22%)
``` diff
 Benchmark               (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringSmall     500  avgt   15  7.204 ± 0.153  us/op
+Integers.toStringSmall     500  avgt   15  7.188 ± 0.255  us/op
```

* Integers.toStringBig (+44.12%)
``` diff
 Benchmark             (size)  Mode  Cnt   Score   Error  Units
-Integers.toStringBig     500  avgt   15  11.942 ± 0.249  us/op
+Integers.toStringBig     500  avgt   15   8.286 ± 0.291  us/op
```

* StringBuilders.toStringCharWithInt8 (+52.27%)
``` diff
 Benchmark                                Mode  Cnt    Score     Error  Units
-StringBuilders.toStringCharWithInt8      avgt   15    52.941 ±  0.702  ns/op
+StringBuilders.toStringCharWithInt8      avgt   15    34.653 ±   0.817  ns/op
```

* StringBuilders.toStringCharWithIntTiny (+3.01%)
``` diff
 Benchmark                                Mode  Cnt  Score      Error  Units
-StringBuilders.toStringCharWithIntTiny   avgt   15  2359.117 ±  0.844  ns/op
+StringBuilders.toStringCharWithIntTiny   avgt   15  2290.051 ±  10.707  ns/op
```

* StringBuilders.toStringCharWithIntSmall (+65.62%)
``` diff
 Benchmark                                Mode  Cnt  Score     Error  Units
-StringBuilders.toStringCharWithIntSmall  avgt   15  6242.325 ± 0.844  ns/op
+StringBuilders.toStringCharWithIntSmall  avgt   15  3768.949 ±   9.792  ns/op
```

* StringBuilders.toStringCharWithIntBig (+63.70%)
``` diff
 Benchmark                                Mode  Cnt      Score     Error  Units
-StringBuilders.toStringCharWithIntBig    avgt   15  11493.624 ± 358.937  ns/op
+StringBuilders.toStringCharWithIntBig    avgt   15   7020.785 ± 326.069  ns/op
```


# 6. [Orange Pi 5 Plus](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5-plus.html)
cpu : RK3588 (aarch64)

* Integers.toStringTiny (-11.14%)
``` diff
 Benchmark              (size)  Mode  Cnt  Score   Error  Units
-Integers.toStringTiny     500  avgt   15  7.981 ± 0.115  us/op
+Integers.toStringTiny     500  avgt   15  8.979 ± 0.147  us/op
```

* Integers.toStringSmall (+33.79%)
``` diff
 Benchmark               (size)  Mode  Cnt   Score   Error  Units
-Integers.toStringSmall     500  avgt   15  12.827 ± 0.190  us/op
+Integers.toStringSmall     500  avgt   15   9.587 ± 0.150  us/op
```

* Integers.toStringBig (+64.91%)
``` diff
 Benchmark             (size)  Mode  Cnt   Score   Error  Units
-Integers.toStringBig     500  avgt   15  20.530 ± 0.219  us/op
+Integers.toStringBig     500  avgt   15  12.449 ± 0.188  us/op
```

* StringBuilders.toStringCharWithInt8 (+95.58%)
``` diff
 Benchmark                                Mode  Cnt      Score     Error  Units
-StringBuilders.toStringCharWithInt8      avgt   15     95.399 ±   2.568  ns/op
+StringBuilders.toStringCharWithInt8      avgt   15     48.775 ±    1.320  ns/op
```

* StringBuilders.toStringCharWithIntTiny (+11.78%)
``` diff
 Benchmark                                Mode  Cnt      Score     Error  Units
-StringBuilders.toStringCharWithIntTiny   avgt   15   4715.996 ± 106.712  ns/op
+StringBuilders.toStringCharWithIntTiny   avgt   15   4218.791 ±   47.060  ns/op
```

* StringBuilders.toStringCharWithIntSmall (+65.39%)
``` diff
 Benchmark                                Mode  Cnt      Score     Error  Units
-StringBuilders.toStringCharWithIntSmall  avgt   15   12202.075 ± 106.712  ns/op
+StringBuilders.toStringCharWithIntSmall  avgt   15    7377.331 ±  119.671  ns/op
```

* StringBuilders.toStringCharWithIntSmall (+61.98%)
``` diff
 Benchmark                                Mode  Cnt      Score     Error  Units
-StringBuilders.toStringCharWithIntBig    avgt   15  21904.673 ± 901.208  ns/op
+StringBuilders.toStringCharWithIntBig    avgt   15  13522.576 ± 1010.084  ns/op
```

