### PR TITLE
[Backport] Fix new fast-locking is_lock_owned of backport of 8291555

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1124,8 +1124,8 @@ ObjectSynchronizer::LockOwnership ObjectSynchronizer::query_lock_ownership
     if (UseWispMonitor) {
       self = WispThread::current(self);
     }
-    return (owner == self ||
-            self->is_lock_owned((address)owner)) ? owner_self : owner_other;
+    bool lock_owned = UseAltFastLocking ? is_lock_owned(self, obj) : self->is_lock_owned((address)owner);
+    return (owner == self || lock_owned) ? owner_self : owner_other;
   }
 
   // CASE: neutral


### PR DESCRIPTION
Summary: Fix new fast-locking is_lock_owned.

Test Plan: CICD

Reviewed-by: yulei, ddh

Issue: https://github.com/dragonwell-project/dragonwell11/issues/679