### PR TITLE
[Backport] Missing monitor inflation log

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2103,9 +2103,6 @@ bool Arguments::check_vm_args_consistency() {
       FLAG_SET_DEFAULT(UseBiasedLocking, false);
     }
 
-    if (UseHeavyMonitors) {
-      FLAG_SET_DEFAULT(UseHeavyMonitors, false);
-    }
 #endif
 
 #if INCLUDE_JVMCI

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1702,6 +1702,14 @@ ObjectMonitor* ObjectSynchronizer::inflate(Thread * Self,
         // Hopefully the performance counters are allocated on distinct
         // cache lines to avoid false sharing on MP systems ...
         OM_PERFDATA_OP(Inflations, inc());
+        if (log_is_enabled(Debug, monitorinflation)) {
+          if (object->is_instance()) {
+            ResourceMark rm;
+            log_debug(monitorinflation)("Inflating object " INTPTR_FORMAT " , mark " INTPTR_FORMAT " , type %s",
+                                        p2i(object), p2i(object->mark()),
+                                        object->klass()->external_name());
+          }
+        }
         if (event.should_commit()) {
           post_monitor_inflate_event(&event, object, cause);
         }


### PR DESCRIPTION
Summary: missing log of monitor inflation

Test Plan: CICD

Reviewed-by: yulei, ddh

Issue: https://github.com/dragonwell-project/dragonwell11/issues/679