### PR TITLE
HeapDump: Optimize segmented heap file merging phase

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -82,6 +82,7 @@
 # include <sys/mman.h>
 # include <sys/stat.h>
 # include <sys/select.h>
+# include <sys/sendfile.h>
 # include <pthread.h>
 # include <signal.h>
 # include <errno.h>
@@ -5152,6 +5153,13 @@ jlong os::Linux::fast_thread_cpu_time(clockid_t clockid) {
   assert(rc == 0, "clock_gettime is expected to return 0 code");
 
   return (tp.tv_sec * NANOSECS_PER_SEC) + tp.tv_nsec;
+}
+
+// copy data between two file descriptor within the kernel
+// the number of bytes written to out_fd is returned if transfer was successful
+// otherwise, returns -1 that implies an error
+jlong os::Linux::sendfile(int out_fd, int in_fd, jlong* offset, jlong count) {
+  return sendfile64(out_fd, in_fd, (off64_t*)offset, (size_t)count);
 }
 
 void os::Linux::initialize_os_info() {

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -224,6 +224,8 @@ class Linux {
 
   static jlong fast_thread_cpu_time(clockid_t clockid);
 
+  static jlong sendfile(int out_fd, int in_fd, jlong* offset, jlong count);
+
   static void initialize_os_info();
   static bool os_version_is_known();
   static uint32_t os_version();

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -55,6 +55,9 @@
 #include "services/threadService.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
+#ifdef LINUX
+#include "os_linux.hpp"
+#endif
 
 /*
  * HPROF binary format - description copied from:
@@ -442,6 +445,7 @@ class DumpWriter : public ResourceObj {
   AbstractCompressor* compressor()             { return _compressor; }
   void set_compressor(AbstractCompressor* p)   { _compressor = p; }
   bool is_overwrite() const                    { return _writer->is_overwrite(); }
+  int get_fd() const                           { return _writer->get_fd(); }
 
   // writer functions
   void write_raw(void* s, size_t len);
@@ -1609,8 +1613,10 @@ private:
   int _dump_seq;
 
 private:
+  LINUX_ONLY(void merge_file_fast(char* path);)
   void merge_file(char* path);
   void merge_done();
+  void set_error(const char* msg);
 
 public:
   DumpMerger(const char* path, DumpWriter* writer, int dump_seq) :
@@ -1621,6 +1627,52 @@ public:
 
   void do_merge();
 };
+
+void DumpMerger::set_error(const char* msg) {
+  assert(msg != NULL, "sanity check");
+  log_error(heapdump)("%s (file: %s)", msg, _path);
+  _writer->set_error(msg);
+  _has_error = true;
+}
+
+#ifdef LINUX
+void DumpMerger::merge_file_fast(char* path) {
+  assert(!SafepointSynchronize::is_at_safepoint(), "merging happens outside safepoint");
+  TraceTime timer("Merge segmented heap file directly", TRACETIME_LOG(Info, heapdump));
+
+  int segment_fd = os::open(path, O_RDONLY, 0);
+  if (segment_fd == -1) {
+    set_error("Can not open segmented heap file during merging");
+    return;
+  }
+
+  struct stat st;
+  if (os::stat(path, &st) != 0) {
+    ::close(segment_fd);
+    set_error("Can not get segmented heap file size during merging");
+    return;
+  }
+
+  // A successful call to sendfile may write fewer bytes than requested; the
+  // caller should be prepared to retry the call if there were unsent bytes.
+  jlong offset = 0;
+  while (offset < st.st_size) {
+    int ret = os::Linux::sendfile(_writer->get_fd(), segment_fd, &offset, st.st_size);
+    if (ret == -1) {
+      ::close(segment_fd);
+      set_error("Failed to merge segmented heap file");
+      return;
+    }
+  }
+
+  // As sendfile variant does not call the write method of the global writer,
+  // bytes_written is also incorrect for this variant, we need to explicitly
+  // accumulate bytes_written for the global writer in this case
+  julong accum = _writer->bytes_written() + st.st_size;
+  _writer->set_bytes_written(accum);
+  ::close(segment_fd);
+}
+#endif
 
 void DumpMerger::merge_done() {
   // Writes the HPROF_HEAP_DUMP_END record.
@@ -1637,9 +1689,7 @@ void DumpMerger::merge_file(char* path) {
 
   fileStream segment_fs(path, "rb");
   if (!segment_fs.is_open()) {
-    log_error(heapdump)("Can not open segmented heap file %s during merging", path);
-    _writer->set_error("Can not open segmented heap file during merging");
-    _has_error = true;
+    set_error("Can not open segmented heap file during merging");
     return;
   }
 
@@ -1653,10 +1703,7 @@ void DumpMerger::merge_file(char* path) {
 
   _writer->flush();
   if (segment_fs.fileSize() != total) {
-    log_error(heapdump)("Merged heap dump %s is incomplete, expect %ld but read " JLONG_FORMAT " bytes",
-                        path, segment_fs.fileSize(), total);
-    _writer->set_error("Merged heap dump is incomplete");
-    _has_error = true;
+    set_error("Merged heap dump is incomplete");
   }
 }
 
@@ -1669,14 +1716,24 @@ void DumpMerger::do_merge() {
   AbstractCompressor* saved_compressor = _writer->compressor();
   _writer->set_compressor(NULL);
 
-  // merge segmented heap file and remove it anyway
+  // Merge the content of the remaining files into base file. Regardless of whether
+  // the merge process is successful or not, these segmented files will be deleted.
   char path[JVM_MAXPATHLEN];
   for (int i = 0; i < _dump_seq; i++) {
     memset(path, 0, JVM_MAXPATHLEN);
     os::snprintf(path, JVM_MAXPATHLEN, "%s.p%d", _path, i);
     if (!_has_error) {
+#ifdef LINUX
+      // Merge segmented heap files via sendfile, it's more efficient than the
+      // read+write combination, which would require transferring data to and from
+      // user space.
+      merge_file_fast(path);
+#else
+      // Otherwise, fallback to using read+write combination for file merging
       merge_file(path);
+#endif
     }
+    // Delete selected segmented heap file nevertheless
     remove(path);
   }
 
@@ -2113,6 +2170,7 @@ DumpWriter* VM_HeapDumper::create_local_writer() {
 
   // generate segmented heap file path
   const char* base_path = writer()->get_file_path();
+  // share global compressor, local DumpWriter is not responsible for its life cycle
   AbstractCompressor* compressor = writer()->compressor();
   int seq = Atomic::add(1, &_dump_seq) - 1;
   os::snprintf(path, JVM_MAXPATHLEN, "%s.p%d", base_path, seq);

--- a/src/hotspot/share/services/heapDumperCompression.hpp
+++ b/src/hotspot/share/services/heapDumperCompression.hpp
@@ -78,6 +78,8 @@ public:
   const char* get_file_path() { return _path; }
 
   bool is_overwrite() const { return _overwrite; }
+
+  int get_fd() const {return _fd; }
 };
 
 


### PR DESCRIPTION
This patch reduces ~16%(24s->20s) pahse 2 merge time during dumping 32g heap with 96threads.

You might argue why this is Linux-only optimization, because sendfile requires at least one socket fd in other platforms([aix sendfile](https://www.ibm.com/docs/en/aix/7.1?topic=s-send-file-subroutine) [maxos sendfile](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/sendfile.2.html) [win32 TransmitFile](https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nf-mswsock-transmitfile)), while [only Linux](https://man7.org/linux/man-pages/man2/sendfile.2.html) supports both two file descriptors.
