### PR TITLE
[Backport] 8319053: Segment dump files remain after parallel heap dump on Windows

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -382,7 +382,7 @@ enum {
 
 // Supports I/O operations for a dump
 
-class DumpWriter : public ResourceObj {
+class DumpWriter : public CHeapObj<mtInternal> {
  private:
   enum {
     io_buffer_max_size = 1*M,
@@ -1734,7 +1734,9 @@ void DumpMerger::do_merge() {
 #endif
     }
     // Delete selected segmented heap file nevertheless
-    remove(path);
+    if (remove(path) != 0) {
+      log_info(heapdump)("Removal of segment file (%d) failed (%d)", i, errno);
+    }
   }
 
   // restore compressor for further use
@@ -2264,6 +2266,7 @@ void VM_HeapDumper::work(uint worker_id) {
     } else {
       // propagate local error to global if any
       _dumper_controller->dumper_complete(local_writer, writer());
+      delete local_writer;
       return;
     }
   }


### PR DESCRIPTION
Summary: Segment file is closed from DumpWriter dtor. On Unix systems remove can delete an opened file, on Windows it fails with "access denied". The fix destroys DumpWriter objects for segment files after all data are dumped

Test Plan: HeapDumpParallelTest.java

Reviewed-by: D-D-H, yuleil

Issue: #714