### PR TITLE
[Backport] 8291555: Implement alternative fast-locking scheme

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3657,36 +3657,40 @@ encode %{
       __ tbnz(disp_hdr, exact_log2(markOopDesc::monitor_value), object_has_monitor);
     }
 
-    // Set tmp to be (markOop of object | UNLOCK_VALUE).
-    __ orr(tmp, disp_hdr, markOopDesc::unlocked_value);
+    if (UseAltFastLocking) {
+      __ fast_lock(oop, disp_hdr, tmp, rscratch1, cont);
+    } else {
+      // Set tmp to be (markOop of object | UNLOCK_VALUE).
+      __ orr(tmp, disp_hdr, markOopDesc::unlocked_value);
 
-    // Initialize the box. (Must happen before we update the object mark!)
-    __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      // Initialize the box. (Must happen before we update the object mark!)
+      __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
-    // Compare object markOop with an unlocked value (tmp) and if
-    // equal exchange the stack address of our box with object markOop.
-    // On failure disp_hdr contains the possibly locked markOop.
-    __ cmpxchg(oop, tmp, box, Assembler::xword, /*acquire*/ true,
-               /*release*/ true, /*weak*/ false, disp_hdr);
-    __ br(Assembler::EQ, cont);
+      // Compare object markOop with an unlocked value (tmp) and if
+      // equal exchange the stack address of our box with object markOop.
+      // On failure disp_hdr contains the possibly locked markOop.
+      __ cmpxchg(oop, tmp, box, Assembler::xword, /*acquire*/ true,
+                 /*release*/ true, /*weak*/ false, disp_hdr);
+      __ br(Assembler::EQ, cont);
 
-    assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
+      assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
 
-    // If the compare-and-exchange succeeded, then we found an unlocked
-    // object, will have now locked it will continue at label cont
+      // If the compare-and-exchange succeeded, then we found an unlocked
+      // object, will have now locked it will continue at label cont
 
-    __ bind(cas_failed);
-    // We did not see an unlocked object so try the fast recursive case.
+      __ bind(cas_failed);
+      // We did not see an unlocked object so try the fast recursive case.
 
-    // Check if the owner is self by comparing the value in the
-    // markOop of object (disp_hdr) with the stack pointer.
-    __ mov(rscratch1, sp);
-    __ sub(disp_hdr, disp_hdr, rscratch1);
-    __ mov(tmp, (address) (~(os::vm_page_size()-1) | (uintptr_t)markOopDesc::lock_mask_in_place));
-    // If condition is true we are cont and hence we can store 0 as the
-    // displaced header in the box, which indicates that it is a recursive lock.
-    __ ands(tmp/*==0?*/, disp_hdr, tmp);   // Sets flags for result
-    __ str(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      // Check if the owner is self by comparing the value in the
+      // markOop of object (disp_hdr) with the stack pointer.
+      __ mov(rscratch1, sp);
+      __ sub(disp_hdr, disp_hdr, rscratch1);
+      __ mov(tmp, (address) (~(os::vm_page_size()-1) | (uintptr_t)markOopDesc::lock_mask_in_place));
+      // If condition is true we are cont and hence we can store 0 as the
+      // displaced header in the box, which indicates that it is a recursive lock.
+      __ ands(tmp/*==0?*/, disp_hdr, tmp);   // Sets flags for result
+      __ str(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+    }
 
     if ((EmitSync & 0x02) == 0) {
       __ b(cont);
@@ -3708,12 +3712,14 @@ encode %{
         __ ldr (rthread, Address(rthread, WispThread::thread_offset()));
       }
 
-      // Store a non-null value into the box to avoid looking like a re-entrant
-      // lock. The fast-path monitor unlock code checks for
-      // markOopDesc::monitor_value so use markOopDesc::unused_mark which has the
-      // relevant bit set, and also matches ObjectSynchronizer::slow_enter.
-      __ mov(tmp, (address)markOopDesc::unused_mark());
-      __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      if (!UseAltFastLocking) {
+        // Store a non-null value into the box to avoid looking like a re-entrant
+        // lock. The fast-path monitor unlock code checks for
+        // markOopDesc::monitor_value so use markOopDesc::unused_mark which has the
+        // relevant bit set, and also matches ObjectSynchronizer::slow_enter.
+        __ mov(tmp, (address)markOopDesc::unused_mark());
+        __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      }
     }
 
     __ bind(cont);
@@ -3742,26 +3748,33 @@ encode %{
       __ biased_locking_exit(oop, tmp, cont);
     }
 
-    // Find the lock address and load the displaced header from the stack.
-    __ ldr(disp_hdr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+    if (!UseAltFastLocking) {
+      // Find the lock address and load the displaced header from the stack.
+      __ ldr(disp_hdr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
-    // If the displaced header is 0, we have a recursive unlock.
-    __ cmp(disp_hdr, zr);
-    __ br(Assembler::EQ, cont);
+      // If the displaced header is 0, we have a recursive unlock.
+      __ cmp(disp_hdr, zr);
+      __ br(Assembler::EQ, cont);
+    }
 
     // Handle existing monitor.
     if ((EmitSync & 0x02) == 0) {
       __ ldr(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
-      __ tbnz(disp_hdr, exact_log2(markOopDesc::monitor_value), object_has_monitor);
+      __ tbnz(tmp, exact_log2(markOopDesc::monitor_value), object_has_monitor);
     }
 
-    // Check if it is still a light weight lock, this is is true if we
-    // see the stack address of the basicLock in the markOop of the
-    // object.
+    if (UseAltFastLocking) {
+      __ fast_unlock(oop, tmp, box, disp_hdr, cont);
+      __ b(cont);
+    } else {
+      // Check if it is still a light weight lock, this is is true if we
+      // see the stack address of the basicLock in the markOop of the
+      // object.
 
-    __ cmpxchg(oop, box, disp_hdr, Assembler::xword, /*acquire*/ false,
-               /*release*/ true, /*weak*/ false, tmp);
-    __ b(cont);
+      __ cmpxchg(oop, box, disp_hdr, Assembler::xword, /*acquire*/ false,
+                 /*release*/ true, /*weak*/ false, tmp);
+      __ b(cont);
+	}
 
     assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
 
@@ -3769,6 +3782,20 @@ encode %{
     if ((EmitSync & 0x02) == 0) {
       __ bind(object_has_monitor);
       __ add(tmp, tmp, -markOopDesc::monitor_value); // monitor
+
+      if (UseAltFastLocking) {
+        // If the owner is anonymous, we need to fix it -- in an outline stub.
+        Register tmp2 = disp_hdr;
+        __ ldr(tmp2, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
+        // We cannot use tbnz here, the target might be too far away and cannot
+        // be encoded.
+        __ tst(tmp2, (uint64_t)ObjectMonitor::ANONYMOUS_OWNER);
+        C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmp, tmp2);
+        Compile::current()->add_stub(stub);
+        __ br(Assembler::NE, stub->entry());
+        __ bind(stub->continuation());
+      }
+
       __ ldr(rscratch1, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
       __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
       if (UseWispMonitor) {

--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "opto/c2_MacroAssembler.hpp"
+#include "opto/c2_CodeStubs.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/sharedRuntime.hpp"
+#include "runtime/stubRoutines.hpp"
+
+#define __ masm.
+
+int C2HandleAnonOMOwnerStub::max_size() const {
+  // Max size of stub has been determined by testing with 0, in which case
+  // C2CodeStubList::emit() will throw an assertion and report the actual size that
+  // is needed.
+  return 24;
+}
+
+void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
+  __ bind(entry());
+  Register mon = monitor();
+  Register t = tmp();
+  assert(t != noreg, "need tmp register");
+
+  // Fix owner to be the current thread.
+  __ str(rthread, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
+
+  // Pop owner object from lock-stack.
+  __ ldrw(t, Address(rthread, JavaThread::lock_stack_top_offset()));
+  __ subw(t, t, oopSize);
+#ifdef ASSERT
+  __ str(zr, Address(rthread, t));
+#endif
+  __ strw(t, Address(rthread, JavaThread::lock_stack_top_offset()));
+
+  __ b(continuation());
+}
+
+#undef __

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5981,3 +5981,97 @@ void MacroAssembler::get_thread(Register dst) {
 
   pop(saved_regs, sp);
 }
+
+// Implements fast-locking.
+// Branches to slow upon failure to lock the object, with ZF cleared.
+// Falls through upon success with ZF set.
+//
+//  - obj: the object to be locked
+//  - hdr: the header, already loaded from obj, will be destroyed
+//  - t1, t2: temporary registers, will be destroyed
+void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow) {
+  assert(UseAltFastLocking, "sanity");
+  assert_different_registers(obj, hdr, t1, t2);
+
+  // Check if we would have space on lock-stack for the object.
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+  cmpw(t1, (unsigned)LockStack::end_offset() - 1);
+  br(Assembler::GT, slow);
+
+  // Load (object->mark() | 1) into hdr
+  orr(hdr, hdr, markOopDesc::unlocked_value);
+  // Clear lock-bits, into t2
+  eor(t2, hdr, markOopDesc::unlocked_value);
+  // Try to swing header from unlocked to locked
+  cmpxchg(/*addr*/ obj, /*expected*/ hdr, /*new*/ t2, Assembler::xword,
+          /*acquire*/ true, /*release*/ true, /*weak*/ false, t1);
+  br(Assembler::NE, slow);
+
+  // After successful lock, push object on lock-stack
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+  str(obj, Address(rthread, t1));
+  addw(t1, t1, oopSize);
+  strw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+}
+
+// Implements fast-unlocking.
+// Branches to slow upon failure, with ZF cleared.
+// Falls through upon success, with ZF set.
+//
+// - obj: the object to be unlocked
+// - hdr: the (pre-loaded) header of the object
+// - t1, t2: temporary registers
+void MacroAssembler::fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow) {
+  assert(UseAltFastLocking, "sanity");
+  assert_different_registers(obj, hdr, t1, t2);
+
+#ifdef ASSERT
+  {
+    // The following checks rely on the fact that LockStack is only ever modified by
+    // its owning thread, even if the lock got inflated concurrently; removal of LockStack
+    // entries after inflation will happen delayed in that case.
+
+    // Check for lock-stack underflow.
+    Label stack_ok;
+    ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+    cmpw(t1, (unsigned)LockStack::start_offset());
+    br(Assembler::GT, stack_ok);
+    STOP("Lock-stack underflow");
+    bind(stack_ok);
+  }
+  {
+    // Check if the top of the lock-stack matches the unlocked object.
+    Label tos_ok;
+    subw(t1, t1, oopSize);
+    ldr(t1, Address(rthread, t1));
+    cmpoop(t1, obj);
+    br(Assembler::EQ, tos_ok);
+    STOP("Top of lock-stack does not match the unlocked object");
+    bind(tos_ok);
+  }
+  {
+    // Check that hdr is fast-locked.
+    Label hdr_ok;
+    tst(hdr, markOopDesc::lock_mask_in_place);
+    br(Assembler::EQ, hdr_ok);
+    STOP("Header is not fast-locked");
+    bind(hdr_ok);
+  }
+#endif
+
+  // Load the new header (unlocked) into t1
+  orr(t1, hdr, markOopDesc::unlocked_value);
+
+  // Try to swing header from locked to unlocked
+  cmpxchg(obj, hdr, t1, Assembler::xword,
+          /*acquire*/ true, /*release*/ true, /*weak*/ false, t2);
+  br(Assembler::NE, slow);
+
+  // After successful unlock, pop object from lock-stack
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+  subw(t1, t1, oopSize);
+#ifdef ASSERT
+  str(zr, Address(rthread, t1));
+#endif
+  strw(t1, Address(rthread, JavaThread::lock_stack_top_offset()));
+}

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1040,6 +1040,9 @@ public:
                enum operand_size size,
                bool acquire, bool release, bool weak,
                Register result);
+
+  void fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow);
+  void fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow);
 private:
   void compare_eq(Register rn, Register rm, enum operand_size size);
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3496,7 +3496,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
     __ jmp(*op->stub()->entry());
   } else if (op->code() == lir_lock) {
     Register scratch = noreg;
-    if (UseBiasedLocking) {
+    if (UseBiasedLocking || UseAltFastLocking) {
       scratch = op->scratch_opr()->as_register();
     }
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -312,6 +312,8 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
   LIR_Opr scratch = LIR_OprFact::illegalOpr;
   if (UseBiasedLocking) {
     scratch = new_register(T_INT);
+  } else if (UseAltFastLocking) {
+    scratch = new_register(T_ADDRESS);
   }
 
   CodeEmitInfo* info_for_exception = NULL;

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -48,6 +48,10 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   Label done;
   int null_check_offset = -1;
 
+  if (UseAltFastLocking) {
+    assert_different_registers(hdr, obj, disp_hdr, scratch);
+  }
+
   verify_oop(obj);
 
   // save object being locked into the BasicObjectLock
@@ -62,45 +66,58 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
     null_check_offset = offset();
   }
 
-  // Load object header
-  movptr(hdr, Address(obj, hdr_offset));
-  // and mark it as unlocked
-  orptr(hdr, markOopDesc::unlocked_value);
-  // save unlocked object header into the displaced header location on the stack
-  movptr(Address(disp_hdr, 0), hdr);
-  // test if object header is still the same (i.e. unlocked), and if so, store the
-  // displaced header address in the object header - if it is not the same, get the
-  // object header instead
-  if (os::is_MP()) MacroAssembler::lock(); // must be immediately before cmpxchg!
-  cmpxchgptr(disp_hdr, Address(obj, hdr_offset));
-  // if the object header was the same, we're done
-  if (PrintBiasedLockingStatistics) {
-    cond_inc32(Assembler::equal,
-               ExternalAddress((address)BiasedLocking::fast_path_entry_count_addr()));
+  if (UseAltFastLocking) {
+    assert(!UseBiasedLocking, "sanity");
+#ifdef _LP64
+    const Register thread = r15_thread;
+#else
+    const Register thread = disp_hdr;
+    get_thread(thread);
+#endif
+    // Load object header
+    movptr(hdr, Address(obj, hdr_offset));
+    fast_lock_impl(obj, hdr, thread, scratch, slow_case);
+  } else {
+    // Load object header
+    movptr(hdr, Address(obj, hdr_offset));
+    // and mark it as unlocked
+    orptr(hdr, markOopDesc::unlocked_value);
+    // save unlocked object header into the displaced header location on the stack
+    movptr(Address(disp_hdr, 0), hdr);
+    // test if object header is still the same (i.e. unlocked), and if so, store the
+    // displaced header address in the object header - if it is not the same, get the
+    // object header instead
+    if (os::is_MP()) MacroAssembler::lock(); // must be immediately before cmpxchg!
+    cmpxchgptr(disp_hdr, Address(obj, hdr_offset));
+    // if the object header was the same, we're done
+    if (PrintBiasedLockingStatistics) {
+      cond_inc32(Assembler::equal,
+                 ExternalAddress((address)BiasedLocking::fast_path_entry_count_addr()));
+    }
+    jcc(Assembler::equal, done);
+    // if the object header was not the same, it is now in the hdr register
+    // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
+    //
+    // 1) (hdr & aligned_mask) == 0
+    // 2) rsp <= hdr
+    // 3) hdr <= rsp + page_size
+    //
+    // these 3 tests can be done by evaluating the following expression:
+    //
+    // (hdr - rsp) & (aligned_mask - page_size)
+    //
+    // assuming both the stack pointer and page_size have their least
+    // significant 2 bits cleared and page_size is a power of 2
+    subptr(hdr, rsp);
+    andptr(hdr, aligned_mask - os::vm_page_size());
+    // for recursive locking, the result is zero => save it in the displaced header
+    // location (NULL in the displaced hdr location indicates recursive locking)
+    movptr(Address(disp_hdr, 0), hdr);
+    // otherwise we don't care about the result and handle locking via runtime call
+    jcc(Assembler::notZero, slow_case);
+    // done
+    bind(done);
   }
-  jcc(Assembler::equal, done);
-  // if the object header was not the same, it is now in the hdr register
-  // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
-  //
-  // 1) (hdr & aligned_mask) == 0
-  // 2) rsp <= hdr
-  // 3) hdr <= rsp + page_size
-  //
-  // these 3 tests can be done by evaluating the following expression:
-  //
-  // (hdr - rsp) & (aligned_mask - page_size)
-  //
-  // assuming both the stack pointer and page_size have their least
-  // significant 2 bits cleared and page_size is a power of 2
-  subptr(hdr, rsp);
-  andptr(hdr, aligned_mask - os::vm_page_size());
-  // for recursive locking, the result is zero => save it in the displaced header
-  // location (NULL in the displaced hdr location indicates recursive locking)
-  movptr(Address(disp_hdr, 0), hdr);
-  // otherwise we don't care about the result and handle locking via runtime call
-  jcc(Assembler::notZero, slow_case);
-  // done
-  bind(done);
   return null_check_offset;
 }
 
@@ -112,33 +129,43 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
   assert(hdr != obj && hdr != disp_hdr && obj != disp_hdr, "registers must be different");
   Label done;
 
-  if (UseBiasedLocking) {
-    // load object
-    movptr(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
-    biased_locking_exit(obj, hdr, done);
-  }
 
-  // load displaced header
-  movptr(hdr, Address(disp_hdr, 0));
-  // if the loaded hdr is NULL we had recursive locking
-  testptr(hdr, hdr);
-  // if we had recursive locking, we are done
-  jcc(Assembler::zero, done);
-  if (!UseBiasedLocking) {
+  if (UseAltFastLocking) {
     // load object
     movptr(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
+    verify_oop(obj);
+    movptr(disp_hdr, Address(obj, hdr_offset));
+    andptr(disp_hdr, ~(int32_t)markOopDesc::lock_mask_in_place);
+    fast_unlock_impl(obj, disp_hdr, hdr, slow_case);
+  } else {
+    if (UseBiasedLocking) {
+      // load object
+      movptr(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
+      biased_locking_exit(obj, hdr, done);
+    }
+
+    // load displaced header
+    movptr(hdr, Address(disp_hdr, 0));
+    // if the loaded hdr is NULL we had recursive locking
+    testptr(hdr, hdr);
+    // if we had recursive locking, we are done
+    jcc(Assembler::zero, done);
+    if (!UseBiasedLocking) {
+      // load object
+      movptr(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
+    }
+    verify_oop(obj);
+    // test if object header is pointing to the displaced header, and if so, restore
+    // the displaced header in the object - if the object header is not pointing to
+    // the displaced header, get the object header instead
+    if (os::is_MP()) MacroAssembler::lock(); // must be immediately before cmpxchg!
+    cmpxchgptr(hdr, Address(obj, hdr_offset));
+    // if the object header was not pointing to the displaced header,
+    // we do unlocking via runtime call
+    jcc(Assembler::notEqual, slow_case);
+    // done
+    bind(done);
   }
-  verify_oop(obj);
-  // test if object header is pointing to the displaced header, and if so, restore
-  // the displaced header in the object - if the object header is not pointing to
-  // the displaced header, get the object header instead
-  if (os::is_MP()) MacroAssembler::lock(); // must be immediately before cmpxchg!
-  cmpxchgptr(hdr, Address(obj, hdr_offset));
-  // if the object header was not pointing to the displaced header,
-  // we do unlocking via runtime call
-  jcc(Assembler::notEqual, slow_case);
-  // done
-  bind(done);
 }
 
 

--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "opto/c2_MacroAssembler.hpp"
+#include "opto/c2_CodeStubs.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/sharedRuntime.hpp"
+#include "runtime/stubRoutines.hpp"
+
+#define __ masm.
+
+#ifdef _LP64
+int C2HandleAnonOMOwnerStub::max_size() const {
+  // Max size of stub has been determined by testing with 0, in which case
+  // C2CodeStubList::emit() will throw an assertion and report the actual size that
+  // is needed.
+  return DEBUG_ONLY(36) NOT_DEBUG(21);
+}
+
+void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
+  __ bind(entry());
+  Register mon = monitor();
+  Register t = tmp();
+  __ movptr(Address(mon, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), r15_thread);
+  __ subl(Address(r15_thread, JavaThread::lock_stack_top_offset()), oopSize);
+#ifdef ASSERT
+  __ movl(t, Address(r15_thread, JavaThread::lock_stack_top_offset()));
+  __ movptr(Address(r15_thread, t), 0);
+#endif
+  __ jmp(continuation());
+}
+#endif
+
+#undef __

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1193,55 +1193,74 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
       biased_locking_enter(lock_reg, obj_reg, swap_reg, tmp_reg, rklass_decode_tmp, false, done, &slow_case);
     }
 
-    // Load immediate 1 into swap_reg %rax
-    movl(swap_reg, (int32_t)1);
+    if (UseAltFastLocking) {
+#ifdef _LP64
+      const Register thread = r15_thread;
+#else
+      const Register thread = lock_reg;
+      get_thread(thread);
+#endif
+      // Load object header, prepare for CAS from unlocked to locked.
+      movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      fast_lock_impl(obj_reg, swap_reg, thread, tmp_reg, slow_case);
+      jmp(done);
+    } else {
+      // Load immediate 1 into swap_reg %rax
+      movl(swap_reg, (int32_t)1);
 
-    // Load (object->mark() | 1) into swap_reg %rax
-    orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      // Load (object->mark() | 1) into swap_reg %rax
+      orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
 
-    // Save (object->mark() | 1) into BasicLock's displaced header
-    movptr(Address(lock_reg, mark_offset), swap_reg);
+      // Save (object->mark() | 1) into BasicLock's displaced header
+      movptr(Address(lock_reg, mark_offset), swap_reg);
 
-    assert(lock_offset == 0,
-           "displaced header must be first word in BasicObjectLock");
+      assert(lock_offset == 0,
+             "displaced header must be first word in BasicObjectLock");
 
-    if (os::is_MP()) lock();
-    cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-    if (PrintBiasedLockingStatistics) {
-      cond_inc32(Assembler::zero,
-                 ExternalAddress((address) BiasedLocking::fast_path_entry_count_addr()));
+      if (os::is_MP()) lock();
+      cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      if (PrintBiasedLockingStatistics) {
+        cond_inc32(Assembler::zero,
+                   ExternalAddress((address) BiasedLocking::fast_path_entry_count_addr()));
+      }
+      jcc(Assembler::zero, done);
+
+      const int zero_bits = LP64_ONLY(7) NOT_LP64(3);
+
+      // Test if the oopMark is an obvious stack pointer, i.e.,
+      //  1) (mark & zero_bits) == 0, and
+      //  2) rsp <= mark < mark + os::pagesize()
+      //
+      // These 3 tests can be done by evaluating the following
+      // expression: ((mark - rsp) & (zero_bits - os::vm_page_size())),
+      // assuming both stack pointer and pagesize have their
+      // least significant bits clear.
+      // NOTE: the oopMark is in swap_reg %rax as the result of cmpxchg
+      subptr(swap_reg, rsp);
+      andptr(swap_reg, zero_bits - os::vm_page_size());
+
+      // Save the test result, for recursive case, the result is zero
+      movptr(Address(lock_reg, mark_offset), swap_reg);
+
+      if (PrintBiasedLockingStatistics) {
+        cond_inc32(Assembler::zero,
+                   ExternalAddress((address) BiasedLocking::fast_path_entry_count_addr()));
+      }
+      jcc(Assembler::zero, done);
     }
-    jcc(Assembler::zero, done);
-
-    const int zero_bits = LP64_ONLY(7) NOT_LP64(3);
-
-    // Test if the oopMark is an obvious stack pointer, i.e.,
-    //  1) (mark & zero_bits) == 0, and
-    //  2) rsp <= mark < mark + os::pagesize()
-    //
-    // These 3 tests can be done by evaluating the following
-    // expression: ((mark - rsp) & (zero_bits - os::vm_page_size())),
-    // assuming both stack pointer and pagesize have their
-    // least significant bits clear.
-    // NOTE: the oopMark is in swap_reg %rax as the result of cmpxchg
-    subptr(swap_reg, rsp);
-    andptr(swap_reg, zero_bits - os::vm_page_size());
-
-    // Save the test result, for recursive case, the result is zero
-    movptr(Address(lock_reg, mark_offset), swap_reg);
-
-    if (PrintBiasedLockingStatistics) {
-      cond_inc32(Assembler::zero,
-                 ExternalAddress((address) BiasedLocking::fast_path_entry_count_addr()));
-    }
-    jcc(Assembler::zero, done);
 
     bind(slow_case);
 
     // Call the runtime routine for slow case
-    call_VM(noreg,
-            CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter),
-            lock_reg);
+    if (UseAltFastLocking) {
+      call_VM(noreg,
+              CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter_obj),
+              obj_reg);
+    } else {
+      call_VM(noreg,
+              CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter),
+              lock_reg);
+    }
 
     bind(done);
   }
@@ -1269,7 +1288,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
             CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit),
             lock_reg);
   } else {
-    Label done;
+    Label done, slow_case;
 
     const Register swap_reg   = rax;  // Must use rax for cmpxchg instruction
     const Register header_reg = LP64_ONLY(c_rarg2) NOT_LP64(rbx);  // Will contain the old oopMark
@@ -1277,9 +1296,11 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
 
     save_bcp(); // Save in case of exception
 
-    // Convert from BasicObjectLock structure to object and BasicLock
-    // structure Store the BasicLock address into %rax
-    lea(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset_in_bytes()));
+    if (!UseAltFastLocking) {
+      // Convert from BasicObjectLock structure to object and BasicLock
+      // structure Store the BasicLock address into %rax
+      lea(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset_in_bytes()));
+    }
 
     // Load oop into obj_reg(%c_rarg3)
     movptr(obj_reg, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()));
@@ -1287,26 +1308,46 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
     // Free entry
     movptr(Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()), (int32_t)NULL_WORD);
 
-    if (UseBiasedLocking) {
-      biased_locking_exit(obj_reg, header_reg, done);
+    if (UseAltFastLocking) {
+#ifdef _LP64
+      const Register thread = r15_thread;
+#else
+      const Register thread = header_reg;
+      get_thread(thread);
+#endif
+      // Handle unstructured locking.
+      Register tmp = swap_reg;
+      movl(tmp, Address(thread, JavaThread::lock_stack_top_offset()));
+      cmpptr(obj_reg, Address(thread, tmp, Address::times_1,  -oopSize));
+      jcc(Assembler::notEqual, slow_case);
+      // Try to swing header from locked to unlock.
+      movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      andptr(swap_reg, ~(int32_t)markOopDesc::lock_mask_in_place);
+      fast_unlock_impl(obj_reg, swap_reg, header_reg, slow_case);
+      jmp(done);
+      bind(slow_case);
+    } else {
+      if (UseBiasedLocking) {
+        biased_locking_exit(obj_reg, header_reg, done);
+      }
+
+      // Load the old header from BasicLock structure
+      movptr(header_reg, Address(swap_reg,
+                                 BasicLock::displaced_header_offset_in_bytes()));
+
+      // Test for recursion
+      testptr(header_reg, header_reg);
+
+      // zero for recursive case
+      jcc(Assembler::zero, done);
+
+      // Atomic swap back the old header
+      if (os::is_MP()) lock();
+      cmpxchgptr(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+
+      // zero for simple unlock of a stack-lock case
+      jcc(Assembler::zero, done);
     }
-
-    // Load the old header from BasicLock structure
-    movptr(header_reg, Address(swap_reg,
-                               BasicLock::displaced_header_offset_in_bytes()));
-
-    // Test for recursion
-    testptr(header_reg, header_reg);
-
-    // zero for recursive case
-    jcc(Assembler::zero, done);
-
-    // Atomic swap back the old header
-    if (os::is_MP()) lock();
-    cmpxchgptr(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-
-    // zero for simple unlock of a stack-lock case
-    jcc(Assembler::zero, done);
 
     // Call the runtime routine for slow case.
     movptr(Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()),

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -673,7 +673,7 @@ class MacroAssembler: public Assembler {
   // Code used by cmpFastLock and cmpFastUnlock mach instructions in .ad file.
   // See full desription in macroAssembler_x86.cpp.
   void fast_lock(Register obj, Register box, Register tmp,
-                 Register scr, Register cx1, Register cx2,
+                 Register scr, Register cx1, Register cx2, Register thread,
                  BiasedLockingCounters* counters,
                  RTMLockingCounters* rtm_counters,
                  RTMLockingCounters* stack_rtm_counters,
@@ -1893,6 +1893,9 @@ public:
                           XMMRegister tmp1, Register tmp2);
 
   void vallones(XMMRegister dst, int vector_len);
+
+  void fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow);
+  void fast_unlock_impl(Register obj, Register hdr, Register tmp, Label& slow);
 };
 
 /**

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -12598,7 +12598,7 @@ instruct cmpFastLockRTM(rFlagsReg cr, rRegP object, rbx_RegP box, rax_RegI tmp, 
   format %{ "fastlock $object,$box\t! kills $box,$tmp,$scr,$cx1,$cx2" %}
   ins_encode %{
     __ fast_lock($object$$Register, $box$$Register, $tmp$$Register,
-                 $scr$$Register, $cx1$$Register, $cx2$$Register,
+                 $scr$$Register, $cx1$$Register, $cx2$$Register, r15_thread,
                  _counters, _rtm_counters, _stack_rtm_counters,
                  ((Method*)(ra_->C->method()->constant_encoding()))->method_data(),
                  true, ra_->C->profile_rtm());
@@ -12614,7 +12614,7 @@ instruct cmpFastLock(rFlagsReg cr, rRegP object, rbx_RegP box, rax_RegI tmp, rRe
   format %{ "fastlock $object,$box\t! kills $box,$tmp,$scr" %}
   ins_encode %{
     __ fast_lock($object$$Register, $box$$Register, $tmp$$Register,
-                 $scr$$Register, $cx1$$Register, noreg, _counters, NULL, NULL, NULL, false, false);
+                 $scr$$Register, $cx1$$Register, noreg, r15_thread, _counters, NULL, NULL, NULL, false, false);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -702,13 +702,13 @@ JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* thread, oopDesc* obj, B
   NOT_PRODUCT(_monitorenter_slowcase_cnt++;)
   if (!UseBiasedLocking) {
     if (UseFastLocking) {
-      assert(obj == lock->obj(), "must match");
+      assert(UseAltFastLocking || obj == lock->obj(), "must match");
     } else {
       lock->set_obj(obj);
     }
   }
   WispPostStealHandleUpdateMark w(thread, __hm);
-  SharedRuntime::monitor_enter_helper(obj, lock->lock(), thread, UseFastLocking);
+  SharedRuntime::monitor_enter_helper(obj, UseAltFastLocking ? NULL : lock->lock(), thread, UseFastLocking);
 JRT_END
 
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -117,6 +117,7 @@ class InterpreterRuntime: AllStatic {
  public:
   // Synchronization
   static void    monitorenter(JavaThread* thread, BasicObjectLock* elem);
+  static void    monitorenter_obj(JavaThread* current, oopDesc* obj);
   static void    monitorexit (JavaThread* thread, BasicObjectLock* elem);
 
   static void    throw_illegal_monitor_state_exception(JavaThread* thread);

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -124,7 +124,7 @@ bool oopDesc::is_oop(oop obj, bool ignore_mark_word) {
   }
 
   // Header verification: the mark is typically non-NULL. If we're
-  // at a safepoint, it must not be null.
+  // at a safepoint, it must not be null, except when using the new lightweight locking.
   // Outside of a safepoint, the header could be changing (for example,
   // another thread could be inflating a lock on this object).
   if (ignore_mark_word) {
@@ -133,7 +133,7 @@ bool oopDesc::is_oop(oop obj, bool ignore_mark_word) {
   if (obj->mark_raw() != NULL) {
     return true;
   }
-  return !SafepointSynchronize::is_at_safepoint();
+  return !SafepointSynchronize::is_at_safepoint() || UseAltFastLocking;
 }
 
 // used only for asserts and guarantees

--- a/src/hotspot/share/opto/c2_CodeStubs.cpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "asm/codeBuffer.hpp"
+#include "code/codeBlob.hpp"
+#include "opto/c2_CodeStubs.hpp"
+#include "opto/c2_MacroAssembler.hpp"
+#include "opto/compile.hpp"
+#include "opto/output.hpp"
+
+C2CodeStubList::C2CodeStubList()  {
+  Arena* arena = Compile::current()->comp_arena();
+  _stubs = new(arena) GrowableArray<C2CodeStub*>(arena, 8,  0, NULL);
+}
+
+void C2CodeStubList::emit(CodeBuffer& cb) {
+  C2_MacroAssembler masm(&cb);
+  for (int i = _stubs->length() - 1; i >= 0; i--) {
+    C2CodeStub* stub = _stubs->at(i);
+    int max_size = stub->max_size();
+    // Make sure there is enough space in the code buffer
+    if (cb.insts()->maybe_expand_to_ensure_remaining(max_size) && cb.blob() == NULL) {
+      ciEnv::current()->record_failure("CodeCache is full");
+      return;
+    }
+
+    DEBUG_ONLY(int size_before = cb.insts_size();)
+
+    stub->emit(masm);
+
+    DEBUG_ONLY(int actual_size = cb.insts_size() - size_before;)
+    assert(max_size >= actual_size, "Expected stub size (%d) must be larger than or equal to actual stub size (%d)", max_size, actual_size);
+  }
+  _stubs->clear();
+}

--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "asm/assembler.hpp"
+#include "asm/codeBuffer.hpp"
+#include "memory/allocation.hpp"
+#include "opto/c2_MacroAssembler.hpp"
+#include "utilities/growableArray.hpp"
+
+#ifndef SHARE_OPTO_C2_CODESTUBS_HPP
+#define SHARE_OPTO_C2_CODESTUBS_HPP
+
+class C2CodeStub : public ResourceObj {
+private:
+  Label _entry;
+  Label _continuation;
+
+protected:
+  C2CodeStub() :
+    _entry(),
+    _continuation() {}
+  ~C2CodeStub() {}
+
+public:
+  Label& entry()        { return _entry; }
+  Label& continuation() { return _continuation; }
+
+  virtual void emit(C2_MacroAssembler& masm) = 0;
+  virtual int max_size() const = 0;
+};
+
+class C2CodeStubList {
+private:
+  GrowableArray<C2CodeStub*>* _stubs;
+
+public:
+  C2CodeStubList();
+  ~C2CodeStubList() {}
+  void add_stub(C2CodeStub* stub) { _stubs->append(stub); }
+  void emit(CodeBuffer& cb);
+};
+
+#ifdef _LP64
+class C2HandleAnonOMOwnerStub : public C2CodeStub {
+private:
+  Register _monitor;
+  Register _tmp;
+public:
+  C2HandleAnonOMOwnerStub(Register monitor, Register tmp = noreg) : C2CodeStub(),
+    _monitor(monitor), _tmp(tmp) {}
+  Register monitor() { return _monitor; }
+  Register tmp() { return _tmp; }
+  int max_size() const;
+  void emit(C2_MacroAssembler& masm);
+};
+#endif
+
+#endif // SHARE_OPTO_C2_CODESTUBS_HPP

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1210,6 +1210,7 @@ void Compile::Init(int aliaslevel) {
   _type_verify_symmetry = true;
   _exception_backedge = false;
 #endif
+  _stub_list = new(comp_arena()) C2CodeStubList();
 }
 
 //---------------------------init_start----------------------------------------

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -35,6 +35,7 @@
 #include "libadt/vectset.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "memory/resourceArea.hpp"
+#include "opto/c2_CodeStubs.hpp"
 #include "oops/methodData.hpp"
 #include "opto/idealGraphPrinter.hpp"
 #include "opto/phasetype.hpp"
@@ -610,6 +611,7 @@ class Compile : public Phase {
   int                   _first_block_size;      // Size of unvalidated entry point code / OSR poison code
   ExceptionHandlerTable _handler_table;         // Table of native-code exception handlers
   ImplicitExceptionTable _inc_table;            // Table of implicit null checks in native code
+  C2CodeStubList*        _stub_list;             // List of code stubs
   OopMapSet*            _oop_map_set;           // Table of oop maps (one for each safepoint location)
   static int            _CompiledZap_count;     // counter compared against CompileZap[First/Last]
   BufferBlob*           _scratch_buffer_blob;   // For temporary code buffers.
@@ -964,6 +966,9 @@ class Compile : public Phase {
 
   // Constant table
   ConstantTable&   constant_table() { return _constant_table; }
+
+  // Code stubs list
+  void add_stub(C2CodeStub* stub) { _stub_list->add_stub(stub); }
 
   MachConstantBaseNode*     mach_constant_base_node();
   bool                  has_mach_constant_base_node() const { return _mach_constant_base_node != NULL; }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1542,6 +1542,10 @@ void Compile::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
 #endif
   if (failing())  return;
 
+  // Fill in stubs.
+  _stub_list->emit(*cb);
+  if (C->failing())  return;
+
 #ifndef PRODUCT
   // Information on the size of the method, without the extraneous code
   Scheduling::increment_method_size(cb->insts_size());

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2093,6 +2093,28 @@ bool Arguments::check_vm_args_consistency() {
       log_warning(arguments) ("NUMA support for Heap depends on the file system when AllocateHeapAt option is used.\n");
     }
   }
+
+  if (UseAltFastLocking) {
+#if !defined(_LP64) || !(defined(X86) || defined(AARCH64))
+    jio_fprintf(defaultStream::error_stream(), "Platform do not support UseAltFastLocking.\n");
+    status = false;
+#else
+    if (UseBiasedLocking) {
+      FLAG_SET_DEFAULT(UseBiasedLocking, false);
+    }
+
+    if (UseHeavyMonitors) {
+      FLAG_SET_DEFAULT(UseHeavyMonitors, false);
+    }
+#endif
+
+#if INCLUDE_JVMCI
+    if (EnableJVMCI || UseAOT) {
+      FLAG_SET_DEFAULT(UseAltFastLocking, false);
+    }
+#endif
+  }
+
   return status;
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2689,6 +2689,10 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
                                                                             \
   experimental(bool, UseFastUnorderedTimeStamps, false,                     \
           "Use platform unstable time where supported for timestamps only") \
+                                                                            \
+  diagnostic(bool, UseAltFastLocking, false,                                \
+          "Alternative lightweight locking")                                \
+                                                                            \
 
 #define VM_FLAGS(develop,                                                   \
                  develop_pd,                                                \

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/lockStack.inline.hpp"
+#include "runtime/safepoint.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/copy.hpp"
+#include "utilities/ostream.hpp"
+
+const int LockStack::lock_stack_offset =      in_bytes(JavaThread::lock_stack_offset());
+const int LockStack::lock_stack_top_offset =  in_bytes(JavaThread::lock_stack_top_offset());
+const int LockStack::lock_stack_base_offset = in_bytes(JavaThread::lock_stack_base_offset());
+
+LockStack::LockStack(JavaThread* jt) :
+  _top(lock_stack_base_offset), _base() {
+#ifdef ASSERT
+  for (int i = 0; i < CAPACITY; i++) {
+    _base[i] = NULL;
+  }
+#endif
+}
+
+uint32_t LockStack::start_offset() {
+  int offset = lock_stack_base_offset;
+  assert(offset > 0, "must be positive offset");
+  return static_cast<uint32_t>(offset);
+}
+
+uint32_t LockStack::end_offset() {
+  int offset = lock_stack_base_offset + CAPACITY * oopSize;
+  assert(offset > 0, "must be positive offset");
+  return static_cast<uint32_t>(offset);
+}
+
+#ifndef PRODUCT
+void LockStack::verify(const char* msg) const {
+  assert(UseAltFastLocking, "never use lock-stack when light weight locking is disabled");
+  assert((_top <= end_offset()), "lockstack overflow: _top %d end_offset %d", _top, end_offset());
+  assert((_top >= start_offset()), "lockstack underflow: _top %d end_offset %d", _top, start_offset());
+  if (SafepointSynchronize::is_at_safepoint() || (Thread::current()->is_Java_thread() && is_owning_thread())) {
+    int top = to_index(_top);
+    for (int i = 0; i < top; i++) {
+      assert(_base[i] != NULL, "no zapped before top");
+      for (int j = i + 1; j < top; j++) {
+        assert(_base[i] != _base[j], "entries must be unique: %s", msg);
+      }
+    }
+    for (int i = top; i < CAPACITY; i++) {
+      assert(_base[i] == NULL, "only zapped entries after top: i: %d, top: %d, entry: " PTR_FORMAT, i, top, p2i(_base[i]));
+    }
+  }
+}
+#endif

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_LOCKSTACK_HPP
+#define SHARE_RUNTIME_LOCKSTACK_HPP
+
+#include "oops/oopsHierarchy.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/sizes.hpp"
+
+class Thread;
+class OopClosure;
+
+class LockStack {
+  friend class VMStructs;
+private:
+  static const int CAPACITY = 8;
+
+  // TODO: It would be very useful if JavaThread::lock_stack_offset() and friends were constexpr,
+  // but this is currently not the case because we're using offset_of() which is non-constexpr,
+  // GCC would warn about non-standard-layout types if we were using offsetof() (which *is* constexpr).
+  static const int lock_stack_offset;
+  static const int lock_stack_top_offset;
+  static const int lock_stack_base_offset;
+
+  // The offset of the next element, in bytes, relative to the JavaThread structure.
+  // We do this instead of a simple index into the array because this allows for
+  // efficient addressing in generated code.
+  uint32_t _top;
+  oop _base[CAPACITY];
+
+  // Get the owning thread of this lock-stack.
+  inline JavaThread* get_thread() const;
+
+  // Tests if the calling thread is the thread that owns this lock-stack.
+  bool is_owning_thread() const;
+
+  // Verifies consistency of the lock-stack.
+  void verify(const char* msg) const PRODUCT_RETURN;
+
+  // Given an offset (in bytes) calculate the index into the lock-stack.
+  static inline int to_index(uint32_t offset);
+
+public:
+  static ByteSize top_offset()  { return byte_offset_of(LockStack, _top); }
+  static ByteSize base_offset() { return byte_offset_of(LockStack, _base); }
+
+  LockStack(JavaThread* jt);
+
+  // The boundary indicies of the lock-stack.
+  static uint32_t start_offset();
+  static uint32_t end_offset();
+
+  // Return true if we have room to push onto this lock-stack, false otherwise.
+  inline bool can_push() const;
+
+  // Pushes an oop on this lock-stack.
+  inline void push(oop o);
+
+  // Pops an oop from this lock-stack.
+  inline oop pop();
+
+  // Removes an oop from an arbitrary location of this lock-stack.
+  inline void remove(oop o);
+
+  // Tests whether the oop is on this lock-stack.
+  inline bool contains(oop o) const;
+
+  // GC support
+  inline void oops_do(OopClosure* cl);
+
+};
+
+#endif // SHARE_RUNTIME_LOCKSTACK_HPP

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_LOCKSTACK_INLINE_HPP
+#define SHARE_RUNTIME_LOCKSTACK_INLINE_HPP
+
+#include "memory/iterator.hpp"
+#include "runtime/lockStack.hpp"
+#include "runtime/safepoint.hpp"
+#include "runtime/thread.hpp"
+
+inline int LockStack::to_index(uint32_t offset) {
+  return (offset - lock_stack_base_offset) / oopSize;
+}
+
+JavaThread* LockStack::get_thread() const {
+  char* addr = reinterpret_cast<char*>(const_cast<LockStack*>(this));
+  return reinterpret_cast<JavaThread*>(addr - lock_stack_offset);
+}
+
+inline bool LockStack::can_push() const {
+  return to_index(_top) < CAPACITY;
+}
+
+inline bool LockStack::is_owning_thread() const {
+  JavaThread* thread = JavaThread::current();
+  bool is_owning = &thread->lock_stack() == this;
+  assert(is_owning == (get_thread() == thread), "is_owning sanity");
+  return is_owning;
+}
+
+inline void LockStack::push(oop o) {
+  verify("pre-push");
+  assert(oopDesc::is_oop(o), "must be");
+  assert(!contains(o), "entries must be unique");
+  assert(can_push(), "must have room");
+  assert(_base[to_index(_top)] == NULL, "expect zapped entry");
+  _base[to_index(_top)] = o;
+  _top += oopSize;
+  verify("post-push");
+}
+
+inline oop LockStack::pop() {
+  verify("pre-pop");
+  assert(to_index(_top) > 0, "underflow, probably unbalanced push/pop");
+  _top -= oopSize;
+  oop o = _base[to_index(_top)];
+#ifdef ASSERT
+  _base[to_index(_top)] = NULL;
+#endif
+  assert(!contains(o), "entries must be unique: " PTR_FORMAT, p2i(o));
+  verify("post-pop");
+  return o;
+}
+
+inline void LockStack::remove(oop o) {
+  verify("pre-remove");
+  assert(contains(o), "entry must be present: " PTR_FORMAT, p2i(o));
+  int end = to_index(_top);
+  for (int i = 0; i < end; i++) {
+    if (_base[i] == o) {
+      int last = end - 1;
+      for (; i < last; i++) {
+        _base[i] = _base[i + 1];
+      }
+      _top -= oopSize;
+#ifdef ASSERT
+      _base[to_index(_top)] = NULL;
+#endif
+      break;
+    }
+  }
+  assert(!contains(o), "entries must be unique: " PTR_FORMAT, p2i(o));
+  verify("post-remove");
+}
+
+inline bool LockStack::contains(oop o) const {
+  verify("pre-contains");
+  int end = to_index(_top);
+  for (int i = end - 1; i >= 0; i--) {
+    if (_base[i] == o) {
+      verify("post-contains");
+      return true;
+    }
+  }
+  verify("post-contains");
+  return false;
+}
+
+inline void LockStack::oops_do(OopClosure* cl) {
+  verify("pre-oops-do");
+  int end = to_index(_top);
+  for (int i = 0; i < end; i++) {
+    cl->do_oop(&_base[i]);
+  }
+  verify("post-oops-do");
+}
+
+#endif // SHARE_RUNTIME_LOCKSTACK_INLINE_HPP

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -37,6 +37,7 @@
 #include "runtime/handshake.hpp"
 #include "runtime/javaFrameAnchor.hpp"
 #include "runtime/jniHandles.hpp"
+#include "runtime/lockStack.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/os.hpp"
 #include "runtime/osThread.hpp"
@@ -2107,6 +2108,19 @@ class JavaThread: public Thread {
   // AsyncGetCallTrace support
   inline bool in_asgct(void) {return _in_asgct;}
   inline void set_in_asgct(bool value) {_in_asgct = value;}
+
+private:
+  LockStack _lock_stack;
+
+public:
+  LockStack& lock_stack() { return _lock_stack; }
+
+  static ByteSize lock_stack_offset()      { return byte_offset_of(JavaThread, _lock_stack); }
+  // Those offsets are used in code generators to access the LockStack that is embedded in this
+  // JavaThread structure. Those accesses are relative to the current thread, which
+  // is typically in a dedicated register.
+  static ByteSize lock_stack_top_offset()  { return lock_stack_offset() + LockStack::top_offset(); }
+  static ByteSize lock_stack_base_offset() { return lock_stack_offset() + LockStack::base_offset(); }
 };
 
 // Inline implementation of JavaThread::current
@@ -2316,6 +2330,9 @@ class Threads: AllStatic {
   // Get owning Java thread from the monitor's owner field.
   static JavaThread *owning_thread_from_monitor_owner(ThreadsList * t_list,
                                                       address owner);
+
+  static JavaThread* owning_thread_from_object(ThreadsList* t_list, oop obj);
+  static JavaThread* owning_thread_from_monitor(ThreadsList* t_list, ObjectMonitor* owner);
 
   // Number of threads on the active threads list
   static int number_of_threads()                 { return _number_of_threads; }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -786,6 +786,9 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   nonstatic_field(JavaThread,                  _vm_result,                                    oop)                                   \
   nonstatic_field(JavaThread,                  _vm_result_2,                                  Metadata*)                             \
   nonstatic_field(JavaThread,                  _pending_async_exception,                      oop)                                   \
+  nonstatic_field(JavaThread,                  _lock_stack,                                   LockStack)                             \
+  nonstatic_field(LockStack,                   _top,                                          uint32_t)                              \
+  nonstatic_field(LockStack,                   _base[0],                                      oop)                                   \
   volatile_nonstatic_field(JavaThread,         _exception_oop,                                oop)                                   \
   volatile_nonstatic_field(JavaThread,         _exception_pc,                                 address)                               \
   volatile_nonstatic_field(JavaThread,         _is_method_handle_return,                      int)                                   \
@@ -1399,6 +1402,7 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
         declare_type(AttachListenerThread, JavaThread)                    \
   declare_toplevel_type(OSThread)                                         \
   declare_toplevel_type(JavaFrameAnchor)                                  \
+  declare_toplevel_type(LockStack)                                        \
                                                                           \
   /***************/                                                       \
   /* Interpreter */                                                       \
@@ -2719,8 +2723,10 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
                                                                           \
   /* InvocationCounter constants */                                       \
   declare_constant(InvocationCounter::count_increment)                    \
-  declare_constant(InvocationCounter::count_shift)
-
+  declare_constant(InvocationCounter::count_shift)                        \
+                                                                          \
+  /* ObjectMonitor constants */                                           \
+  declare_constant(ObjectMonitor::ANONYMOUS_OWNER)                        \
 
 //--------------------------------------------------------------------------------
 //

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -425,8 +425,12 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
       if (waitingToLockMonitor != NULL) {
         address currentOwner = (address)waitingToLockMonitor->owner();
         if (currentOwner != NULL) {
-          currentThread = Threads::owning_thread_from_monitor_owner(t_list,
-                                                                    currentOwner);
+          if (UseAltFastLocking) {
+            currentThread = Threads::owning_thread_from_monitor(t_list, waitingToLockMonitor);
+          } else {
+            currentThread = Threads::owning_thread_from_monitor_owner(t_list,
+                                                                      currentOwner);
+          }
           if (currentThread == NULL) {
             // This function is called at a safepoint so the JavaThread
             // that owns waitingToLockMonitor should be findable, but
@@ -1042,8 +1046,12 @@ void DeadlockCycle::print_on_with(ThreadsList * t_list, outputStream* st) const 
         // No Java object associated - a JVMTI raw monitor
         owner_desc = " (JVMTI raw monitor),\n  which is held by";
       }
-      currentThread = Threads::owning_thread_from_monitor_owner(t_list,
-                                                                (address)waitingToLockMonitor->owner());
+      if (UseAltFastLocking) {
+        currentThread = Threads::owning_thread_from_monitor(t_list, waitingToLockMonitor);
+      } else {
+        currentThread = Threads::owning_thread_from_monitor_owner(t_list,
+                                                                  (address)waitingToLockMonitor->owner());
+      }
       if (currentThread == NULL) {
         // The deadlock was detected at a safepoint so the JavaThread
         // that owns waitingToLockMonitor should be findable, but

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -43,6 +43,8 @@ public class JavaThread extends Thread {
 
   private static AddressField  nextField;
   private static sun.jvm.hotspot.types.OopField threadObjField;
+  private static long          lockStackTopOffset;
+  private static long          lockStackBaseOffset;
   private static AddressField  anchorField;
   private static AddressField  lastJavaSPField;
   private static AddressField  lastJavaPCField;
@@ -51,6 +53,7 @@ public class JavaThread extends Thread {
   private static AddressField  stackBaseField;
   private static CIntegerField stackSizeField;
   private static CIntegerField terminatedField;
+  private static long oopPtrSize;
 
   private static JavaThreadPDAccess access;
 
@@ -83,6 +86,7 @@ public class JavaThread extends Thread {
   private static synchronized void initialize(TypeDataBase db) {
     Type type = db.lookupType("JavaThread");
     Type anchorType = db.lookupType("JavaFrameAnchor");
+    Type typeLockStack = db.lookupType("LockStack");
 
     nextField         = type.getAddressField("_next");
     threadObjField    = type.getOopField("_threadObj");
@@ -94,6 +98,9 @@ public class JavaThread extends Thread {
     stackBaseField    = type.getAddressField("_stack_base");
     stackSizeField    = type.getCIntegerField("_stack_size");
     terminatedField   = type.getCIntegerField("_terminated");
+    lockStackTopOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_top").getOffset();
+    lockStackBaseOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_base[0]").getOffset();
+    oopPtrSize = VM.getVM().getAddressSize();
 
     UNINITIALIZED     = db.lookupIntConstant("_thread_uninitialized").intValue();
     NEW               = db.lookupIntConstant("_thread_new").intValue();
@@ -396,6 +403,23 @@ public class JavaThread extends Thread {
     // Be robust
     if (sp == null) return false;
     return stackBase.greaterThan(a) && sp.lessThanOrEqual(a);
+  }
+
+  public boolean isLockOwned(OopHandle obj) {
+    long current = lockStackBaseOffset;
+    long end = addr.getJIntAt(lockStackTopOffset);
+    if (Assert.ASSERTS_ENABLED) {
+      Assert.that(current <= end, "current stack offset must be above base offset");
+    }
+
+    while (current < end) {
+      Address oop = addr.getAddressAt(current);
+      if (oop.equals(obj)) {
+        return true;
+      }
+      current += oopPtrSize;
+    }
+    return false;
   }
 
   public boolean isLockOwned(Address a) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -77,6 +77,10 @@ public abstract class JavaVFrame extends VFrame {
     if (mark.hasMonitor() &&
         ( // we have marked ourself as pending on this monitor
           mark.monitor().equals(thread.getCurrentPendingMonitor()) ||
+          // Owned anonymously means that we are not the owner of
+          // the monitor and must be waiting for the owner to
+          // exit it.
+          mark.monitor().isOwnedAnonymous() ||
           // we are not the owner of this monitor
           !mark.monitor().isEntered(thread)
         )) {
@@ -146,7 +150,7 @@ public abstract class JavaVFrame extends VFrame {
             // an inflated monitor that is first on the monitor list in
             // the first frame can block us on a monitor enter.
             lockState = identifyLockState(monitor, "waiting to lock");
-          } else if (frameCount != 0) {
+          } else if (frameCount != 0 && !VM.getVM().getCommandLineBooleanFlag("UseAltFastLocking")) { // JDK-8214499
             // This is not the first frame so we either own this monitor
             // or we owned the monitor before and called wait(). Because
             // wait() could have been called on any monitor in a lower

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
@@ -53,6 +53,8 @@ public class ObjectMonitor extends VMObject {
     countField  = type.getJIntField("_count");
     waitersField = type.getJIntField("_waiters");
     recursionsField = type.getCIntegerField("_recursions");
+
+    ANONYMOUS_OWNER = db.lookupLongConstant("ObjectMonitor::ANONYMOUS_OWNER").longValue();
   }
 
   public ObjectMonitor(Address addr) {
@@ -73,6 +75,13 @@ public class ObjectMonitor extends VMObject {
     if (current.threadObjectAddress().equals(o) ||
         current.isLockOwned(o)) {
       return true;
+    }
+    return false;
+  }
+
+  public boolean isOwnedAnonymous() {
+    if (VM.getVM().getCommandLineBooleanFlag("UseAltFastLocking") && owner() != null) {
+      return addr.getAddressAt(ownerFieldOffset).asLongValue() == ANONYMOUS_OWNER;
     }
     return false;
   }
@@ -117,5 +126,7 @@ public class ObjectMonitor extends VMObject {
   private static JIntField     countField;
   private static JIntField     waitersField;
   private static CIntegerField recursionsField;
+  private static long          ANONYMOUS_OWNER;
+
   // FIXME: expose platform-dependent stuff
 }


### PR DESCRIPTION
Summary: Implement new fast-locking with option UseAltFastLocking, also according to JDK-8308107

Test Plan: CICD

Reviewed-by: kuaiwei, yulei, ddh

Issue: https://github.com/dragonwell-project/dragonwell11/issues/679