### PR TITLE
[Backport] 8191998: C2: inlining through MH linkers drops speculative part of argument types

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -917,7 +917,8 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
           const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
           const Type*       sig_type = TypeOopPtr::make_from_klass(signature->accessing_klass());
           if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-            Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, sig_type));
+            const Type* recv_type = arg_type->join_speculative(sig_type); // keep speculative part
+            Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, recv_type));
             kit.set_argument(0, cast_obj);
           }
         }
@@ -929,7 +930,8 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
             const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
             const Type*       sig_type = TypeOopPtr::make_from_klass(t->as_klass());
             if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-              Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, sig_type));
+              const Type* narrowed_arg_type = arg_type->join_speculative(sig_type); // keep speculative part
+              Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, narrowed_arg_type));
               kit.set_argument(receiver_skip + j, cast_obj);
             }
           }


### PR DESCRIPTION
Summary: CallGenerator::for_method_handle_inline() casts MH linker (MH::linkTo*) arguments before attempting inlining. If any argument has a speculative type attached, it is lost and can't be used later. The patch preserves speculative part while sharpening the type (if needed) based on static information from the MemberName instance.

Test Plan: ci jtreg

Reviewed-by: Kuaiwei, Wangzhuo

Issue: https://github.com/dragonwell-project/dragonwell11/issues/634