### PR TITLE
[EagerAppCDS] Fix unstable test case TestExecStartupProbe

### DIFF
--- a/test/jdk/com/alibaba/quickstart/StartupProbeTestRunner.java
+++ b/test/jdk/com/alibaba/quickstart/StartupProbeTestRunner.java
@@ -85,6 +85,8 @@ public class StartupProbeTestRunner extends QuickStartTestRunner {
         ProcessBuilder pb = createJavaProcessBuilder(cp, merge(new String[][]{
                 getProfileOptions(workDir.getCacheDir()), commands}));
         pb.environment().put("DRAGONWELL_QUICKSTART_STARTUP_PROBE",base64StartupProbe);
+        //set a file flag that indicate CDS dump successful
+        pb.environment().put("CDS_DUMP_FINISH_FILE", workDir.getCacheDir() + File.separator + "metadata");
         jdk.test.lib.process.OutputAnalyzer output = new jdk.test.lib.process.OutputAnalyzer(pb.start());
         output.shouldContain("Running as profiler");
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
Summary: Change hard-code sleep time to test if a file exist which means CDS dump successful.

Test Plan: TestExecStartupProbe.java

Reviewed-by: jia-wei-tang, yuleil

Issue: https://github.com/dragonwell-project/dragonwell11/issues/687