### PR TITLE
[Backport] 8173196: [REDO] C2 does not optimize redundant memory operations with G1

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -469,7 +469,7 @@ void G1BarrierSetC2::post_barrier(GraphKit* kit,
 
         __ if_then(card_val, BoolTest::ne, young_card); {
           kit->sync_kit(ideal);
-          kit->insert_mem_bar(Op_MemBarVolatile, oop_store);
+          kit->insert_store_load_for_barrier();
           __ sync_kit(kit);
 
           Node* card_val_reload = __ load(__ ctrl(), card_adr, TypeInt::INT, T_BYTE, Compile::AliasIdxRaw);

--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
@@ -105,7 +105,7 @@ void CardTableBarrierSetC2::post_barrier(GraphKit* kit,
 
   if (UseCondCardMark) {
     if (ct->scanned_concurrently()) {
-      kit->insert_mem_bar(Op_MemBarVolatile, oop_store);
+      kit->insert_store_load_for_barrier();
       __ sync_kit(kit);
     }
     // The classic GC reference write barrier is typically implemented

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3258,6 +3258,18 @@ Node* GraphKit::insert_mem_bar_volatile(int opcode, int alias_idx, Node* precede
   return membar;
 }
 
+void GraphKit::insert_store_load_for_barrier() {
+  Node* mem = reset_memory();
+  MemBarNode* mb = MemBarNode::make(C, Op_MemBarVolatile, Compile::AliasIdxRaw);
+  mb->init_req(TypeFunc::Control, control());
+  mb->init_req(TypeFunc::Memory, mem);
+  Node* membar = _gvn.transform(mb);
+  set_control(_gvn.transform(new ProjNode(membar, TypeFunc::Control)));
+  Node* newmem = _gvn.transform(new ProjNode(membar, TypeFunc::Memory));
+  set_all_memory(mem);
+  set_memory(newmem, Compile::AliasIdxRaw);
+}
+
 #define __ ideal.
 
 //------------------------------shared_lock------------------------------------

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -815,6 +815,7 @@ class GraphKit : public Phase {
   int next_monitor();
   Node* insert_mem_bar(int opcode, Node* precedent = NULL);
   Node* insert_mem_bar_volatile(int opcode, int alias_idx, Node* precedent = NULL);
+  void insert_store_load_for_barrier();
   // Optional 'precedent' is appended as an extra edge, to force ordering.
   FastLockNode* shared_lock(Node* obj);
   void shared_unlock(Node* box, Node* obj, bool at_method_return = false);


### PR DESCRIPTION
Summary: JDK-8087341 was backed out due to JDK-8172850. We should re-implement the enhancement.

Test Plan: ci jtreg

Reviewed-by: kuaiwei, JoshuaZhuwj

Issue: https://github.com/dragonwell-project/dragonwell11/issues/646

CR: https://github.com/dragonwell-project/dragonwell11/pull/647