### PR TITLE
[Backport] 8269285: Crash/miscompile in CallGenerator::for_method_handle_inline after JDK-8191998

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -917,7 +917,7 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
           const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
           const Type*       sig_type = TypeOopPtr::make_from_klass(signature->accessing_klass());
           if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-            const Type* recv_type = arg_type->join_speculative(sig_type); // keep speculative part
+            const Type* recv_type = arg_type->filter_speculative(sig_type); // keep speculative part
             Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, recv_type));
             kit.set_argument(0, cast_obj);
           }
@@ -930,7 +930,7 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
             const TypeOopPtr* arg_type = arg->bottom_type()->isa_oopptr();
             const Type*       sig_type = TypeOopPtr::make_from_klass(t->as_klass());
             if (arg_type != NULL && !arg_type->higher_equal(sig_type)) {
-              const Type* narrowed_arg_type = arg_type->join_speculative(sig_type); // keep speculative part
+              const Type* narrowed_arg_type = arg_type->filter_speculative(sig_type); // keep speculative part
               Node* cast_obj = gvn.transform(new CheckCastPPNode(kit.control(), arg, narrowed_arg_type));
               kit.set_argument(receiver_skip + j, cast_obj);
             }

--- a/test/hotspot/jtreg/compiler/types/TestMethodHandleSpeculation.java
+++ b/test/hotspot/jtreg/compiler/types/TestMethodHandleSpeculation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8269285
+ * @summary Crash/miscompile in CallGenerator::for_method_handle_inline after JDK-8191998
+ * @requires vm.compMode == "Xmixed" & vm.flavor == "server"
+ *
+ * @run main/othervm
+ *        -Xcomp -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,compiler.types.TestMethodHandleSpeculation::main
+ *        compiler.types.TestMethodHandleSpeculation
+ */
+
+package compiler.types;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+public class TestMethodHandleSpeculation {
+
+    public static void main(String... args) {
+        byte[] serObj = {1};
+        MyClass<byte[]> obj = new MyClass<>();
+        for (int i = 0; i < 100_000; i++) {
+            boolean test = obj.test(serObj);
+            if (test) {
+                throw new IllegalStateException("Cannot be null");
+            }
+        }
+    }
+
+    static class MyClass<V extends Serializable> {
+        boolean test(V obj) {
+            Supplier<Boolean> supp = () -> (obj == null);
+            return supp.get();
+        }
+    }
+
+}


### PR DESCRIPTION
Summary: Fix crash introduced by JDK-8191998.

Test Plan: ci jtreg

Reviewed-by: Kuaiwei, Wangzhuo

Issue: https://github.com/dragonwell-project/dragonwell11/issues/636