### PR TITLE
[Backport] 8272873: C2: Inlining should not depend on absolute call site counts

### DIFF
--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -164,18 +164,17 @@ bool InlineTree::should_inline(ciMethod* callee_method, ciMethod* caller_method,
   int invoke_count     = method()->interpreter_invocation_count();
 
   assert(invoke_count != 0, "require invocation count greater than zero");
-  int freq = call_site_count / invoke_count;
+  double freq = (double)call_site_count / (double)invoke_count;
 
   // bump the max size if the call is frequent
   if ((freq >= InlineFrequencyRatio) ||
-      (call_site_count >= InlineFrequencyCount) ||
       is_unboxing_method(callee_method, C) ||
       is_init_with_ea(callee_method, caller_method, C)) {
 
     max_inline_size = C->freq_inline_size();
     if (size <= max_inline_size && TraceFrequencyInlining) {
       CompileTask::print_inline_indent(inline_level());
-      tty->print_cr("Inlined frequent method (freq=%d count=%d):", freq, call_site_count);
+      tty->print_cr("Inlined frequent method (freq=%lf):", freq);
       CompileTask::print_inline_indent(inline_level());
       callee_method->print();
       tty->cr();

--- a/src/hotspot/share/runtime/compilationPolicy.cpp
+++ b/src/hotspot/share/runtime/compilationPolicy.cpp
@@ -669,7 +669,7 @@ RFrame* StackWalkCompPolicy::findTopInlinableFrame(GrowableArray<RFrame*>* stack
 
     // Caller counts / call-site counts; i.e. is this call site
     // a hot call site for method next_m?
-    int freq = (invcnt) ? cnt/invcnt : cnt;
+    double freq = (invcnt) ? (double)cnt/(double)invcnt : (double)cnt;
 
     // Check size and frequency limits
     if ((msg = shouldInline(m, freq, cnt)) != NULL) {
@@ -716,7 +716,7 @@ RFrame* StackWalkCompPolicy::senderOf(RFrame* rf, GrowableArray<RFrame*>* stack)
 }
 
 
-const char* StackWalkCompPolicy::shouldInline(const methodHandle& m, float freq, int cnt) {
+const char* StackWalkCompPolicy::shouldInline(const methodHandle& m, double freq, int cnt) {
   // Allows targeted inlining
   // positive filter: should send be inlined?  returns NULL (--> yes)
   // or rejection msg
@@ -729,7 +729,7 @@ const char* StackWalkCompPolicy::shouldInline(const methodHandle& m, float freq,
   }
 
   // bump the max size if the call is frequent
-  if ((freq >= InlineFrequencyRatio) || (cnt >= InlineFrequencyCount)) {
+  if (freq >= InlineFrequencyRatio) {
     if (TraceFrequencyInlining) {
       tty->print("(Inlined frequent method)\n");
       m->print();

--- a/src/hotspot/share/runtime/compilationPolicy.hpp
+++ b/src/hotspot/share/runtime/compilationPolicy.hpp
@@ -142,7 +142,7 @@ class StackWalkCompPolicy : public NonTieredCompPolicy {
   // they are used for performance debugging only (print better messages)
   static const char* _msg;            // reason for not inlining
 
-  static const char* shouldInline   (const methodHandle& callee, float frequency, int cnt);
+  static const char* shouldInline   (const methodHandle& callee, double frequency, int cnt);
   // positive filter: should send be inlined?  returns NULL (--> yes) or rejection msg
   static const char* shouldNotInline(const methodHandle& callee);
   // negative filter: should send NOT be inlined?  returns NULL (--> inline) or rejection msg

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1789,9 +1789,9 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   experimental(intx, SpecTrapLimitExtraEntries,  3,                         \
           "Extra method data trap entries for speculation")                 \
                                                                             \
-  develop(intx, InlineFrequencyRatio,    20,                                \
+  develop(double, InlineFrequencyRatio, 0.25,                               \
           "Ratio of call site execution to caller method invocation")       \
-          range(0, max_jint)                                                \
+          range(0.0, DBL_MAX)                                               \
                                                                             \
   diagnostic_pd(intx, InlineFrequencyCount,                                 \
           "Count of call site execution necessary to trigger frequent "     \


### PR DESCRIPTION
Summary: C2 considers absolute call site counts in its inlining decisions, which seems very wrong considering the asynchronous nature of profiling and background compilation (See InlineTree::should_inline()). It causes substantial over-inlining, which in presence of a depth-first inlining can lead to an early cut off. It also is inherently unstable. C2 already uses call frequency as an additional factor and it's better to consider only that in the inlining heuristic. The author did extensive benchmarking it yielded almost no losses and single-digit wins (up to 5%) on some benchmarks. The author think it's safe to remove/deprecate InlineFrequencyCount and continue using InlineFrequencyRatio instead. The author found that converting the frequency computation to FP and setting InlineFrequencyRatio=0.25 (inline a method that is called a least 25% of the time) works best.

Test Plan: ci jtreg

Reviewed-by: Kuaiwei, Wangzhuo

Issue: https://github.com/dragonwell-project/dragonwell11/issues/635