### PR TITLE
[Backport] C2CodeStubList should be ResourceObj

### DIFF
--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -50,7 +50,7 @@ public:
   virtual int max_size() const = 0;
 };
 
-class C2CodeStubList {
+class C2CodeStubList : public ResourceObj {
 private:
   GrowableArray<C2CodeStub*>* _stubs;
 


### PR DESCRIPTION
Summary: Fix jtreg nightly failure due to backport 8291555.

Test Plan: CICD

Reviewed-by: kuaiwei,yifeng

Issue: https://github.com/dragonwell-project/dragonwell11/issues/685