### PR TITLE
[Misc] Update riscv build environment

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -95,7 +95,7 @@ jobs:
           ${TEST_JDK_HOME}/bin/java -version
 
   build_release_riscv_jdk:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted , X64]
     container:
       image: docker.io/alibabadragonwelljdk/centos7_gcc7_build_image:latest
     steps:


### PR DESCRIPTION
Summary: Since the environment provided by github always runs out of space, the environment needs to be updated.

Test Plan: CI

Reviewed-by: sendaoYan, yuleil

Issue: https://github.com/dragonwell-project/dragonwell11/issues/674