### PR TITLE
[Backport] 8234173: assert(loader != __null && oopDesc::is_oop(loader…

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
@@ -131,7 +131,7 @@ void BFSClosure::closure_impl(const oop* reference, const oop pointee) {
   if (!_mark_bits->is_marked(pointee)) {
     _mark_bits->mark_obj(pointee);
     // is the pointee a sample object?
-    if (NULL == pointee->mark()) {
+    if (pointee->mark()->is_marked()) {
       add_chain(reference, pointee);
     }
 
@@ -148,7 +148,7 @@ void BFSClosure::closure_impl(const oop* reference, const oop pointee) {
 
 void BFSClosure::add_chain(const oop* reference, const oop pointee) {
   assert(pointee != NULL, "invariant");
-  assert(NULL == pointee->mark(), "invariant");
+  assert(pointee->mark()->is_marked(), "invariant");
   Edge leak_edge(_current_parent, reference);
   _edge_store->put_chain(&leak_edge, _current_parent == NULL ? 1 : _current_frontier_level + 2);
 }

--- a/src/hotspot/share/jfr/leakprofiler/chains/dfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/dfsClosure.cpp
@@ -121,7 +121,7 @@ void DFSClosure::closure_impl(const oop* reference, const oop pointee) {
   assert(_mark_bits->is_marked(pointee), "invariant");
 
   // is the pointee a sample object?
-  if (NULL == pointee->mark()) {
+  if (pointee->mark()->is_marked()) {
     add_chain();
   }
 

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
@@ -237,7 +237,7 @@ StoredEdge* EdgeStore::associate_leak_context_with_candidate(const Edge* edge) {
   StoredEdge* const leak_context_edge = put(edge->reference());
   oop sample_object = edge->pointee();
   assert(sample_object != NULL, "invariant");
-  assert(NULL == sample_object->mark(), "invariant");
+  assert(sample_object->mark()->is_marked(), "invariant");
   sample_object->set_mark(markOop(leak_context_edge));
   return leak_context_edge;
 }

--- a/src/hotspot/share/jfr/leakprofiler/chains/objectSampleMarker.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/objectSampleMarker.hpp
@@ -67,14 +67,11 @@ class ObjectSampleMarker : public StackObj {
     assert(obj != NULL, "invariant");
     // save the original markOop
     _store->push(ObjectSampleMarkOop(obj, obj->mark()));
-    // now we will "poison" the mark word of the sample object
-    // to the intermediate monitor INFLATING state.
-    // This is an "impossible" state during a safepoint,
-    // hence we will use it to quickly identify sample objects
-    // during the reachability search from gc roots.
-    assert(NULL == markOopDesc::INFLATING(), "invariant");
-    obj->set_mark(markOopDesc::INFLATING());
-    assert(NULL == obj->mark(), "invariant");
+    // now we will set the mark word to "marked" in order to quickly
+    // identify sample objects during the reachability search from gc roots.
+    assert(!obj->mark()->is_marked(), "should only mark an object once");
+    obj->set_mark(markOopDesc::prototype()->set_marked());
+    assert(obj->mark()->is_marked(), "invariant");
   }
 };
 

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
@@ -111,7 +111,9 @@ void EventEmitter::write_event(const ObjectSample* sample, EdgeStore* edge_store
   traceid gc_root_id = 0;
   const Edge* edge = NULL;
   if (SafepointSynchronize::is_at_safepoint()) {
-    edge = (const Edge*)(*object_addr)->mark();
+    if (!(*object_addr)->mark()->is_marked()) {
+      edge = (const Edge*)(*object_addr)->mark();
+    }
   }
   if (edge == NULL) {
     // In order to dump out a representation of the event

--- a/src/hotspot/share/oops/markOop.hpp
+++ b/src/hotspot/share/oops/markOop.hpp
@@ -92,8 +92,7 @@
 //    [ptr             | 00]  locked             ptr points to real header on stack
 //    [header      | 0 | 01]  unlocked           regular object header
 //    [ptr             | 10]  monitor            inflated lock (header is wapped out)
-//    [ptr             | 11]  marked             used by markSweep to mark an object
-//                                               not valid at any other time
+//    [ptr             | 11]  marked             used to mark an object
 //
 //    We assume that stack/thread pointers have the lowest two bits cleared.
 


### PR DESCRIPTION
…)) failed: loader must be oop

Summary: Change the mark setting in JFR leak profiler to make it robust. For lilliput as well.

Test Plan: CICD

Reviewed-by: ddh, yanglong

Issue: https://github.com/dragonwell-project/dragonwell11/issues/704