### PR TITLE
[Backport] 8276673: Optimize abs operations in C2 compiler

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1702,6 +1702,64 @@ bool BoolNode::is_counted_loop_exit_test() {
     }
   }
   return false;
+}
+
+//=============================================================================
+//------------------------------Value------------------------------------------
+const Type* AbsNode::Value(PhaseGVN* phase) const {
+  const Type* t1 = phase->type(in(1));
+  if (t1 == Type::TOP) return Type::TOP;
+
+  switch (t1->base()) {
+  case Type::Int: {
+    const TypeInt* ti = t1->is_int();
+    if (ti->is_con()) {
+      return TypeInt::make(uabs(ti->get_con()));
+    }
+    break;
+  }
+  case Type::Long: {
+    const TypeLong* tl = t1->is_long();
+    if (tl->is_con()) {
+      return TypeLong::make(uabs(tl->get_con()));
+    }
+    break;
+  }
+  case Type::FloatCon:
+    return TypeF::make(abs(t1->getf()));
+  case Type::DoubleCon:
+    return TypeD::make(abs(t1->getd()));
+  default:
+    break;
+  }
+
+  return bottom_type();
+}
+
+//------------------------------Identity----------------------------------------
+Node* AbsNode::Identity(PhaseGVN* phase) {
+  Node* in1 = in(1);
+  // No need to do abs for non-negative values
+  if (phase->type(in1)->higher_equal(TypeInt::POS) ||
+      phase->type(in1)->higher_equal(TypeLong::POS)) {
+    return in1;
+  }
+  // Convert "abs(abs(x))" into "abs(x)"
+  if (in1->Opcode() == Opcode()) {
+    return in1;
+  }
+  return this;
+}
+
+//------------------------------Ideal------------------------------------------
+Node* AbsNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  Node* in1 = in(1);
+  // Convert "abs(0-x)" into "abs(x)"
+  if (in1->is_Sub() && phase->type(in1->in(1))->is_zero_type()) {
+    set_req_X(1, in1->in(2), phase);
+    return this;
+  }
+  return NULL;
 }
 
 //=============================================================================

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -337,6 +337,9 @@ public:
 class AbsNode : public Node {
 public:
   AbsNode( Node *value ) : Node(0,value) {}
+  virtual Node* Identity(PhaseGVN* phase);
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
+  virtual const Type* Value(PhaseGVN* phase) const;
 };
 
 //------------------------------AbsINode---------------------------------------

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -558,7 +558,7 @@ public:
 
   // Check for single integer
   int is_con() const { return _lo==_hi; }
-  bool is_con(int i) const { return is_con() && _lo == i; }
+  bool is_con(jint i) const { return is_con() && _lo == i; }
   jint get_con() const { assert( is_con(), "" );  return _lo; }
 
   virtual bool        is_finite() const;  // Has a finite value
@@ -622,7 +622,7 @@ public:
 
   // Check for single integer
   int is_con() const { return _lo==_hi; }
-  bool is_con(int i) const { return is_con() && _lo == i; }
+  bool is_con(jlong i) const { return is_con() && _lo == i; }
   jlong get_con() const { assert( is_con(), "" ); return _lo; }
 
   // Check for positive 32-bit value.


### PR DESCRIPTION
Summary: In current SLP, the vectorization of Math.abs() with char type is intentionally disabled after JDK-8261022 because it generates incorrect result before.

But in Java semantics, as the char type is always non-negative, we could actually translate Math.abs(char) to a no-op by adding a no-op IR and matching rules somehow.

We can consider re-enable Math.abs() vectorization with char type.

Test Plan: ci jtreg

Reviewed-by: kuaiwei, JoshuaZhuwj

Issue: https://github.com/dragonwell-project/dragonwell11/issues/648

CR: https://github.com/dragonwell-project/dragonwell11/pull/649