### PR TITLE
[Backport] 8270519: Move several vector helper methods to shared head…

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1345,39 +1345,6 @@ class HandlerImpl {
 #endif
 };
 
-
-inline uint vector_length(const Node* n) {
-  const TypeVect* vt = n->bottom_type()->is_vect();
-  return vt->length();
-}
-
-inline uint vector_length(const MachNode* use, MachOper* opnd) {
-  uint def_idx = use->operand_index(opnd);
-  Node* def = use->in(def_idx);
-  return def->bottom_type()->is_vect()->length();
-}
-
-inline uint vector_length_in_bytes(const Node* n) {
-  const TypeVect* vt = n->bottom_type()->is_vect();
-  return vt->length_in_bytes();
-}
-
-inline uint vector_length_in_bytes(const MachNode* use, MachOper* opnd) {
-  uint def_idx = use->operand_index(opnd);
-  Node* def = use->in(def_idx);
-  return def->bottom_type()->is_vect()->length_in_bytes();
-}
-
-inline BasicType vector_element_basic_type(const Node *n) {
-  return n->bottom_type()->is_vect()->element_basic_type();
-}
-
-inline BasicType vector_element_basic_type(const MachNode *use, MachOper* opnd) {
-  uint def_idx = use->operand_index(opnd);
-  Node* def = use->in(def_idx);
-  return def->bottom_type()->is_vect()->element_basic_type();
-}
-
 inline Assembler::AvxVectorLen vector_length_encoding(int bytes) {
   switch(bytes) {
     case  4: // fall-through
@@ -1394,7 +1361,7 @@ inline Assembler::AvxVectorLen vector_length_encoding(int bytes) {
 }
 
 static inline Assembler::AvxVectorLen vector_length_encoding(const Node* n) {
-  return vector_length_encoding(vector_length_in_bytes(n));
+  return vector_length_encoding(Matcher::vector_length_in_bytes(n));
 }
 
 static inline Assembler::AvxVectorLen vector_length_encoding(const MachNode* use, MachOper* opnd) {
@@ -3465,7 +3432,7 @@ instruct sqrtD_imm(regD dst, immD con) %{
 // ---------------------------------------- VectorReinterpret ------------------------------------
 
 instruct reinterpret(vec dst) %{
-  predicate(vector_length_in_bytes(n) == vector_length_in_bytes(n->in(1))); // dst == src
+  predicate(Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1))); // dst == src
   match(Set dst (VectorReinterpret dst));
   ins_cost(125);
   format %{ "vector_reinterpret $dst\t!" %}
@@ -3477,16 +3444,16 @@ instruct reinterpret(vec dst) %{
 
 instruct reinterpret_expand(vec dst, vec src, rRegP scratch) %{
   predicate(UseAVX == 0 &&
-            (vector_length_in_bytes(n->in(1)) < vector_length_in_bytes(n))); // src < dst
+            (Matcher::vector_length_in_bytes(n->in(1)) < Matcher::vector_length_in_bytes(n))); // src < dst
   match(Set dst (VectorReinterpret src));
   ins_cost(125);
   effect(TEMP dst, TEMP scratch);
   format %{ "vector_reinterpret_expand $dst,$src\t! using $scratch as TEMP" %}
   ins_encode %{
-    assert(vector_length_in_bytes(this)       <= 16, "required");
-    assert(vector_length_in_bytes(this, $src) <=  8, "required");
+    assert(Matcher::vector_length_in_bytes(this)       <= 16, "required");
+    assert(Matcher::vector_length_in_bytes(this, $src) <=  8, "required");
 
-    int src_vlen_in_bytes = vector_length_in_bytes(this, $src);
+    int src_vlen_in_bytes = Matcher::vector_length_in_bytes(this, $src);
     if (src_vlen_in_bytes == 4) {
       __ movdqu($dst$$XMMRegister, ExternalAddress(vector_32_bit_mask()), $scratch$$Register);
     } else {
@@ -3500,8 +3467,8 @@ instruct reinterpret_expand(vec dst, vec src, rRegP scratch) %{
 
 instruct vreinterpret_expand4(legVec dst, vec src, rRegP scratch) %{
   predicate(UseAVX > 0 &&
-            (vector_length_in_bytes(n->in(1)) == 4) && // src
-            (vector_length_in_bytes(n->in(1)) < vector_length_in_bytes(n))); // src < dst
+            (Matcher::vector_length_in_bytes(n->in(1)) == 4) && // src
+            (Matcher::vector_length_in_bytes(n->in(1)) < Matcher::vector_length_in_bytes(n))); // src < dst
   match(Set dst (VectorReinterpret src));
   ins_cost(125);
   effect(TEMP scratch);
@@ -3515,13 +3482,13 @@ instruct vreinterpret_expand4(legVec dst, vec src, rRegP scratch) %{
 
 instruct vreinterpret_expand(legVec dst, vec src) %{
   predicate(UseAVX > 0 &&
-            (vector_length_in_bytes(n->in(1)) > 4) && // src
-            (vector_length_in_bytes(n->in(1)) < vector_length_in_bytes(n))); // src < dst
+            (Matcher::vector_length_in_bytes(n->in(1)) > 4) && // src
+            (Matcher::vector_length_in_bytes(n->in(1)) < Matcher::vector_length_in_bytes(n))); // src < dst
   match(Set dst (VectorReinterpret src));
   ins_cost(125);
   format %{ "vector_reinterpret_expand $dst,$src\t!" %}
   ins_encode %{
-    switch (vector_length_in_bytes(this, $src)) {
+    switch (Matcher::vector_length_in_bytes(this, $src)) {
       case  8: __ movq   ($dst$$XMMRegister, $src$$XMMRegister); break;
       case 16: __ movdqu ($dst$$XMMRegister, $src$$XMMRegister); break;
       case 32: __ vmovdqu($dst$$XMMRegister, $src$$XMMRegister); break;
@@ -3532,12 +3499,12 @@ instruct vreinterpret_expand(legVec dst, vec src) %{
 %}
 
 instruct reinterpret_shrink(vec dst, legVec src) %{
-  predicate(vector_length_in_bytes(n->in(1)) > vector_length_in_bytes(n)); // src > dst
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) > Matcher::vector_length_in_bytes(n)); // src > dst
   match(Set dst (VectorReinterpret src));
   ins_cost(125);
   format %{ "vector_reinterpret_shrink $dst,$src\t!" %}
   ins_encode %{
-    switch (vector_length_in_bytes(this)) {
+    switch (Matcher::vector_length_in_bytes(this)) {
       case  4: __ movfltz($dst$$XMMRegister, $src$$XMMRegister); break;
       case  8: __ movq   ($dst$$XMMRegister, $src$$XMMRegister); break;
       case 16: __ movdqu ($dst$$XMMRegister, $src$$XMMRegister); break;
@@ -3586,7 +3553,7 @@ instruct roundD_imm(legRegD dst, immD con, immU8 rmode, rRegI scratch_reg) %{
 %}
 
 instruct vroundD_reg(legVec dst, legVec src, immU8 rmode) %{
-  predicate(vector_length(n) < 8);
+  predicate(Matcher::vector_length(n) < 8);
   match(Set dst (RoundDoubleModeV src rmode));
   format %{ "vroundpd $dst,$src,$rmode\t! round packedD" %}
   ins_encode %{
@@ -3598,7 +3565,7 @@ instruct vroundD_reg(legVec dst, legVec src, immU8 rmode) %{
 %}
 
 instruct vround8D_reg(vec dst, vec src, immU8 rmode) %{
-  predicate(vector_length(n) == 8);
+  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (RoundDoubleModeV src rmode));
   format %{ "vrndscalepd $dst,$src,$rmode\t! round packed8D" %}
   ins_encode %{
@@ -3609,7 +3576,7 @@ instruct vround8D_reg(vec dst, vec src, immU8 rmode) %{
 %}
 
 instruct vroundD_mem(legVec dst, memory mem, immU8 rmode) %{
-  predicate(vector_length(n) < 8);
+  predicate(Matcher::vector_length(n) < 8);
   match(Set dst (RoundDoubleModeV (LoadVector mem) rmode));
   format %{ "vroundpd $dst, $mem, $rmode\t! round packedD" %}
   ins_encode %{
@@ -3621,7 +3588,7 @@ instruct vroundD_mem(legVec dst, memory mem, immU8 rmode) %{
 %}
 
 instruct vround8D_mem(vec dst, memory mem, immU8 rmode) %{
-  predicate(vector_length(n) == 8);
+  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (RoundDoubleModeV (LoadVector mem) rmode));
   format %{ "vrndscalepd $dst,$mem,$rmode\t! round packed8D" %}
   ins_encode %{
@@ -3703,7 +3670,7 @@ instruct loadV(vec dst, memory mem) %{
   ins_cost(125);
   format %{ "load_vector $dst,$mem" %}
   ins_encode %{
-    switch (vector_length_in_bytes(this)) {
+    switch (Matcher::vector_length_in_bytes(this)) {
       case  4: __ movdl    ($dst$$XMMRegister, $mem$$Address); break;
       case  8: __ movq     ($dst$$XMMRegister, $mem$$Address); break;
       case 16: __ movdqu   ($dst$$XMMRegister, $mem$$Address); break;
@@ -3721,7 +3688,7 @@ instruct storeV(memory mem, vec src) %{
   ins_cost(145);
   format %{ "store_vector $mem,$src\n\t" %}
   ins_encode %{
-    switch (vector_length_in_bytes(this, $src)) {
+    switch (Matcher::vector_length_in_bytes(this, $src)) {
       case  4: __ movdl    ($mem$$Address, $src$$XMMRegister); break;
       case  8: __ movq     ($mem$$Address, $src$$XMMRegister); break;
       case 16: __ movdqu   ($mem$$Address, $src$$XMMRegister); break;
@@ -3738,7 +3705,7 @@ instruct storeV(memory mem, vec src) %{
 // Gather INT, LONG, FLOAT, DOUBLE
 
 instruct gather(legVec dst, memory mem, legVec idx, rRegP tmp, legVec mask) %{
-  predicate(vector_length_in_bytes(n) <= 32);
+  predicate(Matcher::vector_length_in_bytes(n) <= 32);
   match(Set dst (LoadVectorGather mem idx));
   effect(TEMP dst, TEMP tmp, TEMP mask);
   format %{ "load_vector_gather $dst, $mem, $idx\t! using $tmp and $mask as TEMP" %}
@@ -3746,9 +3713,9 @@ instruct gather(legVec dst, memory mem, legVec idx, rRegP tmp, legVec mask) %{
     assert(UseAVX >= 2, "sanity");
 
     int vlen_enc = vector_length_encoding(this);
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
-    assert(vector_length_in_bytes(this) >= 16, "sanity");
+    assert(Matcher::vector_length_in_bytes(this) >= 16, "sanity");
     assert(!is_subword_type(elem_bt), "sanity"); // T_INT, T_LONG, T_FLOAT, T_DOUBLE
 
     if (vlen_enc == Assembler::AVX_128bit) {
@@ -3763,7 +3730,7 @@ instruct gather(legVec dst, memory mem, legVec idx, rRegP tmp, legVec mask) %{
 %}
 
 instruct evgather(vec dst, memory mem, vec idx, rRegP tmp, kReg ktmp) %{
-  predicate(vector_length_in_bytes(n) == 64);
+  predicate(Matcher::vector_length_in_bytes(n) == 64);
   match(Set dst (LoadVectorGather mem idx));
   effect(TEMP dst, TEMP tmp, TEMP ktmp);
   format %{ "load_vector_gather $dst, $mem, $idx\t! using $tmp and k2 as TEMP" %}
@@ -3771,7 +3738,7 @@ instruct evgather(vec dst, memory mem, vec idx, rRegP tmp, kReg ktmp) %{
     assert(UseAVX > 2, "sanity");
 
     int vlen_enc = vector_length_encoding(this);
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
     assert(!is_subword_type(elem_bt), "sanity"); // T_INT, T_LONG, T_FLOAT, T_DOUBLE
 
@@ -3793,9 +3760,9 @@ instruct scatter(memory mem, vec src, vec idx, rRegP tmp, kReg ktmp) %{
   format %{ "store_vector_scatter $mem, $idx, $src\t! using k2 and $tmp as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this, $src);
-    BasicType elem_bt = vector_element_basic_type(this, $src);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this, $src);
 
-    assert(vector_length_in_bytes(this, $src) >= 16, "sanity");
+    assert(Matcher::vector_length_in_bytes(this, $src) >= 16, "sanity");
     assert(!is_subword_type(elem_bt), "sanity"); // T_INT, T_LONG, T_FLOAT, T_DOUBLE
 
     __ kmovwl($ktmp$$KRegister, ExternalAddress(vector_all_bits_set()), $tmp$$Register);
@@ -3812,7 +3779,7 @@ instruct ReplB_reg(vec dst, rRegI src) %{
   match(Set dst (ReplicateB src));
   format %{ "replicateB $dst,$src" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 64 || VM_Version::supports_avx512vlbw()) { // AVX512VL for <512bit operands
       assert(VM_Version::supports_avx512bw(), "required"); // 512-bit byte vectors assume AVX512BW
       int vlen_enc = vector_length_encoding(this);
@@ -3852,7 +3819,7 @@ instruct ReplB_imm(vec dst, immI con) %{
   match(Set dst (ReplicateB con));
   format %{ "replicateB $dst,$con" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     InternalAddress const_addr = $constantaddress(replicate8_imm($con$$constant, 1));
     if (vlen == 4) {
       __ movdl($dst$$XMMRegister, const_addr);
@@ -3877,7 +3844,7 @@ instruct ReplB_zero(vec dst, immI_0 zero) %{
   match(Set dst (ReplicateB zero));
   format %{ "replicateB $dst,$zero" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 16) {
       __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
     } else {
@@ -3895,7 +3862,7 @@ instruct ReplS_reg(vec dst, rRegI src) %{
   match(Set dst (ReplicateS src));
   format %{ "replicateS $dst,$src" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 32 || VM_Version::supports_avx512vlbw()) { // AVX512VL for <512bit operands
       assert(VM_Version::supports_avx512bw(), "required"); // 512-bit short vectors assume AVX512BW
       int vlen_enc = vector_length_encoding(this);
@@ -3934,7 +3901,7 @@ instruct ReplS_imm(vec dst, immI con) %{
   match(Set dst (ReplicateS con));
   format %{ "replicateS $dst,$con" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     InternalAddress const_addr = $constantaddress(replicate8_imm($con$$constant, 2));
     if (vlen == 2) {
       __ movdl($dst$$XMMRegister, const_addr);
@@ -3958,7 +3925,7 @@ instruct ReplS_zero(vec dst, immI_0 zero) %{
   match(Set dst (ReplicateS zero));
   format %{ "replicateS $dst,$zero" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 8) {
       __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
     } else {
@@ -3975,7 +3942,7 @@ instruct ReplI_reg(vec dst, rRegI src) %{
   match(Set dst (ReplicateI src));
   format %{ "replicateI $dst,$src" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 16 || VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
       int vlen_enc = vector_length_encoding(this);
       __ evpbroadcastd($dst$$XMMRegister, $src$$Register, vlen_enc);
@@ -3999,7 +3966,7 @@ instruct ReplI_mem(vec dst, memory mem) %{
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "replicateI $dst,$mem" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 4) {
       __ movdl($dst$$XMMRegister, $mem$$Address);
       __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
@@ -4016,7 +3983,7 @@ instruct ReplI_imm(vec dst, immI con) %{
   match(Set dst (ReplicateI con));
   format %{ "replicateI $dst,$con" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     InternalAddress const_addr = $constantaddress(replicate8_imm($con$$constant, 4));
     if (vlen <= 4) {
       __ movq($dst$$XMMRegister, const_addr);
@@ -4038,7 +4005,7 @@ instruct ReplI_zero(vec dst, immI_0 zero) %{
   match(Set dst (ReplicateI zero));
   format %{ "replicateI $dst,$zero" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 4) {
       __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
     } else {
@@ -4071,7 +4038,7 @@ instruct ReplL_reg(vec dst, rRegL src) %{
   match(Set dst (ReplicateL src));
   format %{ "replicateL $dst,$src" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ movdq($dst$$XMMRegister, $src$$Register);
       __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
@@ -4095,12 +4062,12 @@ instruct ReplL_reg(vec dst, rRegL src) %{
 #else // _LP64
 // Replicate long (8 byte) scalar to be vector
 instruct ReplL_reg(vec dst, eRegL src, vec tmp) %{
-  predicate(vector_length(n) <= 4);
+  predicate(Matcher::vector_length(n) <= 4);
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
   format %{ "replicateL $dst,$src" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ movdl($dst$$XMMRegister, $src$$Register);
       __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
@@ -4124,7 +4091,7 @@ instruct ReplL_reg(vec dst, eRegL src, vec tmp) %{
 %}
 
 instruct ReplL_reg_leg(legVec dst, eRegL src, legVec tmp) %{
-  predicate(vector_length(n) == 8);
+  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
   format %{ "replicateL $dst,$src" %}
@@ -4152,7 +4119,7 @@ instruct ReplL_mem(vec dst, memory mem) %{
   match(Set dst (ReplicateL (LoadL mem)));
   format %{ "replicateL $dst,$mem" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ movq($dst$$XMMRegister, $mem$$Address);
       __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
@@ -4170,7 +4137,7 @@ instruct ReplL_imm(vec dst, immL con) %{
   match(Set dst (ReplicateL con));
   format %{ "replicateL $dst,$con" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     InternalAddress const_addr = $constantaddress($con);
     if (vlen == 2) {
       __ movq($dst$$XMMRegister, const_addr);
@@ -4189,7 +4156,7 @@ instruct ReplL_zero(vec dst, immL0 zero) %{
   match(Set dst (ReplicateL zero));
   format %{ "replicateL $dst,$zero" %}
   ins_encode %{
-    int vlen = vector_length(this);
+    int vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
     } else {
@@ -4218,7 +4185,7 @@ instruct ReplF_reg(vec dst, vlRegF src) %{
   match(Set dst (ReplicateF src));
   format %{ "replicateF $dst,$src" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 4) {
       __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
    } else if (VM_Version::supports_avx2()) {
@@ -4237,7 +4204,7 @@ instruct ReplF_mem(vec dst, memory mem) %{
   match(Set dst (ReplicateF (LoadF mem)));
   format %{ "replicateF $dst,$mem" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 4) {
       __ movdl($dst$$XMMRegister, $mem$$Address);
       __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
@@ -4254,7 +4221,7 @@ instruct ReplF_zero(vec dst, immF0 zero) %{
   match(Set dst (ReplicateF zero));
   format %{ "replicateF $dst,$zero" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 4) {
       __ xorps($dst$$XMMRegister, $dst$$XMMRegister);
     } else {
@@ -4272,7 +4239,7 @@ instruct ReplD_reg(vec dst, vlRegD src) %{
   match(Set dst (ReplicateD src));
   format %{ "replicateD $dst,$src" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x44);
     } else if (VM_Version::supports_avx2()) {
@@ -4291,7 +4258,7 @@ instruct ReplD_mem(vec dst, memory mem) %{
   match(Set dst (ReplicateD (LoadD mem)));
   format %{ "replicateD $dst,$mem" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ movq($dst$$XMMRegister, $mem$$Address);
       __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x44);
@@ -4308,7 +4275,7 @@ instruct ReplD_zero(vec dst, immD0 zero) %{
   match(Set dst (ReplicateD zero));
   format %{ "replicateD $dst,$zero" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ xorpd($dst$$XMMRegister, $dst$$XMMRegister);
     } else {
@@ -4322,17 +4289,17 @@ instruct ReplD_zero(vec dst, immD0 zero) %{
 // ====================VECTOR INSERT=======================================
 
 instruct insert(vec dst, rRegI val, immU8 idx) %{
-  predicate(vector_length_in_bytes(n) < 32);
+  predicate(Matcher::vector_length_in_bytes(n) < 32);
   match(Set dst (VectorInsert (Binary dst val) idx));
   format %{ "vector_insert $dst,$val,$idx" %}
   ins_encode %{
     assert(UseSSE >= 4, "required");
-    assert(vector_length_in_bytes(this) >= 8, "required");
+    assert(Matcher::vector_length_in_bytes(this) >= 8, "required");
 
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
     assert(is_integral_type(elem_bt), "");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     __ insert(elem_bt, $dst$$XMMRegister, $val$$Register, $idx$$constant);
   %}
@@ -4340,18 +4307,18 @@ instruct insert(vec dst, rRegI val, immU8 idx) %{
 %}
 
 instruct insert32(vec dst, vec src, rRegI val, immU8 idx, vec vtmp) %{
-  predicate(vector_length_in_bytes(n) == 32);
+  predicate(Matcher::vector_length_in_bytes(n) == 32);
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP vtmp);
   format %{ "vector_insert $dst,$src,$val,$idx\t!using $vtmp as TEMP" %}
   ins_encode %{
     int vlen_enc = Assembler::AVX_256bit;
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
     int elem_per_lane = 16/type2aelembytes(elem_bt);
     int log2epr = log2(elem_per_lane);
 
     assert(is_integral_type(elem_bt), "sanity");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     uint x_idx = $idx$$constant & right_n_bits(log2epr);
     uint y_idx = ($idx$$constant >> log2epr) & 1;
@@ -4363,19 +4330,19 @@ instruct insert32(vec dst, vec src, rRegI val, immU8 idx, vec vtmp) %{
 %}
 
 instruct insert64(vec dst, vec src, rRegI val, immU8 idx, legVec vtmp) %{
-  predicate(vector_length_in_bytes(n) == 64);
+  predicate(Matcher::vector_length_in_bytes(n) == 64);
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP vtmp);
   format %{ "vector_insert $dst,$src,$val,$idx\t!using $vtmp as TEMP" %}
   ins_encode %{
     assert(UseAVX > 2, "sanity");
 
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
     int elem_per_lane = 16/type2aelembytes(elem_bt);
     int log2epr = log2(elem_per_lane);
 
     assert(is_integral_type(elem_bt), "");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     uint x_idx = $idx$$constant & right_n_bits(log2epr);
     uint y_idx = ($idx$$constant >> log2epr) & 3;
@@ -4388,13 +4355,13 @@ instruct insert64(vec dst, vec src, rRegI val, immU8 idx, legVec vtmp) %{
 
 #ifdef _LP64
 instruct insert2L(vec dst, rRegL val, immU8 idx) %{
-  predicate(vector_length(n) == 2);
+  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (VectorInsert (Binary dst val) idx));
   format %{ "vector_insert $dst,$val,$idx" %}
   ins_encode %{
     assert(UseSSE >= 4, "required");
-    assert(vector_element_basic_type(this) == T_LONG, "");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_LONG, "");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     __ pinsrq($dst$$XMMRegister, $val$$Register, $idx$$constant);
   %}
@@ -4402,13 +4369,13 @@ instruct insert2L(vec dst, rRegL val, immU8 idx) %{
 %}
 
 instruct insert4L(vec dst, vec src, rRegL val, immU8 idx, vec vtmp) %{
-  predicate(vector_length(n) == 4);
+  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP vtmp);
   format %{ "vector_insert $dst,$src,$val,$idx\t!using $vtmp as TEMP" %}
   ins_encode %{
-    assert(vector_element_basic_type(this) == T_LONG, "");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_LONG, "");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     uint x_idx = $idx$$constant & right_n_bits(1);
     uint y_idx = ($idx$$constant >> 1) & 1;
@@ -4421,13 +4388,13 @@ instruct insert4L(vec dst, vec src, rRegL val, immU8 idx, vec vtmp) %{
 %}
 
 instruct insert8L(vec dst, vec src, rRegL val, immU8 idx, legVec vtmp) %{
-  predicate(vector_length(n) == 8);
+  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP vtmp);
   format %{ "vector_insert $dst,$src,$val,$idx\t!using $vtmp as TEMP" %}
   ins_encode %{
-    assert(vector_element_basic_type(this) == T_LONG, "sanity");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_LONG, "sanity");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     uint x_idx = $idx$$constant & right_n_bits(1);
     uint y_idx = ($idx$$constant >> 1) & 3;
@@ -4440,14 +4407,14 @@ instruct insert8L(vec dst, vec src, rRegL val, immU8 idx, legVec vtmp) %{
 #endif
 
 instruct insertF(vec dst, regF val, immU8 idx) %{
-  predicate(vector_length(n) < 8);
+  predicate(Matcher::vector_length(n) < 8);
   match(Set dst (VectorInsert (Binary dst val) idx));
   format %{ "vector_insert $dst,$val,$idx" %}
   ins_encode %{
     assert(UseSSE >= 4, "sanity");
 
-    assert(vector_element_basic_type(this) == T_FLOAT, "sanity");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_FLOAT, "sanity");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     __ insertps($dst$$XMMRegister, $val$$XMMRegister, $idx$$constant);
   %}
@@ -4455,15 +4422,15 @@ instruct insertF(vec dst, regF val, immU8 idx) %{
 %}
 
 instruct vinsertF(vec dst, vec src, regF val, immU8 idx, vec vtmp) %{
-  predicate(vector_length(n) >= 8);
+  predicate(Matcher::vector_length(n) >= 8);
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP vtmp);
   format %{ "vector_insert $dst,$src,$val,$idx\t!using $vtmp as TEMP" %}
   ins_encode %{
-    assert(vector_element_basic_type(this) == T_FLOAT, "sanity");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_FLOAT, "sanity");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
-    int vlen = vector_length(this);
+    int vlen = Matcher::vector_length(this);
     uint x_idx = $idx$$constant & right_n_bits(2);
     if (vlen == 8) {
       uint y_idx = ($idx$$constant >> 2) & 1;
@@ -4484,14 +4451,14 @@ instruct vinsertF(vec dst, vec src, regF val, immU8 idx, vec vtmp) %{
 
 #ifdef _LP64
 instruct insert2D(vec dst, regD val, immU8 idx, rRegL tmp) %{
-  predicate(vector_length(n) == 2);
+  predicate(Matcher::vector_length(n) == 2);
   match(Set dst (VectorInsert (Binary dst val) idx));
   effect(TEMP tmp);
   format %{ "vector_insert $dst,$val,$idx\t!using $tmp as TEMP" %}
   ins_encode %{
     assert(UseSSE >= 4, "sanity");
-    assert(vector_element_basic_type(this) == T_DOUBLE, "sanity");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_DOUBLE, "sanity");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     __ movq($tmp$$Register, $val$$XMMRegister);
     __ pinsrq($dst$$XMMRegister, $tmp$$Register, $idx$$constant);
@@ -4500,13 +4467,13 @@ instruct insert2D(vec dst, regD val, immU8 idx, rRegL tmp) %{
 %}
 
 instruct insert4D(vec dst, vec src, regD val, immU8 idx, rRegL tmp, vec vtmp) %{
-  predicate(vector_length(n) == 4);
+  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP vtmp, TEMP tmp);
   format %{ "vector_insert $dst,$src,$val,$idx\t!using $tmp, $vtmp as TEMP" %}
   ins_encode %{
-    assert(vector_element_basic_type(this) == T_DOUBLE, "sanity");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_DOUBLE, "sanity");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     uint x_idx = $idx$$constant & right_n_bits(1);
     uint y_idx = ($idx$$constant >> 1) & 1;
@@ -4520,13 +4487,13 @@ instruct insert4D(vec dst, vec src, regD val, immU8 idx, rRegL tmp, vec vtmp) %{
 %}
 
 instruct insert8D(vec dst, vec src, regD val, immI idx, rRegL tmp, legVec vtmp) %{
-  predicate(vector_length(n) == 8);
+  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (VectorInsert (Binary src val) idx));
   effect(TEMP tmp, TEMP vtmp);
   format %{ "vector_insert $dst,$src,$val,$idx\t!using $vtmp as TEMP" %}
   ins_encode %{
-    assert(vector_element_basic_type(this) == T_DOUBLE, "sanity");
-    assert($idx$$constant < (int)vector_length(this), "out of bounds");
+    assert(Matcher::vector_element_basic_type(this) == T_DOUBLE, "sanity");
+    assert($idx$$constant < (int)Matcher::vector_length(this), "out of bounds");
 
     uint x_idx = $idx$$constant & right_n_bits(1);
     uint y_idx = ($idx$$constant >> 1) & 3;
@@ -4544,7 +4511,7 @@ instruct insert8D(vec dst, vec src, regD val, immI idx, rRegL tmp, legVec vtmp) 
 // =======================Int Reduction==========================================
 
 instruct reductionI(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_INT); // src2
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_INT); // src2
   match(Set dst (AddReductionVI src1 src2));
   match(Set dst (MulReductionVI src1 src2));
   match(Set dst (AndReductionV  src1 src2));
@@ -4556,7 +4523,7 @@ instruct reductionI(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtm
   format %{ "vector_reduction_int $dst,$src1,$src2 ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceI(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -4566,7 +4533,7 @@ instruct reductionI(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtm
 
 #ifdef _LP64
 instruct reductionL(rRegL dst, rRegL src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_LONG && !VM_Version::supports_avx512dq());
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG && !VM_Version::supports_avx512dq());
   match(Set dst (AddReductionVL src1 src2));
   match(Set dst (MulReductionVL src1 src2));
   match(Set dst (AndReductionV  src1 src2));
@@ -4578,14 +4545,14 @@ instruct reductionL(rRegL dst, rRegL src1, legVec src2, legVec vtmp1, legVec vtm
   format %{ "vector_reduction_long $dst,$src1,$src2 ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceL(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct reductionL_avx512dq(rRegL dst, rRegL src1, vec src2, vec vtmp1, vec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_LONG && VM_Version::supports_avx512dq());
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_LONG && VM_Version::supports_avx512dq());
   match(Set dst (AddReductionVL src1 src2));
   match(Set dst (MulReductionVL src1 src2));
   match(Set dst (AndReductionV  src1 src2));
@@ -4597,7 +4564,7 @@ instruct reductionL_avx512dq(rRegL dst, rRegL src1, vec src2, vec vtmp1, vec vtm
   format %{ "vector_reduction_long $dst,$src1,$src2 ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceL(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -4607,42 +4574,42 @@ instruct reductionL_avx512dq(rRegL dst, rRegL src1, vec src2, vec vtmp1, vec vtm
 // =======================Float Reduction==========================================
 
 instruct reductionF128(regF dst, vec src, vec vtmp) %{
-  predicate(vector_length(n->in(2)) <= 4); // src
+  predicate(Matcher::vector_length(n->in(2)) <= 4); // src
   match(Set dst (AddReductionVF dst src));
   match(Set dst (MulReductionVF dst src));
   effect(TEMP dst, TEMP vtmp);
   format %{ "vector_reduction_float  $dst,$src ; using $vtmp as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduce_fp(opcode, vlen, $dst$$XMMRegister, $src$$XMMRegister, $vtmp$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct reduction8F(regF dst, vec src, vec vtmp1, vec vtmp2) %{
-  predicate(vector_length(n->in(2)) == 8); // src
+  predicate(Matcher::vector_length(n->in(2)) == 8); // src
   match(Set dst (AddReductionVF dst src));
   match(Set dst (MulReductionVF dst src));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2);
   format %{ "vector_reduction_float $dst,$src ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduce_fp(opcode, vlen, $dst$$XMMRegister, $src$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct reduction16F(regF dst, legVec src, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_length(n->in(2)) == 16); // src
+  predicate(Matcher::vector_length(n->in(2)) == 16); // src
   match(Set dst (AddReductionVF dst src));
   match(Set dst (MulReductionVF dst src));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2);
   format %{ "vector_reduction_float $dst,$src ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduce_fp(opcode, vlen, $dst$$XMMRegister, $src$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -4651,42 +4618,42 @@ instruct reduction16F(regF dst, legVec src, legVec vtmp1, legVec vtmp2) %{
 // =======================Double Reduction==========================================
 
 instruct reduction2D(regD dst, vec src, vec vtmp) %{
-  predicate(vector_length(n->in(2)) == 2); // src
+  predicate(Matcher::vector_length(n->in(2)) == 2); // src
   match(Set dst (AddReductionVD dst src));
   match(Set dst (MulReductionVD dst src));
   effect(TEMP dst, TEMP vtmp);
   format %{ "vector_reduction_double $dst,$src ; using $vtmp as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduce_fp(opcode, vlen, $dst$$XMMRegister, $src$$XMMRegister, $vtmp$$XMMRegister);
 %}
   ins_pipe( pipe_slow );
 %}
 
 instruct reduction4D(regD dst, vec src, vec vtmp1, vec vtmp2) %{
-  predicate(vector_length(n->in(2)) == 4); // src
+  predicate(Matcher::vector_length(n->in(2)) == 4); // src
   match(Set dst (AddReductionVD dst src));
   match(Set dst (MulReductionVD dst src));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2);
   format %{ "vector_reduction_double $dst,$src ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduce_fp(opcode, vlen, $dst$$XMMRegister, $src$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct reduction8D(regD dst, legVec src, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_length(n->in(2)) == 8); // src
+  predicate(Matcher::vector_length(n->in(2)) == 8); // src
   match(Set dst (AddReductionVD dst src));
   match(Set dst (MulReductionVD dst src));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2);
   format %{ "vector_reduction_double $dst,$src ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduce_fp(opcode, vlen, $dst$$XMMRegister, $src$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -4696,7 +4663,7 @@ instruct reduction8D(regD dst, legVec src, legVec vtmp1, legVec vtmp2) %{
 
 #ifdef _LP64
 instruct reductionB(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_BYTE && !VM_Version::supports_avx512bw());
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE && !VM_Version::supports_avx512bw());
   match(Set dst (AddReductionVI src1 src2));
   match(Set dst (AndReductionV  src1 src2));
   match(Set dst ( OrReductionV  src1 src2));
@@ -4707,14 +4674,14 @@ instruct reductionB(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtm
   format %{ "vector_reduction_byte $dst,$src1,$src2 ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceB(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct reductionB_avx512bw(rRegI dst, rRegI src1, vec src2, vec vtmp1, vec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_BYTE && VM_Version::supports_avx512bw());
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE && VM_Version::supports_avx512bw());
   match(Set dst (AddReductionVI src1 src2));
   match(Set dst (AndReductionV  src1 src2));
   match(Set dst ( OrReductionV  src1 src2));
@@ -4725,7 +4692,7 @@ instruct reductionB_avx512bw(rRegI dst, rRegI src1, vec src2, vec vtmp1, vec vtm
   format %{ "vector_reduction_byte $dst,$src1,$src2 ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceB(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -4735,7 +4702,7 @@ instruct reductionB_avx512bw(rRegI dst, rRegI src1, vec src2, vec vtmp1, vec vtm
 // =======================Short Reduction==========================================
 
 instruct reductionS(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_SHORT); // src2
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_SHORT); // src2
   match(Set dst (AddReductionVI src1 src2));
   match(Set dst (MulReductionVI src1 src2));
   match(Set dst (AndReductionV  src1 src2));
@@ -4747,7 +4714,7 @@ instruct reductionS(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtm
   format %{ "vector_reduction_short $dst,$src1,$src2 ; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceS(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -4756,28 +4723,28 @@ instruct reductionS(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtm
 // =======================Mul Reduction==========================================
 
 instruct mul_reductionB(rRegI dst, rRegI src1, vec src2, vec vtmp1, vec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_BYTE &&
-            vector_length(n->in(2)) <= 32); // src2
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE &&
+            Matcher::vector_length(n->in(2)) <= 32); // src2
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2);
   format %{ "vector_mul_reduction_byte $dst,$src1,$src2; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ mulreduceB(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct mul_reduction64B(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legVec vtmp2) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_BYTE &&
-            vector_length(n->in(2)) == 64); // src2
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_BYTE &&
+            Matcher::vector_length(n->in(2)) == 64); // src2
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2);
   format %{ "vector_mul_reduction_byte $dst,$src1,$src2; using $vtmp1, $vtmp2 as TEMP" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ mulreduceB(opcode, vlen, $dst$$Register, $src1$$Register, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
@@ -4787,10 +4754,10 @@ instruct mul_reduction64B(rRegI dst, rRegI src1, legVec src2, legVec vtmp1, legV
 // Float Min Reduction
 instruct minmax_reduction2F(legRegF dst, immF src1, legVec src2, legVec tmp,
                             legVec atmp, legVec btmp, legVec xmm_1, rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_FLOAT &&
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeF::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeF::NEG_INF)) &&
-            vector_length(n->in(2)) == 2);
+            Matcher::vector_length(n->in(2)) == 2);
   match(Set dst (MinReductionV src1 src2));
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP dst, TEMP tmp, TEMP atmp, TEMP btmp, TEMP xmm_1, KILL cr);
@@ -4799,7 +4766,7 @@ instruct minmax_reduction2F(legRegF dst, immF src1, legVec src2, legVec tmp,
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceFloatMinMax(opcode, vlen, false, $dst$$XMMRegister, $src2$$XMMRegister, $tmp$$XMMRegister,
                          $atmp$$XMMRegister, $btmp$$XMMRegister, $xmm_1$$XMMRegister);
   %}
@@ -4808,10 +4775,10 @@ instruct minmax_reduction2F(legRegF dst, immF src1, legVec src2, legVec tmp,
 
 instruct minmax_reductionF(legRegF dst, immF src1, legVec src2, legVec tmp, legVec atmp,
                            legVec btmp, legVec xmm_0, legVec xmm_1, rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_FLOAT &&
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeF::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeF::NEG_INF)) &&
-            vector_length(n->in(2)) >= 4);
+            Matcher::vector_length(n->in(2)) >= 4);
   match(Set dst (MinReductionV src1 src2));
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP dst, TEMP tmp, TEMP atmp, TEMP btmp, TEMP xmm_0, TEMP xmm_1, KILL cr);
@@ -4820,7 +4787,7 @@ instruct minmax_reductionF(legRegF dst, immF src1, legVec src2, legVec tmp, legV
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceFloatMinMax(opcode, vlen, false, $dst$$XMMRegister, $src2$$XMMRegister, $tmp$$XMMRegister,
                          $atmp$$XMMRegister, $btmp$$XMMRegister, $xmm_0$$XMMRegister, $xmm_1$$XMMRegister);
   %}
@@ -4829,8 +4796,8 @@ instruct minmax_reductionF(legRegF dst, immF src1, legVec src2, legVec tmp, legV
 
 instruct minmax_reduction2F_av(legRegF dst, legVec src, legVec tmp,
                                legVec atmp, legVec btmp, legVec xmm_1, rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_FLOAT &&
-            vector_length(n->in(2)) == 2);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
+            Matcher::vector_length(n->in(2)) == 2);
   match(Set dst (MinReductionV dst src));
   match(Set dst (MaxReductionV dst src));
   effect(TEMP dst, TEMP tmp, TEMP atmp, TEMP btmp, TEMP xmm_1, KILL cr);
@@ -4839,7 +4806,7 @@ instruct minmax_reduction2F_av(legRegF dst, legVec src, legVec tmp,
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduceFloatMinMax(opcode, vlen, true, $dst$$XMMRegister, $src$$XMMRegister, $tmp$$XMMRegister,
                          $atmp$$XMMRegister, $btmp$$XMMRegister, $xmm_1$$XMMRegister);
   %}
@@ -4849,8 +4816,8 @@ instruct minmax_reduction2F_av(legRegF dst, legVec src, legVec tmp,
 
 instruct minmax_reductionF_av(legRegF dst, legVec src, legVec tmp,
                               legVec atmp, legVec btmp, legVec xmm_0, legVec xmm_1, rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_FLOAT &&
-            vector_length(n->in(2)) >= 4);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_FLOAT &&
+            Matcher::vector_length(n->in(2)) >= 4);
   match(Set dst (MinReductionV dst src));
   match(Set dst (MaxReductionV dst src));
   effect(TEMP dst, TEMP tmp, TEMP atmp, TEMP btmp, TEMP xmm_0, TEMP xmm_1, KILL cr);
@@ -4859,7 +4826,7 @@ instruct minmax_reductionF_av(legRegF dst, legVec src, legVec tmp,
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduceFloatMinMax(opcode, vlen, true, $dst$$XMMRegister, $src$$XMMRegister, $tmp$$XMMRegister,
                          $atmp$$XMMRegister, $btmp$$XMMRegister, $xmm_0$$XMMRegister, $xmm_1$$XMMRegister);
   %}
@@ -4871,10 +4838,10 @@ instruct minmax_reductionF_av(legRegF dst, legVec src, legVec tmp,
 instruct minmax_reduction2D(legRegD dst, immD src1, legVec src2,
                             legVec tmp1, legVec tmp2, legVec tmp3, legVec tmp4, // TEMPs
                             rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_DOUBLE &&
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeD::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeD::NEG_INF)) &&
-            vector_length(n->in(2)) == 2);
+            Matcher::vector_length(n->in(2)) == 2);
   match(Set dst (MinReductionV src1 src2));
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL cr);
@@ -4883,7 +4850,7 @@ instruct minmax_reduction2D(legRegD dst, immD src1, legVec src2,
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceDoubleMinMax(opcode, vlen, false, $dst$$XMMRegister, $src2$$XMMRegister,
                           $tmp1$$XMMRegister, $tmp2$$XMMRegister, $tmp3$$XMMRegister, $tmp4$$XMMRegister);
   %}
@@ -4893,10 +4860,10 @@ instruct minmax_reduction2D(legRegD dst, immD src1, legVec src2,
 instruct minmax_reductionD(legRegD dst, immD src1, legVec src2,
                            legVec tmp1, legVec tmp2, legVec tmp3, legVec tmp4, legVec tmp5, // TEMPs
                            rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_DOUBLE &&
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
             ((n->Opcode() == Op_MinReductionV && n->in(1)->bottom_type() == TypeD::POS_INF) ||
              (n->Opcode() == Op_MaxReductionV && n->in(1)->bottom_type() == TypeD::NEG_INF)) &&
-            vector_length(n->in(2)) >= 4);
+            Matcher::vector_length(n->in(2)) >= 4);
   match(Set dst (MinReductionV src1 src2));
   match(Set dst (MaxReductionV src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, TEMP tmp5, KILL cr);
@@ -4905,7 +4872,7 @@ instruct minmax_reductionD(legRegD dst, immD src1, legVec src2,
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src2);
+    int vlen = Matcher::vector_length(this, $src2);
     __ reduceDoubleMinMax(opcode, vlen, false, $dst$$XMMRegister, $src2$$XMMRegister,
                           $tmp1$$XMMRegister, $tmp2$$XMMRegister, $tmp3$$XMMRegister, $tmp4$$XMMRegister, $tmp5$$XMMRegister);
   %}
@@ -4916,8 +4883,8 @@ instruct minmax_reductionD(legRegD dst, immD src1, legVec src2,
 instruct minmax_reduction2D_av(legRegD dst, legVec src,
                                legVec tmp1, legVec tmp2, legVec tmp3, legVec tmp4, // TEMPs
                                rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_DOUBLE &&
-            vector_length(n->in(2)) == 2);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
+            Matcher::vector_length(n->in(2)) == 2);
   match(Set dst (MinReductionV dst src));
   match(Set dst (MaxReductionV dst src));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL cr);
@@ -4926,7 +4893,7 @@ instruct minmax_reduction2D_av(legRegD dst, legVec src,
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduceDoubleMinMax(opcode, vlen, true, $dst$$XMMRegister, $src$$XMMRegister,
                           $tmp1$$XMMRegister, $tmp2$$XMMRegister, $tmp3$$XMMRegister, $tmp4$$XMMRegister);
   %}
@@ -4936,8 +4903,8 @@ instruct minmax_reduction2D_av(legRegD dst, legVec src,
 instruct minmax_reductionD_av(legRegD dst, legVec src,
                               legVec tmp1, legVec tmp2, legVec tmp3, legVec tmp4, legVec tmp5, // TEMPs
                               rFlagsReg cr) %{
-  predicate(vector_element_basic_type(n->in(2)) == T_DOUBLE &&
-            vector_length(n->in(2)) >= 4);
+  predicate(Matcher::vector_element_basic_type(n->in(2)) == T_DOUBLE &&
+            Matcher::vector_length(n->in(2)) >= 4);
   match(Set dst (MinReductionV dst src));
   match(Set dst (MaxReductionV dst src));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, TEMP tmp5, KILL cr);
@@ -4946,7 +4913,7 @@ instruct minmax_reductionD_av(legRegD dst, legVec src,
     assert(UseAVX > 0, "sanity");
 
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this, $src);
+    int vlen = Matcher::vector_length(this, $src);
     __ reduceDoubleMinMax(opcode, vlen, true, $dst$$XMMRegister, $src$$XMMRegister,
                           $tmp1$$XMMRegister, $tmp2$$XMMRegister, $tmp3$$XMMRegister, $tmp4$$XMMRegister, $tmp5$$XMMRegister);
   %}
@@ -4981,7 +4948,7 @@ instruct vaddB_reg(vec dst, vec src1, vec src2) %{
 
 instruct vaddB_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-    (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVB src (LoadVector mem)));
   format %{ "vpaddb  $dst,$src,$mem\t! add packedB" %}
   ins_encode %{
@@ -5015,7 +4982,7 @@ instruct vaddS_reg(vec dst, vec src1, vec src2) %{
 
 instruct vaddS_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-    (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVS src (LoadVector mem)));
   format %{ "vpaddw  $dst,$src,$mem\t! add packedS" %}
   ins_encode %{
@@ -5050,7 +5017,7 @@ instruct vaddI_reg(vec dst, vec src1, vec src2) %{
 
 instruct vaddI_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVI src (LoadVector mem)));
   format %{ "vpaddd  $dst,$src,$mem\t! add packedI" %}
   ins_encode %{
@@ -5084,7 +5051,7 @@ instruct vaddL_reg(vec dst, vec src1, vec src2) %{
 
 instruct vaddL_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVL src (LoadVector mem)));
   format %{ "vpaddq  $dst,$src,$mem\t! add packedL" %}
   ins_encode %{
@@ -5118,7 +5085,7 @@ instruct vaddF_reg(vec dst, vec src1, vec src2) %{
 
 instruct vaddF_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVF src (LoadVector mem)));
   format %{ "vaddps  $dst,$src,$mem\t! add packedF" %}
   ins_encode %{
@@ -5152,7 +5119,7 @@ instruct vaddD_reg(vec dst, vec src1, vec src2) %{
 
 instruct vaddD_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVD src (LoadVector mem)));
   format %{ "vaddpd  $dst,$src,$mem\t! add packedD" %}
   ins_encode %{
@@ -5188,7 +5155,7 @@ instruct vsubB_reg(vec dst, vec src1, vec src2) %{
 
 instruct vsubB_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVB src (LoadVector mem)));
   format %{ "vpsubb  $dst,$src,$mem\t! sub packedB" %}
   ins_encode %{
@@ -5223,7 +5190,7 @@ instruct vsubS_reg(vec dst, vec src1, vec src2) %{
 
 instruct vsubS_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVS src (LoadVector mem)));
   format %{ "vpsubw  $dst,$src,$mem\t! sub packedS" %}
   ins_encode %{
@@ -5257,7 +5224,7 @@ instruct vsubI_reg(vec dst, vec src1, vec src2) %{
 
 instruct vsubI_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVI src (LoadVector mem)));
   format %{ "vpsubd  $dst,$src,$mem\t! sub packedI" %}
   ins_encode %{
@@ -5292,7 +5259,7 @@ instruct vsubL_reg(vec dst, vec src1, vec src2) %{
 
 instruct vsubL_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVL src (LoadVector mem)));
   format %{ "vpsubq  $dst,$src,$mem\t! sub packedL" %}
   ins_encode %{
@@ -5326,7 +5293,7 @@ instruct vsubF_reg(vec dst, vec src1, vec src2) %{
 
 instruct vsubF_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVF src (LoadVector mem)));
   format %{ "vsubps  $dst,$src,$mem\t! sub packedF" %}
   ins_encode %{
@@ -5360,7 +5327,7 @@ instruct vsubD_reg(vec dst, vec src1, vec src2) %{
 
 instruct vsubD_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVD src (LoadVector mem)));
   format %{ "vsubpd  $dst,$src,$mem\t! sub packedD" %}
   ins_encode %{
@@ -5374,8 +5341,8 @@ instruct vsubD_mem(vec dst, vec src, memory mem) %{
 
 // Byte vector mul
 instruct mulB_reg(vec dst, vec src1, vec src2, vec tmp, rRegI scratch) %{
-  predicate(vector_length(n) == 4 ||
-            vector_length(n) == 8);
+  predicate(Matcher::vector_length(n) == 4 ||
+            Matcher::vector_length(n) == 8);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp, TEMP scratch);
   format %{"vector_mulB $dst,$src1,$src2" %}
@@ -5392,7 +5359,7 @@ instruct mulB_reg(vec dst, vec src1, vec src2, vec tmp, rRegI scratch) %{
 %}
 
 instruct mul16B_reg(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI scratch) %{
-  predicate(vector_length(n) == 16 && UseAVX <= 1);
+  predicate(Matcher::vector_length(n) == 16 && UseAVX <= 1);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP scratch);
   format %{"vector_mulB $dst,$src1,$src2" %}
@@ -5415,7 +5382,7 @@ instruct mul16B_reg(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI scrat
 %}
 
 instruct vmul16B_reg_avx(vec dst, vec src1, vec src2, vec tmp, rRegI scratch) %{
-  predicate(vector_length(n) == 16 && UseAVX > 1);
+  predicate(Matcher::vector_length(n) == 16 && UseAVX > 1);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp, TEMP scratch);
   format %{"vector_mulB $dst,$src1,$src2" %}
@@ -5433,7 +5400,7 @@ instruct vmul16B_reg_avx(vec dst, vec src1, vec src2, vec tmp, rRegI scratch) %{
 %}
 
 instruct vmul32B_reg_avx(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI scratch) %{
-  predicate(vector_length(n) == 32);
+  predicate(Matcher::vector_length(n) == 32);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP scratch);
   format %{"vector_mulB $dst,$src1,$src2" %}
@@ -5459,7 +5426,7 @@ instruct vmul32B_reg_avx(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI 
 %}
 
 instruct vmul64B_reg_avx(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI scratch) %{
-  predicate(vector_length(n) == 64);
+  predicate(Matcher::vector_length(n) == 64);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP scratch);
   format %{"vector_mulB $dst,$src1,$src2\n\t" %}
@@ -5509,7 +5476,7 @@ instruct vmulS_reg(vec dst, vec src1, vec src2) %{
 
 instruct vmulS_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVS src (LoadVector mem)));
   format %{ "vpmullw $dst,$src,$mem\t! mul packedS" %}
   ins_encode %{
@@ -5544,7 +5511,7 @@ instruct vmulI_reg(vec dst, vec src1, vec src2) %{
 
 instruct vmulI_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVI src (LoadVector mem)));
   format %{ "vpmulld $dst,$src,$mem\t! mul packedI" %}
   ins_encode %{
@@ -5569,7 +5536,7 @@ instruct vmulL_reg(vec dst, vec src1, vec src2) %{
 
 instruct vmulL_mem(vec dst, vec src, memory mem) %{
   predicate(VM_Version::supports_avx512dq() &&
-              (vector_length_in_bytes(n->in(1)) > 8));
+              (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVL src (LoadVector mem)));
   format %{ "vpmullq $dst,$src,$mem\t! mul packedL" %}
   ins_encode %{
@@ -5581,7 +5548,7 @@ instruct vmulL_mem(vec dst, vec src, memory mem) %{
 %}
 
 instruct mul2L_reg(vec dst, vec src2, legVec tmp) %{
-  predicate(vector_length(n) == 2 && !VM_Version::supports_avx512dq());
+  predicate(Matcher::vector_length(n) == 2 && !VM_Version::supports_avx512dq());
   match(Set dst (MulVL dst src2));
   effect(TEMP dst, TEMP tmp);
   format %{ "pshufd $tmp,$src2, 177\n\t"
@@ -5607,7 +5574,7 @@ instruct mul2L_reg(vec dst, vec src2, legVec tmp) %{
 %}
 
 instruct vmul4L_reg_avx(vec dst, vec src1, vec src2, legVec tmp, legVec tmp1) %{
-  predicate(vector_length(n) == 4 && !VM_Version::supports_avx512dq());
+  predicate(Matcher::vector_length(n) == 4 && !VM_Version::supports_avx512dq());
   match(Set dst (MulVL src1 src2));
   effect(TEMP tmp1, TEMP tmp);
   format %{ "vpshufd $tmp,$src2\n\t"
@@ -5655,7 +5622,7 @@ instruct vmulF_reg(vec dst, vec src1, vec src2) %{
 
 instruct vmulF_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVF src (LoadVector mem)));
   format %{ "vmulps  $dst,$src,$mem\t! mul packedF" %}
   ins_encode %{
@@ -5689,7 +5656,7 @@ instruct vmulD_reg(vec dst, vec src1, vec src2) %{
 
 instruct vmulD_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVD src (LoadVector mem)));
   format %{ "vmulpd  $dst,$src,$mem\t! mul packedD" %}
   ins_encode %{
@@ -5700,7 +5667,7 @@ instruct vmulD_mem(vec dst, vec src, memory mem) %{
 %}
 
 instruct vcmov8F_reg(legVec dst, legVec src1, legVec src2, immI8 cop, cmpOp_vcmppd copnd) %{
-  predicate(vector_length(n) == 8);
+  predicate(Matcher::vector_length(n) == 8);
   match(Set dst (CMoveVF (Binary copnd cop) (Binary src1 src2)));
   effect(TEMP dst, USE src1, USE src2);
   format %{ "cmpps.$copnd  $dst, $src1, $src2  ! vcmovevf, cond=$cop\n\t"
@@ -5718,7 +5685,7 @@ instruct vcmov8F_reg(legVec dst, legVec src1, legVec src2, immI8 cop, cmpOp_vcmp
 %}
 
 instruct vcmov4D_reg(legVec dst, legVec src1, legVec src2, immI8 cop, cmpOp_vcmppd copnd) %{
-  predicate(vector_length(n) == 4);
+  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (CMoveVD (Binary copnd cop) (Binary src1 src2)));
   effect(TEMP dst, USE src1, USE src2);
   format %{ "cmppd.$copnd  $dst, $src1, $src2  ! vcmovevd, cond=$cop\n\t"
@@ -5761,7 +5728,7 @@ instruct vdivF_reg(vec dst, vec src1, vec src2) %{
 
 instruct vdivF_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (DivVF src (LoadVector mem)));
   format %{ "vdivps  $dst,$src,$mem\t! div packedF" %}
   ins_encode %{
@@ -5795,7 +5762,7 @@ instruct vdivD_reg(vec dst, vec src1, vec src2) %{
 
 instruct vdivD_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (DivVD src (LoadVector mem)));
   format %{ "vdivpd  $dst,$src,$mem\t! div packedD" %}
   ins_encode %{
@@ -5809,7 +5776,7 @@ instruct vdivD_mem(vec dst, vec src, memory mem) %{
 
 // Byte, Short, Int vector Min/Max
 instruct minmax_reg_sse(vec dst, vec src) %{
-  predicate(is_integral_type(vector_element_basic_type(n)) && vector_element_basic_type(n) != T_LONG && // T_BYTE, T_SHORT, T_INT
+  predicate(is_integral_type(Matcher::vector_element_basic_type(n)) && Matcher::vector_element_basic_type(n) != T_LONG && // T_BYTE, T_SHORT, T_INT
             UseAVX == 0);
   match(Set dst (MinV dst src));
   match(Set dst (MaxV dst src));
@@ -5818,14 +5785,14 @@ instruct minmax_reg_sse(vec dst, vec src) %{
     assert(UseSSE >= 4, "required");
 
     int opcode = this->ideal_Opcode();
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
     __ pminmax(opcode, elem_bt, $dst$$XMMRegister, $src$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct vminmax_reg(vec dst, vec src1, vec src2) %{
-  predicate(is_integral_type(vector_element_basic_type(n)) && vector_element_basic_type(n) != T_LONG && // T_BYTE, T_SHORT, T_INT
+  predicate(is_integral_type(Matcher::vector_element_basic_type(n)) && Matcher::vector_element_basic_type(n) != T_LONG && // T_BYTE, T_SHORT, T_INT
             UseAVX > 0);
   match(Set dst (MinV src1 src2));
   match(Set dst (MaxV src1 src2));
@@ -5833,7 +5800,7 @@ instruct vminmax_reg(vec dst, vec src1, vec src2) %{
   ins_encode %{
     int opcode = this->ideal_Opcode();
     int vlen_enc = vector_length_encoding(this);
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
     __ vpminmax(opcode, elem_bt, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
   %}
@@ -5842,7 +5809,7 @@ instruct vminmax_reg(vec dst, vec src1, vec src2) %{
 
 // Long vector Min/Max
 instruct minmaxL_reg_sse(vec dst, vec src, rxmm0 tmp) %{
-  predicate(vector_length_in_bytes(n) == 16 && vector_element_basic_type(n) == T_LONG &&
+  predicate(Matcher::vector_length_in_bytes(n) == 16 && Matcher::vector_element_basic_type(n) == T_LONG &&
             UseAVX == 0);
   match(Set dst (MinV dst src));
   match(Set dst (MaxV src dst));
@@ -5852,7 +5819,7 @@ instruct minmaxL_reg_sse(vec dst, vec src, rxmm0 tmp) %{
     assert(UseSSE >= 4, "required");
 
     int opcode = this->ideal_Opcode();
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
     assert(elem_bt == T_LONG, "sanity");
 
     __ pminmax(opcode, elem_bt, $dst$$XMMRegister, $src$$XMMRegister, $tmp$$XMMRegister);
@@ -5861,7 +5828,7 @@ instruct minmaxL_reg_sse(vec dst, vec src, rxmm0 tmp) %{
 %}
 
 instruct vminmaxL_reg_avx(legVec dst, legVec src1, legVec src2) %{
-  predicate(vector_length_in_bytes(n) <= 32 && vector_element_basic_type(n) == T_LONG &&
+  predicate(Matcher::vector_length_in_bytes(n) <= 32 && Matcher::vector_element_basic_type(n) == T_LONG &&
             UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (MinV src1 src2));
   match(Set dst (MaxV src1 src2));
@@ -5870,7 +5837,7 @@ instruct vminmaxL_reg_avx(legVec dst, legVec src1, legVec src2) %{
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
     int opcode = this->ideal_Opcode();
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
     assert(elem_bt == T_LONG, "sanity");
 
     __ vpminmax(opcode, elem_bt, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
@@ -5879,8 +5846,8 @@ instruct vminmaxL_reg_avx(legVec dst, legVec src1, legVec src2) %{
 %}
 
 instruct vminmaxL_reg_evex(vec dst, vec src1, vec src2) %{
-  predicate((vector_length_in_bytes(n) == 64 || VM_Version::supports_avx512vl()) &&
-            vector_element_basic_type(n) == T_LONG);
+  predicate((Matcher::vector_length_in_bytes(n) == 64 || VM_Version::supports_avx512vl()) &&
+            Matcher::vector_element_basic_type(n) == T_LONG);
   match(Set dst (MinV src1 src2));
   match(Set dst (MaxV src1 src2));
   format %{ "vector_minmaxL  $dst,$src1,src2\t! " %}
@@ -5889,7 +5856,7 @@ instruct vminmaxL_reg_evex(vec dst, vec src1, vec src2) %{
 
     int vlen_enc = vector_length_encoding(this);
     int opcode = this->ideal_Opcode();
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
     assert(elem_bt == T_LONG, "sanity");
 
     __ vpminmax(opcode, elem_bt, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
@@ -5899,8 +5866,8 @@ instruct vminmaxL_reg_evex(vec dst, vec src1, vec src2) %{
 
 // Float/Double vector Min/Max
 instruct minmaxFP_reg(legVec dst, legVec a, legVec b, legVec tmp, legVec atmp, legVec btmp) %{
-  predicate(vector_length_in_bytes(n) <= 32 &&
-            is_floating_point_type(vector_element_basic_type(n)) && // T_FLOAT, T_DOUBLE
+  predicate(Matcher::vector_length_in_bytes(n) <= 32 &&
+            is_floating_point_type(Matcher::vector_element_basic_type(n)) && // T_FLOAT, T_DOUBLE
             UseAVX > 0);
   match(Set dst (MinV a b));
   match(Set dst (MaxV a b));
@@ -5911,7 +5878,7 @@ instruct minmaxFP_reg(legVec dst, legVec a, legVec b, legVec tmp, legVec atmp, l
 
     int opcode = this->ideal_Opcode();
     int vlen_enc = vector_length_encoding(this);
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
     __ vminmax_fp(opcode, elem_bt,
                   $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister,
@@ -5921,8 +5888,8 @@ instruct minmaxFP_reg(legVec dst, legVec a, legVec b, legVec tmp, legVec atmp, l
 %}
 
 instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp, kReg ktmp) %{
-  predicate(vector_length_in_bytes(n) == 64 &&
-            is_floating_point_type(vector_element_basic_type(n))); // T_FLOAT, T_DOUBLE
+  predicate(Matcher::vector_length_in_bytes(n) == 64 &&
+            is_floating_point_type(Matcher::vector_element_basic_type(n))); // T_FLOAT, T_DOUBLE
   match(Set dst (MinV a b));
   match(Set dst (MaxV a b));
   effect(TEMP dst, USE a, USE b, TEMP atmp, TEMP btmp, TEMP ktmp);
@@ -5932,7 +5899,7 @@ instruct evminmaxFP_reg_eavx(vec dst, vec a, vec b, vec atmp, vec btmp, kReg ktm
 
     int opcode = this->ideal_Opcode();
     int vlen_enc = vector_length_encoding(this);
-    BasicType elem_bt = vector_element_basic_type(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
     __ evminmax_fp(opcode, elem_bt,
                    $dst$$XMMRegister, $a$$XMMRegister, $b$$XMMRegister,
@@ -5955,7 +5922,7 @@ instruct vsqrtF_reg(vec dst, vec src) %{
 %}
 
 instruct vsqrtF_mem(vec dst, memory mem) %{
-  predicate(vector_length_in_bytes(n->in(1)) > 8);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) > 8);
   match(Set dst (SqrtVF (LoadVector mem)));
   format %{ "vsqrtps  $dst,$mem\t! sqrt packedF" %}
   ins_encode %{
@@ -5979,7 +5946,7 @@ instruct vsqrtD_reg(vec dst, vec src) %{
 %}
 
 instruct vsqrtD_mem(vec dst, memory mem) %{
-  predicate(vector_length_in_bytes(n->in(1)) > 8);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) > 8);
   match(Set dst (SqrtVD (LoadVector mem)));
   format %{ "vsqrtpd  $dst,$mem\t! sqrt packedD" %}
   ins_encode %{
@@ -6006,7 +5973,7 @@ instruct vshiftcnt(vec dst, rRegI cnt) %{
 
 // Byte vector shift
 instruct vshiftB(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
-  predicate(vector_length(n) <= 8 && VectorNode::is_vshift_cnt(n->in(2)));
+  predicate(Matcher::vector_length(n) <= 8 && VectorNode::is_vshift_cnt(n->in(2)));
   match(Set dst ( LShiftVB src shift));
   match(Set dst ( RShiftVB src shift));
   match(Set dst (URShiftVB src shift));
@@ -6026,7 +5993,7 @@ instruct vshiftB(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
 %}
 
 instruct vshift16B(vec dst, vec src, vec shift, vec tmp1, vec tmp2, rRegI scratch) %{
-  predicate(vector_length(n) == 16 && VectorNode::is_vshift_cnt(n->in(2)) &&
+  predicate(Matcher::vector_length(n) == 16 && VectorNode::is_vshift_cnt(n->in(2)) &&
             UseAVX <= 1);
   match(Set dst ( LShiftVB src shift));
   match(Set dst ( RShiftVB src shift));
@@ -6051,7 +6018,7 @@ instruct vshift16B(vec dst, vec src, vec shift, vec tmp1, vec tmp2, rRegI scratc
 %}
 
 instruct vshift16B_avx(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
-  predicate(vector_length(n) == 16 && VectorNode::is_vshift_cnt(n->in(2)) &&
+  predicate(Matcher::vector_length(n) == 16 && VectorNode::is_vshift_cnt(n->in(2)) &&
             UseAVX > 1);
   match(Set dst ( LShiftVB src shift));
   match(Set dst ( RShiftVB src shift));
@@ -6072,7 +6039,7 @@ instruct vshift16B_avx(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
 %}
 
 instruct vshift32B_avx(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
-  predicate(vector_length(n) == 32 && VectorNode::is_vshift_cnt(n->in(2)));
+  predicate(Matcher::vector_length(n) == 32 && VectorNode::is_vshift_cnt(n->in(2)));
   match(Set dst ( LShiftVB src shift));
   match(Set dst ( RShiftVB src shift));
   match(Set dst (URShiftVB src shift));
@@ -6097,7 +6064,7 @@ instruct vshift32B_avx(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
 %}
 
 instruct vshift64B_avx(vec dst, vec src, vec shift, vec tmp1, vec tmp2, rRegI scratch) %{
-  predicate(vector_length(n) == 64 && VectorNode::is_vshift_cnt(n->in(2)));
+  predicate(Matcher::vector_length(n) == 64 && VectorNode::is_vshift_cnt(n->in(2)));
   match(Set dst ( LShiftVB src shift));
   match(Set dst  (RShiftVB src shift));
   match(Set dst (URShiftVB src shift));
@@ -6142,7 +6109,7 @@ instruct vshiftS(vec dst, vec src, vec shift) %{
       int vlen_enc = vector_length_encoding(this);
       __ vshiftw(opcode, $dst$$XMMRegister, $src$$XMMRegister, $shift$$XMMRegister, vlen_enc);
     } else {
-      int vlen = vector_length(this);
+      int vlen = Matcher::vector_length(this);
       if (vlen == 2) {
         __ movflt($dst$$XMMRegister, $src$$XMMRegister);
         __ vshiftw(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
@@ -6173,7 +6140,7 @@ instruct vshiftI(vec dst, vec src, vec shift) %{
       int vlen_enc = vector_length_encoding(this);
       __ vshiftd(opcode, $dst$$XMMRegister, $src$$XMMRegister, $shift$$XMMRegister, vlen_enc);
     } else {
-      int vlen = vector_length(this);
+      int vlen = Matcher::vector_length(this);
       if (vlen == 2) {
         __ movdbl($dst$$XMMRegister, $src$$XMMRegister);
         __ vshiftd(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
@@ -6200,7 +6167,7 @@ instruct vshiftL(vec dst, vec src, vec shift) %{
       int vlen_enc = vector_length_encoding(this);
       __ vshiftq(opcode, $dst$$XMMRegister, $src$$XMMRegister, $shift$$XMMRegister, vlen_enc);
     } else {
-      assert(vector_length(this) == 2, "");
+      assert(Matcher::vector_length(this) == 2, "");
       __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
       __ vshiftq(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
     }
@@ -6216,7 +6183,7 @@ instruct vshiftL_arith_reg(vec dst, vec src, vec shift, vec tmp, rRegI scratch) 
   effect(TEMP dst, TEMP tmp, TEMP scratch);
   format %{ "vshiftq $dst,$src,$shift" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       assert(UseSSE >= 2, "required");
       __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
@@ -6253,7 +6220,7 @@ instruct vshiftL_arith_reg_evex(vec dst, vec src, vec shift) %{
 // ------------------- Variable Shift -----------------------------
 // Byte variable shift
 instruct vshift8B_var_nobw(vec dst, vec src, vec shift, vec vtmp, rRegP scratch) %{
-  predicate(vector_length(n) <= 8 &&
+  predicate(Matcher::vector_length(n) <= 8 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             !VM_Version::supports_avx512bw());
   match(Set dst ( LShiftVB src shift));
@@ -6273,7 +6240,7 @@ instruct vshift8B_var_nobw(vec dst, vec src, vec shift, vec vtmp, rRegP scratch)
 %}
 
 instruct vshift16B_var_nobw(vec dst, vec src, vec shift, vec vtmp1, vec vtmp2, rRegP scratch) %{
-  predicate(vector_length(n) == 16 &&
+  predicate(Matcher::vector_length(n) == 16 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             !VM_Version::supports_avx512bw());
   match(Set dst ( LShiftVB src shift));
@@ -6301,7 +6268,7 @@ instruct vshift16B_var_nobw(vec dst, vec src, vec shift, vec vtmp1, vec vtmp2, r
 %}
 
 instruct vshift32B_var_nobw(vec dst, vec src, vec shift, vec vtmp1, vec vtmp2, vec vtmp3, vec vtmp4, rRegP scratch) %{
-  predicate(vector_length(n) == 32 &&
+  predicate(Matcher::vector_length(n) == 32 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             !VM_Version::supports_avx512bw());
   match(Set dst ( LShiftVB src shift));
@@ -6337,7 +6304,7 @@ instruct vshift32B_var_nobw(vec dst, vec src, vec shift, vec vtmp1, vec vtmp2, v
 %}
 
 instruct vshiftB_var_evex_bw(vec dst, vec src, vec shift, vec vtmp, rRegP scratch) %{
-  predicate(vector_length(n) <= 32 &&
+  predicate(Matcher::vector_length(n) <= 32 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             VM_Version::supports_avx512bw());
   match(Set dst ( LShiftVB src shift));
@@ -6356,7 +6323,7 @@ instruct vshiftB_var_evex_bw(vec dst, vec src, vec shift, vec vtmp, rRegP scratc
 %}
 
 instruct vshift64B_var_evex_bw(vec dst, vec src, vec shift, vec vtmp1, vec vtmp2, rRegP scratch) %{
-  predicate(vector_length(n) == 64 &&
+  predicate(Matcher::vector_length(n) == 64 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             VM_Version::supports_avx512bw());
   match(Set dst ( LShiftVB src shift));
@@ -6380,7 +6347,7 @@ instruct vshift64B_var_evex_bw(vec dst, vec src, vec shift, vec vtmp1, vec vtmp2
 
 // Short variable shift
 instruct vshift8S_var_nobw(vec dst, vec src, vec shift, vec vtmp, rRegP scratch) %{
-  predicate(vector_length(n) <= 8 &&
+  predicate(Matcher::vector_length(n) <= 8 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             !VM_Version::supports_avx512bw());
   match(Set dst ( LShiftVS src shift));
@@ -6405,7 +6372,7 @@ instruct vshift8S_var_nobw(vec dst, vec src, vec shift, vec vtmp, rRegP scratch)
 %}
 
 instruct vshift16S_var_nobw(vec dst, vec src, vec shift, vec vtmp1, vec vtmp2, rRegP scratch) %{
-  predicate(vector_length(n) == 16 &&
+  predicate(Matcher::vector_length(n) == 16 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             !VM_Version::supports_avx512bw());
   match(Set dst ( LShiftVS src shift));
@@ -6495,7 +6462,7 @@ instruct vshiftL_var(vec dst, vec src, vec shift) %{
 
 //Long variable right shift arithmetic
 instruct vshiftL_arith_var(vec dst, vec src, vec shift, vec vtmp) %{
-  predicate(vector_length(n) <= 4 &&
+  predicate(Matcher::vector_length(n) <= 4 &&
             !VectorNode::is_vshift_cnt(n->in(2)) &&
             UseAVX == 2);
   match(Set dst (RShiftVL src shift));
@@ -6548,7 +6515,7 @@ instruct vand_reg(vec dst, vec src1, vec src2) %{
 
 instruct vand_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AndV src (LoadVector mem)));
   format %{ "vpand   $dst,$src,$mem\t! and vectors" %}
   ins_encode %{
@@ -6583,7 +6550,7 @@ instruct vor_reg(vec dst, vec src1, vec src2) %{
 
 instruct vor_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (OrV src (LoadVector mem)));
   format %{ "vpor    $dst,$src,$mem\t! or vectors" %}
   ins_encode %{
@@ -6618,7 +6585,7 @@ instruct vxor_reg(vec dst, vec src1, vec src2) %{
 
 instruct vxor_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) &&
-            (vector_length_in_bytes(n->in(1)) > 8));
+            (Matcher::vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (XorV src (LoadVector mem)));
   format %{ "vpxor   $dst,$src,$mem\t! xor vectors" %}
   ins_encode %{
@@ -6636,7 +6603,7 @@ instruct vcastBtoX(vec dst, vec src) %{
   ins_encode %{
     assert(UseAVX > 0, "required");
 
-    BasicType to_elem_bt = vector_element_basic_type(this);
+    BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
     int vlen_enc = vector_length_encoding(this);
     switch (to_elem_bt) {
       case T_SHORT:
@@ -6665,8 +6632,8 @@ instruct vcastBtoX(vec dst, vec src) %{
 
 instruct castStoX(vec dst, vec src, rRegP scratch) %{
   predicate((UseAVX <= 2 || !VM_Version::supports_avx512vlbw()) &&
-            vector_length(n->in(1)) <= 8 && // src
-            vector_element_basic_type(n) == T_BYTE);
+            Matcher::vector_length(n->in(1)) <= 8 && // src
+            Matcher::vector_element_basic_type(n) == T_BYTE);
   effect(TEMP scratch);
   match(Set dst (VectorCastS2X src));
   format %{ "vector_cast_s2x $dst,$src\t! using $scratch as TEMP" %}
@@ -6681,15 +6648,15 @@ instruct castStoX(vec dst, vec src, rRegP scratch) %{
 
 instruct vcastStoX(vec dst, vec src, vec vtmp, rRegP scratch) %{
   predicate((UseAVX <= 2 || !VM_Version::supports_avx512vlbw()) &&
-            vector_length(n->in(1)) == 16 && // src
-            vector_element_basic_type(n) == T_BYTE);
+            Matcher::vector_length(n->in(1)) == 16 && // src
+            Matcher::vector_element_basic_type(n) == T_BYTE);
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   match(Set dst (VectorCastS2X src));
   format %{ "vector_cast_s2x $dst,$src\t! using $vtmp, $scratch as TEMP" %}
   ins_encode %{
     assert(UseAVX > 0, "required");
 
-    int vlen_enc = vector_length_encoding(vector_length_in_bytes(this, $src));
+    int vlen_enc = vector_length_encoding(Matcher::vector_length_in_bytes(this, $src));
     __ vpand($dst$$XMMRegister, $src$$XMMRegister, ExternalAddress(vector_short_to_byte_mask()), vlen_enc, $scratch$$Register);
     __ vextracti128($vtmp$$XMMRegister, $dst$$XMMRegister, 0x1);
     __ vpackuswb($dst$$XMMRegister, $dst$$XMMRegister, $vtmp$$XMMRegister, 0);
@@ -6699,11 +6666,11 @@ instruct vcastStoX(vec dst, vec src, vec vtmp, rRegP scratch) %{
 
 instruct vcastStoX_evex(vec dst, vec src) %{
   predicate((UseAVX > 2 && VM_Version::supports_avx512vlbw()) ||
-            (vector_length_in_bytes(n) >= vector_length_in_bytes(n->in(1)))); // dst >= src
+            (Matcher::vector_length_in_bytes(n) >= Matcher::vector_length_in_bytes(n->in(1)))); // dst >= src
   match(Set dst (VectorCastS2X src));
   format %{ "vector_cast_s2x $dst,$src\t!" %}
   ins_encode %{
-    BasicType to_elem_bt = vector_element_basic_type(this);
+    BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
     int src_vlen_enc = vector_length_encoding(this, $src);
     int vlen_enc = vector_length_encoding(this);
     switch (to_elem_bt) {
@@ -6736,15 +6703,15 @@ instruct vcastStoX_evex(vec dst, vec src) %{
 
 instruct castItoX(vec dst, vec src, rRegP scratch) %{
   predicate(UseAVX <= 2 &&
-            (vector_length_in_bytes(n->in(1)) <= 16) &&
-            (vector_length_in_bytes(n) < vector_length_in_bytes(n->in(1)))); // dst < src
+            (Matcher::vector_length_in_bytes(n->in(1)) <= 16) &&
+            (Matcher::vector_length_in_bytes(n) < Matcher::vector_length_in_bytes(n->in(1)))); // dst < src
   match(Set dst (VectorCastI2X src));
   format %{ "vector_cast_i2x $dst,$src\t! using $scratch as TEMP" %}
   effect(TEMP scratch);
   ins_encode %{
     assert(UseAVX > 0, "required");
 
-    BasicType to_elem_bt = vector_element_basic_type(this);
+    BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
     int vlen_enc = vector_length_encoding(this, $src);
 
     if (to_elem_bt == T_BYTE) {
@@ -6762,15 +6729,15 @@ instruct castItoX(vec dst, vec src, rRegP scratch) %{
 
 instruct vcastItoX(vec dst, vec src, vec vtmp, rRegP scratch) %{
   predicate(UseAVX <= 2 &&
-            (vector_length_in_bytes(n->in(1)) == 32) &&
-            (vector_length_in_bytes(n) < vector_length_in_bytes(n->in(1)))); // dst < src
+            (Matcher::vector_length_in_bytes(n->in(1)) == 32) &&
+            (Matcher::vector_length_in_bytes(n) < Matcher::vector_length_in_bytes(n->in(1)))); // dst < src
   match(Set dst (VectorCastI2X src));
   format %{ "vector_cast_i2x $dst,$src\t! using $vtmp and $scratch as TEMP" %}
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   ins_encode %{
     assert(UseAVX > 0, "required");
 
-    BasicType to_elem_bt = vector_element_basic_type(this);
+    BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
     int vlen_enc = vector_length_encoding(this, $src);
 
     if (to_elem_bt == T_BYTE) {
@@ -6790,13 +6757,13 @@ instruct vcastItoX(vec dst, vec src, vec vtmp, rRegP scratch) %{
 
 instruct vcastItoX_evex(vec dst, vec src) %{
   predicate(UseAVX > 2 ||
-            (vector_length_in_bytes(n) >= vector_length_in_bytes(n->in(1)))); // dst >= src
+            (Matcher::vector_length_in_bytes(n) >= Matcher::vector_length_in_bytes(n->in(1)))); // dst >= src
   match(Set dst (VectorCastI2X src));
   format %{ "vector_cast_i2x $dst,$src\t!" %}
   ins_encode %{
     assert(UseAVX > 0, "required");
 
-    BasicType dst_elem_bt = vector_element_basic_type(this);
+    BasicType dst_elem_bt = Matcher::vector_element_basic_type(this);
     int src_vlen_enc = vector_length_encoding(this, $src);
     int dst_vlen_enc = vector_length_encoding(this);
     switch (dst_elem_bt) {
@@ -6829,7 +6796,7 @@ instruct vcastItoX_evex(vec dst, vec src) %{
 %}
 
 instruct vcastLtoBS(vec dst, vec src, rRegP scratch) %{
-  predicate((vector_element_basic_type(n) == T_BYTE || vector_element_basic_type(n) == T_SHORT) &&
+  predicate((Matcher::vector_element_basic_type(n) == T_BYTE || Matcher::vector_element_basic_type(n) == T_SHORT) &&
             UseAVX <= 2);
   match(Set dst (VectorCastL2X src));
   effect(TEMP scratch);
@@ -6837,8 +6804,8 @@ instruct vcastLtoBS(vec dst, vec src, rRegP scratch) %{
   ins_encode %{
     assert(UseAVX > 0, "required");
 
-    int vlen = vector_length_in_bytes(this, $src);
-    BasicType to_elem_bt  = vector_element_basic_type(this);
+    int vlen = Matcher::vector_length_in_bytes(this, $src);
+    BasicType to_elem_bt  = Matcher::vector_element_basic_type(this);
     AddressLiteral mask_addr = (to_elem_bt == T_BYTE) ? ExternalAddress(vector_int_to_byte_mask())
                                                       : ExternalAddress(vector_int_to_short_mask());
     if (vlen <= 16) {
@@ -6861,14 +6828,14 @@ instruct vcastLtoBS(vec dst, vec src, rRegP scratch) %{
 
 instruct vcastLtoX_evex(vec dst, vec src) %{
   predicate(UseAVX > 2 ||
-            (vector_element_basic_type(n) == T_INT ||
-             vector_element_basic_type(n) == T_FLOAT ||
-             vector_element_basic_type(n) == T_DOUBLE));
+            (Matcher::vector_element_basic_type(n) == T_INT ||
+             Matcher::vector_element_basic_type(n) == T_FLOAT ||
+             Matcher::vector_element_basic_type(n) == T_DOUBLE));
   match(Set dst (VectorCastL2X src));
   format %{ "vector_cast_l2x  $dst,$src\t!" %}
   ins_encode %{
-    BasicType to_elem_bt = vector_element_basic_type(this);
-    int vlen = vector_length_in_bytes(this, $src);
+    BasicType to_elem_bt = Matcher::vector_element_basic_type(this);
+    int vlen = Matcher::vector_length_in_bytes(this, $src);
     int vlen_enc = vector_length_encoding(this, $src);
     switch (to_elem_bt) {
       case T_BYTE:
@@ -6920,7 +6887,7 @@ instruct vcastLtoX_evex(vec dst, vec src) %{
 %}
 
 instruct vcastFtoD_reg(vec dst, vec src) %{
-  predicate(vector_element_basic_type(n) == T_DOUBLE);
+  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE);
   match(Set dst (VectorCastF2X src));
   format %{ "vector_cast_f2x  $dst,$src\t!" %}
   ins_encode %{
@@ -6931,7 +6898,7 @@ instruct vcastFtoD_reg(vec dst, vec src) %{
 %}
 
 instruct vcastDtoF_reg(vec dst, vec src) %{
-  predicate(vector_element_basic_type(n) == T_FLOAT);
+  predicate(Matcher::vector_element_basic_type(n) == T_FLOAT);
   match(Set dst (VectorCastD2X src));
   format %{ "vector_cast_d2x  $dst,$src\t!" %}
   ins_encode %{
@@ -6944,15 +6911,15 @@ instruct vcastDtoF_reg(vec dst, vec src) %{
 // --------------------------------- VectorMaskCmp --------------------------------------
 
 instruct vcmpFD(legVec dst, legVec src1, legVec src2, immI8 cond) %{
-  predicate(vector_length_in_bytes(n->in(1)->in(1)) >=  8 && // src1
-            vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
-            is_floating_point_type(vector_element_basic_type(n->in(1)->in(1)))); // src1 T_FLOAT, T_DOUBLE
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(1)) >=  8 && // src1
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
+            is_floating_point_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1 T_FLOAT, T_DOUBLE
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   format %{ "vector_compare $dst,$src1,$src2,$cond\t!" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this, $src1);
     Assembler::ComparisonPredicateFP cmp = booltest_pred_to_comparison_pred_fp($cond$$constant);
-    if (vector_element_basic_type(this, $src1) == T_FLOAT) {
+    if (Matcher::vector_element_basic_type(this, $src1) == T_FLOAT) {
       __ vcmpps($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, cmp, vlen_enc);
     } else {
       __ vcmppd($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, cmp, vlen_enc);
@@ -6962,8 +6929,8 @@ instruct vcmpFD(legVec dst, legVec src1, legVec src2, immI8 cond) %{
 %}
 
 instruct evcmpFD(vec dst, vec src1, vec src2, immI8 cond, rRegP scratch, kReg ktmp) %{
-  predicate(vector_length_in_bytes(n->in(1)->in(1)) == 64 && // src1
-            is_floating_point_type(vector_element_basic_type(n->in(1)->in(1)))); // src1 T_FLOAT, T_DOUBLE
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(1)) == 64 && // src1
+            is_floating_point_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1 T_FLOAT, T_DOUBLE
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(TEMP scratch, TEMP ktmp);
   format %{ "vector_compare $dst,$src1,$src2,$cond\t! using $scratch as TEMP" %}
@@ -6971,7 +6938,7 @@ instruct evcmpFD(vec dst, vec src1, vec src2, immI8 cond, rRegP scratch, kReg kt
     int vlen_enc = Assembler::AVX_512bit;
     Assembler::ComparisonPredicateFP cmp = booltest_pred_to_comparison_pred_fp($cond$$constant);
     KRegister mask = k0; // The comparison itself is not being masked.
-    if (vector_element_basic_type(this, $src1) == T_FLOAT) {
+    if (Matcher::vector_element_basic_type(this, $src1) == T_FLOAT) {
       __ evcmpps($ktmp$$KRegister, mask, $src1$$XMMRegister, $src2$$XMMRegister, cmp, vlen_enc);
       __ evmovdqul($dst$$XMMRegister, $ktmp$$KRegister, ExternalAddress(vector_all_bits_set()), false, vlen_enc, $scratch$$Register);
     } else {
@@ -6985,16 +6952,16 @@ instruct evcmpFD(vec dst, vec src1, vec src2, immI8 cond, rRegP scratch, kReg kt
 instruct vcmp(legVec dst, legVec src1, legVec src2, immI8 cond, rRegP scratch) %{
   predicate((UseAVX <= 2 || !VM_Version::supports_avx512vl()) &&
             !is_unsigned_booltest_pred(n->in(2)->get_int()) &&
-            vector_length_in_bytes(n->in(1)->in(1)) >=  4 && // src1
-            vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
-            is_integral_type(vector_element_basic_type(n->in(1)->in(1)))); // src1
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) >=  4 && // src1
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
+            is_integral_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(TEMP scratch);
   format %{ "vector_compare $dst,$src1,$src2,$cond\t! using $scratch as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this, $src1);
     Assembler::ComparisonPredicate cmp = booltest_pred_to_comparison_pred($cond$$constant);
-    Assembler::Width ww = widthForType(vector_element_basic_type(this, $src1));
+    Assembler::Width ww = widthForType(Matcher::vector_element_basic_type(this, $src1));
     __ vpcmpCCW($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, cmp, ww, vlen_enc, $scratch$$Register);
   %}
   ins_pipe( pipe_slow );
@@ -7003,16 +6970,16 @@ instruct vcmp(legVec dst, legVec src1, legVec src2, immI8 cond, rRegP scratch) %
 instruct vcmpu(legVec dst, legVec src1, legVec src2, immI8 cond, legVec vtmp1, legVec vtmp2, rRegP scratch) %{
   predicate((UseAVX == 2 || !VM_Version::supports_avx512vl()) &&
             is_unsigned_booltest_pred(n->in(2)->get_int()) &&
-            vector_length_in_bytes(n->in(1)->in(1)) >=  8 && // src1
-            vector_length_in_bytes(n->in(1)->in(1)) <= 16 && // src1
-            is_integral_type(vector_element_basic_type(n->in(1)->in(1)))); // src1
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) >=  8 && // src1
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) <= 16 && // src1
+            is_integral_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(TEMP vtmp1, TEMP vtmp2, TEMP scratch);
   format %{ "vector_compareu $dst,$src1,$src2,$cond\t! using $scratch as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     Assembler::ComparisonPredicate cmp = booltest_pred_to_comparison_pred($cond$$constant);
-    BasicType bt = vector_element_basic_type(this, $src1);
+    BasicType bt = Matcher::vector_element_basic_type(this, $src1);
     __ vpcmpu(bt, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, cmp, vlen, $vtmp1$$XMMRegister,
               $vtmp2$$XMMRegister, $scratch$$Register);
   %}
@@ -7022,15 +6989,15 @@ instruct vcmpu(legVec dst, legVec src1, legVec src2, immI8 cond, legVec vtmp1, l
 instruct vcmpu32(legVec dst, legVec src1, legVec src2, immI8 cond, legVec vtmp1, legVec vtmp2, legVec vtmp3, rRegP scratch) %{
   predicate((UseAVX == 2 || !VM_Version::supports_avx512vl()) &&
             is_unsigned_booltest_pred(n->in(2)->get_int()) &&
-            vector_length_in_bytes(n->in(1)->in(1)) == 32 && // src1
-            is_integral_type(vector_element_basic_type(n->in(1)->in(1)))); // src1
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) == 32 && // src1
+            is_integral_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2, TEMP vtmp3, TEMP scratch);
   format %{ "vector_compareu $dst,$src1,$src2,$cond\t! using $scratch as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     Assembler::ComparisonPredicate cmp = booltest_pred_to_comparison_pred($cond$$constant);
-    BasicType bt = vector_element_basic_type(this, $src1);
+    BasicType bt = Matcher::vector_element_basic_type(this, $src1);
     __ vpcmpu32(bt, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, cmp, vlen, $vtmp1$$XMMRegister,
                 $vtmp2$$XMMRegister, $vtmp3$$XMMRegister, $scratch$$Register);
   %}
@@ -7040,8 +7007,8 @@ instruct vcmpu32(legVec dst, legVec src1, legVec src2, immI8 cond, legVec vtmp1,
 instruct evcmp(vec dst, vec src1, vec src2, immI8 cond, rRegP scratch, kReg ktmp) %{
   predicate(UseAVX > 2 &&
             (VM_Version::supports_avx512vl() ||
-             vector_length_in_bytes(n->in(1)->in(1)) == 64) && // src1
-             is_integral_type(vector_element_basic_type(n->in(1)->in(1)))); // src1
+             Matcher::vector_length_in_bytes(n->in(1)->in(1)) == 64) && // src1
+             is_integral_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(TEMP scratch, TEMP ktmp);
   format %{ "vector_compare $dst,$src1,$src2,$cond\t! using $scratch as TEMP" %}
@@ -7053,7 +7020,7 @@ instruct evcmp(vec dst, vec src1, vec src2, immI8 cond, rRegP scratch, kReg ktmp
     bool is_unsigned = is_unsigned_booltest_pred($cond$$constant);
     KRegister mask = k0; // The comparison itself is not being masked.
     bool merge = false;
-    BasicType src1_elem_bt = vector_element_basic_type(this, $src1);
+    BasicType src1_elem_bt = Matcher::vector_element_basic_type(this, $src1);
 
     switch (src1_elem_bt) {
       case T_BYTE: {
@@ -7085,7 +7052,7 @@ instruct evcmp(vec dst, vec src1, vec src2, immI8 cond, rRegP scratch, kReg ktmp
 // Extract
 
 instruct extractI(rRegI dst, legVec src, immU8 idx) %{
-  predicate(vector_length_in_bytes(n->in(1)) <= 16); // src
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) <= 16); // src
   match(Set dst (ExtractI src idx));
   match(Set dst (ExtractS src idx));
 #ifdef _LP64
@@ -7093,17 +7060,17 @@ instruct extractI(rRegI dst, legVec src, immU8 idx) %{
 #endif
   format %{ "extractI $dst,$src,$idx\t!" %}
   ins_encode %{
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
-    BasicType elem_bt = vector_element_basic_type(this, $src);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this, $src);
     __ get_elem(elem_bt, $dst$$Register, $src$$XMMRegister, $idx$$constant);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct vextractI(rRegI dst, legVec src, immI idx, legVec vtmp) %{
-  predicate(vector_length_in_bytes(n->in(1)) == 32 || // src
-            vector_length_in_bytes(n->in(1)) == 64);  // src
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) == 32 || // src
+            Matcher::vector_length_in_bytes(n->in(1)) == 64);  // src
   match(Set dst (ExtractI src idx));
   match(Set dst (ExtractS src idx));
 #ifdef _LP64
@@ -7112,9 +7079,9 @@ instruct vextractI(rRegI dst, legVec src, immI idx, legVec vtmp) %{
   effect(TEMP vtmp);
   format %{ "vextractI $dst,$src,$idx\t! using $vtmp as TEMP" %}
   ins_encode %{
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
-    BasicType elem_bt = vector_element_basic_type(this, $src);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this, $src);
     XMMRegister lane_xmm = __ get_lane(elem_bt, $vtmp$$XMMRegister, $src$$XMMRegister, $idx$$constant);
     __ get_elem(elem_bt, $dst$$Register, lane_xmm, $idx$$constant);
   %}
@@ -7123,12 +7090,12 @@ instruct vextractI(rRegI dst, legVec src, immI idx, legVec vtmp) %{
 
 #ifdef _LP64
 instruct extractL(rRegL dst, legVec src, immU8 idx) %{
-  predicate(vector_length(n->in(1)) <= 2); // src
+  predicate(Matcher::vector_length(n->in(1)) <= 2); // src
   match(Set dst (ExtractL src idx));
   format %{ "extractL $dst,$src,$idx\t!" %}
   ins_encode %{
     assert(UseSSE >= 4, "required");
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
     __ get_elem(T_LONG, $dst$$Register, $src$$XMMRegister, $idx$$constant);
   %}
@@ -7136,13 +7103,13 @@ instruct extractL(rRegL dst, legVec src, immU8 idx) %{
 %}
 
 instruct vextractL(rRegL dst, legVec src, immU8 idx, legVec vtmp) %{
-  predicate(vector_length(n->in(1)) == 4 || // src
-            vector_length(n->in(1)) == 8);  // src
+  predicate(Matcher::vector_length(n->in(1)) == 4 || // src
+            Matcher::vector_length(n->in(1)) == 8);  // src
   match(Set dst (ExtractL src idx));
   effect(TEMP vtmp);
   format %{ "vextractL $dst,$src,$idx\t! using $vtmp as TEMP" %}
   ins_encode %{
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
     XMMRegister lane_reg = __ get_lane(T_LONG, $vtmp$$XMMRegister, $src$$XMMRegister, $idx$$constant);
     __ get_elem(T_LONG, $dst$$Register, lane_reg, $idx$$constant);
@@ -7152,12 +7119,12 @@ instruct vextractL(rRegL dst, legVec src, immU8 idx, legVec vtmp) %{
 #endif
 
 instruct extractF(legRegF dst, legVec src, immU8 idx, rRegI tmp, legVec vtmp) %{
-  predicate(vector_length(n->in(1)) <= 4);
+  predicate(Matcher::vector_length(n->in(1)) <= 4);
   match(Set dst (ExtractF src idx));
   effect(TEMP dst, TEMP tmp, TEMP vtmp);
   format %{ "extractF $dst,$src,$idx\t! using $tmp, $vtmp as TEMP" %}
   ins_encode %{
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
     __ get_elem(T_FLOAT, $dst$$XMMRegister, $src$$XMMRegister, $idx$$constant, $tmp$$Register, $vtmp$$XMMRegister);
   %}
@@ -7165,13 +7132,13 @@ instruct extractF(legRegF dst, legVec src, immU8 idx, rRegI tmp, legVec vtmp) %{
 %}
 
 instruct vextractF(legRegF dst, legVec src, immU8 idx, rRegI tmp, legVec vtmp) %{
-  predicate(vector_length(n->in(1)/*src*/) == 8 ||
-            vector_length(n->in(1)/*src*/) == 16);
+  predicate(Matcher::vector_length(n->in(1)/*src*/) == 8 ||
+            Matcher::vector_length(n->in(1)/*src*/) == 16);
   match(Set dst (ExtractF src idx));
   effect(TEMP tmp, TEMP vtmp);
   format %{ "vextractF $dst,$src,$idx\t! using $tmp, $vtmp as TEMP" %}
   ins_encode %{
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
     XMMRegister lane_reg = __ get_lane(T_FLOAT, $vtmp$$XMMRegister, $src$$XMMRegister, $idx$$constant);
     __ get_elem(T_FLOAT, $dst$$XMMRegister, lane_reg, $idx$$constant, $tmp$$Register);
@@ -7180,11 +7147,11 @@ instruct vextractF(legRegF dst, legVec src, immU8 idx, rRegI tmp, legVec vtmp) %
 %}
 
 instruct extractD(legRegD dst, legVec src, immU8 idx) %{
-  predicate(vector_length(n->in(1)) == 2); // src
+  predicate(Matcher::vector_length(n->in(1)) == 2); // src
   match(Set dst (ExtractD src idx));
   format %{ "extractD $dst,$src,$idx\t!" %}
   ins_encode %{
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
     __ get_elem(T_DOUBLE, $dst$$XMMRegister, $src$$XMMRegister, $idx$$constant);
   %}
@@ -7192,13 +7159,13 @@ instruct extractD(legRegD dst, legVec src, immU8 idx) %{
 %}
 
 instruct vextractD(legRegD dst, legVec src, immU8 idx, legVec vtmp) %{
-  predicate(vector_length(n->in(1)) == 4 || // src
-            vector_length(n->in(1)) == 8);  // src
+  predicate(Matcher::vector_length(n->in(1)) == 4 || // src
+            Matcher::vector_length(n->in(1)) == 8);  // src
   match(Set dst (ExtractD src idx));
   effect(TEMP vtmp);
   format %{ "vextractD $dst,$src,$idx\t! using $vtmp as TEMP" %}
   ins_encode %{
-    assert($idx$$constant < (int)vector_length(this, $src), "out of bounds");
+    assert($idx$$constant < (int)Matcher::vector_length(this, $src), "out of bounds");
 
     XMMRegister lane_reg = __ get_lane(T_DOUBLE, $vtmp$$XMMRegister, $src$$XMMRegister, $idx$$constant);
     __ get_elem(T_DOUBLE, $dst$$XMMRegister, lane_reg, $idx$$constant);
@@ -7226,8 +7193,8 @@ instruct blendvp(vec dst, vec src, vec mask, rxmm0 tmp) %{
 
 instruct vblendvpI(legVec dst, legVec src1, legVec src2, legVec mask) %{
   predicate(UseAVX > 0 &&
-            vector_length_in_bytes(n) <= 32 &&
-            is_integral_type(vector_element_basic_type(n)));
+            Matcher::vector_length_in_bytes(n) <= 32 &&
+            is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorBlend (Binary src1 src2) mask));
   format %{ "vector_blend  $dst,$src1,$src2,$mask\t!" %}
   ins_encode %{
@@ -7239,8 +7206,8 @@ instruct vblendvpI(legVec dst, legVec src1, legVec src2, legVec mask) %{
 
 instruct vblendvpFD(legVec dst, legVec src1, legVec src2, legVec mask) %{
   predicate(UseAVX > 0 &&
-            vector_length_in_bytes(n) <= 32 &&
-            !is_integral_type(vector_element_basic_type(n)));
+            Matcher::vector_length_in_bytes(n) <= 32 &&
+            !is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorBlend (Binary src1 src2) mask));
   format %{ "vector_blend  $dst,$src1,$src2,$mask\t!" %}
   ins_encode %{
@@ -7251,13 +7218,13 @@ instruct vblendvpFD(legVec dst, legVec src1, legVec src2, legVec mask) %{
 %}
 
 instruct evblendvp64(vec dst, vec src1, vec src2, vec mask, rRegP scratch, kReg ktmp) %{
-  predicate(vector_length_in_bytes(n) == 64);
+  predicate(Matcher::vector_length_in_bytes(n) == 64);
   match(Set dst (VectorBlend (Binary src1 src2) mask));
   format %{ "vector_blend  $dst,$src1,$src2,$mask\t! using $scratch and k2 as TEMP" %}
   effect(TEMP scratch, TEMP ktmp);
   ins_encode %{
      int vlen_enc = Assembler::AVX_512bit;
-     BasicType elem_bt = vector_element_basic_type(this);
+     BasicType elem_bt = Matcher::vector_element_basic_type(this);
     __ evpcmp(elem_bt, $ktmp$$KRegister, k0, $mask$$XMMRegister, ExternalAddress(vector_all_bits_set()), Assembler::eq, vlen_enc, $scratch$$Register);
     __ evpblend(elem_bt, $dst$$XMMRegister, $ktmp$$KRegister, $src1$$XMMRegister, $src2$$XMMRegister, true, vlen_enc);
   %}
@@ -7270,7 +7237,7 @@ instruct vabsB_reg(vec dst, vec src) %{
   match(Set dst (AbsVB  src));
   format %{ "vabsb $dst,$src\t# $dst = |$src| abs packedB" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 16) {
       __ pabsb($dst$$XMMRegister, $src$$XMMRegister);
     } else {
@@ -7285,7 +7252,7 @@ instruct vabsS_reg(vec dst, vec src) %{
   match(Set dst (AbsVS  src));
   format %{ "vabsw $dst,$src\t# $dst = |$src| abs packedS" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 8) {
       __ pabsw($dst$$XMMRegister, $src$$XMMRegister);
     } else {
@@ -7300,7 +7267,7 @@ instruct vabsI_reg(vec dst, vec src) %{
   match(Set dst (AbsVI  src));
   format %{ "pabsd $dst,$src\t# $dst = |$src| abs packedI" %}
   ins_encode %{
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen <= 4) {
       __ pabsd($dst$$XMMRegister, $src$$XMMRegister);
     } else {
@@ -7328,7 +7295,7 @@ instruct vabsL_reg(vec dst, vec src) %{
 // --------------------------------- ABSNEG --------------------------------------
 
 instruct vabsnegF(vec dst, vec src, rRegI scratch) %{
-  predicate(vector_length(n) != 4); // handled by 1-operand instruction vabsneg4F
+  predicate(Matcher::vector_length(n) != 4); // handled by 1-operand instruction vabsneg4F
   match(Set dst (AbsVF src));
   match(Set dst (NegVF src));
   effect(TEMP scratch);
@@ -7336,7 +7303,7 @@ instruct vabsnegF(vec dst, vec src, rRegI scratch) %{
   ins_cost(150);
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    int vlen = vector_length(this);
+    int vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       __ vabsnegf(opcode, $dst$$XMMRegister, $src$$XMMRegister, $scratch$$Register);
     } else {
@@ -7349,7 +7316,7 @@ instruct vabsnegF(vec dst, vec src, rRegI scratch) %{
 %}
 
 instruct vabsneg4F(vec dst, rRegI scratch) %{
-  predicate(vector_length(n) == 4);
+  predicate(Matcher::vector_length(n) == 4);
   match(Set dst (AbsVF dst));
   match(Set dst (NegVF dst));
   effect(TEMP scratch);
@@ -7369,7 +7336,7 @@ instruct vabsnegD(vec dst, vec src, rRegI scratch) %{
   format %{ "vabsnegd $dst,$src,[mask]\t# absneg packedD" %}
   ins_encode %{
     int opcode = this->ideal_Opcode();
-    uint vlen = vector_length(this);
+    uint vlen = Matcher::vector_length(this);
     if (vlen == 2) {
       assert(UseSSE >= 2, "required");
       __ vabsnegd(opcode, $dst$$XMMRegister, $src$$XMMRegister, $scratch$$Register);
@@ -7385,14 +7352,14 @@ instruct vabsnegD(vec dst, vec src, rRegI scratch) %{
 
 #ifdef _LP64
 instruct vptest_alltrue_lt16(rRegI dst, legVec src1, legVec src2, legVec vtmp1, legVec vtmp2, rFlagsReg cr) %{
-  predicate(vector_length_in_bytes(n->in(1)) >= 4 &&
-            vector_length_in_bytes(n->in(1)) < 16 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) >= 4 &&
+            Matcher::vector_length_in_bytes(n->in(1)) < 16 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2 ));
   effect(TEMP vtmp1, TEMP vtmp2, KILL cr);
   format %{ "vector_test $dst,$src1, $src2\t! using $vtmp1, $vtmp2 and $cr as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::overflow, vlen, $src1$$XMMRegister, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
     __ setb(Assembler::carrySet, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
@@ -7401,14 +7368,14 @@ instruct vptest_alltrue_lt16(rRegI dst, legVec src1, legVec src2, legVec vtmp1, 
 %}
 
 instruct vptest_alltrue(rRegI dst, legVec src1, legVec src2, rFlagsReg cr) %{
-  predicate(vector_length_in_bytes(n->in(1)) >= 16 &&
-            vector_length_in_bytes(n->in(1)) <  64 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) >= 16 &&
+            Matcher::vector_length_in_bytes(n->in(1)) <  64 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2 ));
   effect(KILL cr);
   format %{ "vector_test $dst,$src1, $src2\t! using $cr as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::overflow, vlen, $src1$$XMMRegister, $src2$$XMMRegister, xnoreg, xnoreg, knoreg);
     __ setb(Assembler::carrySet, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
@@ -7417,13 +7384,13 @@ instruct vptest_alltrue(rRegI dst, legVec src1, legVec src2, rFlagsReg cr) %{
 %}
 
 instruct vptest_alltrue_evex(rRegI dst, legVec src1, legVec src2, kReg ktmp, rFlagsReg cr) %{
-  predicate(vector_length_in_bytes(n->in(1)) == 64 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) == 64 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2 ));
   effect(KILL cr, TEMP ktmp);
   format %{ "vector_test $dst,$src1, $src2\t! using $cr as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::overflow, vlen, $src1$$XMMRegister, $src2$$XMMRegister, xnoreg, xnoreg, $ktmp$$KRegister);
     __ setb(Assembler::carrySet, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
@@ -7432,14 +7399,14 @@ instruct vptest_alltrue_evex(rRegI dst, legVec src1, legVec src2, kReg ktmp, rFl
 %}
 
 instruct vptest_anytrue_lt16(rRegI dst, legVec src1, legVec src2, legVec vtmp, rFlagsReg cr) %{
-  predicate(vector_length_in_bytes(n->in(1)) >= 4 &&
-            vector_length_in_bytes(n->in(1)) < 16 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) >= 4 &&
+            Matcher::vector_length_in_bytes(n->in(1)) < 16 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2 ));
   effect(TEMP vtmp, KILL cr);
   format %{ "vector_test_any_true $dst,$src1,$src2\t! using $vtmp, $cr as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, $vtmp$$XMMRegister);
     __ setb(Assembler::notZero, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
@@ -7448,14 +7415,14 @@ instruct vptest_anytrue_lt16(rRegI dst, legVec src1, legVec src2, legVec vtmp, r
 %}
 
 instruct vptest_anytrue(rRegI dst, legVec src1, legVec src2, rFlagsReg cr) %{
-  predicate(vector_length_in_bytes(n->in(1)) >= 16 &&
-            vector_length_in_bytes(n->in(1)) < 64  &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) >= 16 &&
+            Matcher::vector_length_in_bytes(n->in(1)) < 64  &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2 ));
   effect(KILL cr);
   format %{ "vector_test_any_true $dst,$src1,$src2\t! using $cr as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, xnoreg, xnoreg, knoreg);
     __ setb(Assembler::notZero, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
@@ -7464,13 +7431,13 @@ instruct vptest_anytrue(rRegI dst, legVec src1, legVec src2, rFlagsReg cr) %{
 %}
 
 instruct vptest_anytrue_evex(rRegI dst, legVec src1, legVec src2, kReg ktmp, rFlagsReg cr) %{
-  predicate(vector_length_in_bytes(n->in(1)) == 64 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) == 64 &&
             static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2 ));
   effect(KILL cr, TEMP ktmp);
   format %{ "vector_test_any_true $dst,$src1,$src2\t! using $cr as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, xnoreg, xnoreg, $ktmp$$KRegister);
     __ setb(Assembler::notZero, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
@@ -7479,40 +7446,40 @@ instruct vptest_anytrue_evex(rRegI dst, legVec src1, legVec src2, kReg ktmp, rFl
 %}
 
 instruct cmpvptest_anytrue_lt16(rFlagsReg cr, legVec src1, legVec src2, immI_0 zero, legVec vtmp) %{
-  predicate(vector_length_in_bytes(n->in(1)->in(1)) >= 4 &&
-            vector_length_in_bytes(n->in(1)->in(1)) < 16 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(1)) >= 4 &&
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) < 16 &&
             static_cast<const VectorTestNode*>(n->in(1))->get_predicate() == BoolTest::ne);
   match(Set cr (CmpI (VectorTest src1 src2) zero));
   effect(TEMP vtmp);
   format %{ "cmp_vector_test_any_true $src1,$src2\t! using $vtmp as TEMP" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, $vtmp$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct cmpvptest_anytrue(rFlagsReg cr, legVec src1, legVec src2, immI_0 zero) %{
-  predicate(vector_length_in_bytes(n->in(1)->in(1)) >= 16 &&
-            vector_length_in_bytes(n->in(1)->in(1)) <  64 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(1)) >= 16 &&
+            Matcher::vector_length_in_bytes(n->in(1)->in(1)) <  64 &&
             static_cast<const VectorTestNode*>(n->in(1))->get_predicate() == BoolTest::ne);
   match(Set cr (CmpI (VectorTest src1 src2) zero));
   format %{ "cmp_vector_test_any_true $src1,$src2\t!" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, xnoreg, xnoreg, knoreg);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct cmpvptest_anytrue_evex(rFlagsReg cr, legVec src1, legVec src2, immI_0 zero, kReg ktmp) %{
-  predicate(vector_length_in_bytes(n->in(1)->in(1)) == 64 &&
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(1)) == 64 &&
             static_cast<const VectorTestNode*>(n->in(1))->get_predicate() == BoolTest::ne);
   match(Set cr (CmpI (VectorTest src1 src2) zero));
   effect(TEMP ktmp);
   format %{ "cmp_vector_test_any_true $src1,$src2\t!" %}
   ins_encode %{
-    int vlen = vector_length_in_bytes(this, $src1);
+    int vlen = Matcher::vector_length_in_bytes(this, $src1);
     __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, xnoreg, xnoreg, $ktmp$$KRegister);
   %}
   ins_pipe( pipe_slow );
@@ -7527,8 +7494,8 @@ instruct loadMask(legVec dst, legVec src) %{
   effect(TEMP dst);
   format %{ "vector_loadmask_byte $dst,$src\n\t" %}
   ins_encode %{
-    int vlen_in_bytes = vector_length_in_bytes(this);
-    BasicType elem_bt = vector_element_basic_type(this);
+    int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
     __ load_vector_mask($dst$$XMMRegister, $src$$XMMRegister, vlen_in_bytes, elem_bt, true);
   %}
@@ -7541,8 +7508,8 @@ instruct loadMask_evex(vec dst, vec src) %{
   effect(TEMP dst);
   format %{ "vector_loadmask_byte $dst,$src\n\t" %}
   ins_encode %{
-    int vlen_in_bytes = vector_length_in_bytes(this);
-    BasicType elem_bt = vector_element_basic_type(this);
+    int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
+    BasicType elem_bt = Matcher::vector_element_basic_type(this);
 
     __ load_vector_mask($dst$$XMMRegister, $src$$XMMRegister, vlen_in_bytes, elem_bt, false);
   %}
@@ -7552,12 +7519,12 @@ instruct loadMask_evex(vec dst, vec src) %{
 //------------------------------------- StoreMask --------------------------------------------
 
 instruct storeMask1B(vec dst, vec src, immI_1 size) %{
-  predicate(vector_length(n) < 64 || VM_Version::supports_avx512vlbw());
+  predicate(Matcher::vector_length(n) < 64 || VM_Version::supports_avx512vlbw());
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst,$src\t!" %}
   ins_encode %{
     assert(UseSSE >= 3, "required");
-    if (vector_length_in_bytes(this) <= 16) {
+    if (Matcher::vector_length_in_bytes(this) <= 16) {
       __ pabsb($dst$$XMMRegister, $src$$XMMRegister);
     } else {
       assert(UseAVX >= 2, "required");
@@ -7569,7 +7536,7 @@ instruct storeMask1B(vec dst, vec src, immI_1 size) %{
 %}
 
 instruct storeMask2B(vec dst, vec src, immI_2 size) %{
-  predicate(vector_length(n) <= 8);
+  predicate(Matcher::vector_length(n) <= 8);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst,$src\n\t" %}
   ins_encode %{
@@ -7581,7 +7548,7 @@ instruct storeMask2B(vec dst, vec src, immI_2 size) %{
 %}
 
 instruct vstoreMask2B(vec dst, vec src, immI_2 size) %{
-  predicate(vector_length(n) == 16 && !VM_Version::supports_avx512bw());
+  predicate(Matcher::vector_length(n) == 16 && !VM_Version::supports_avx512bw());
   match(Set dst (VectorStoreMask src size));
   effect(TEMP dst);
   format %{ "vector_store_mask $dst,$src\t!" %}
@@ -7608,7 +7575,7 @@ instruct vstoreMask2B_evex(vec dst, vec src, immI_2 size) %{
 %}
 
 instruct storeMask4B(vec dst, vec src, immI_4 size) %{
-  predicate (vector_length(n) <= 4 && UseAVX <= 2);
+  predicate(Matcher::vector_length(n) <= 4 && UseAVX <= 2);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst,$src\t!" %}
   ins_encode %{
@@ -7621,7 +7588,7 @@ instruct storeMask4B(vec dst, vec src, immI_4 size) %{
 %}
 
 instruct vstoreMask4B(vec dst, vec src, immI_4 size) %{
-  predicate(vector_length(n) == 8 && UseAVX <= 2);
+  predicate(Matcher::vector_length(n) == 8 && UseAVX <= 2);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst,$src\t!" %}
   effect(TEMP dst);
@@ -7652,7 +7619,7 @@ instruct vstoreMask4B_evex(vec dst, vec src, immI_4 size) %{
 %}
 
 instruct storeMask8B(vec dst, vec src, immI_8 size) %{
-  predicate(vector_length(n) == 2 && UseAVX <= 2);
+  predicate(Matcher::vector_length(n) == 2 && UseAVX <= 2);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst,$src\t!" %}
   ins_encode %{
@@ -7666,7 +7633,7 @@ instruct storeMask8B(vec dst, vec src, immI_8 size) %{
 %}
 
 instruct storeMask8B_avx(vec dst, vec src, immI_8 size, legVec vtmp) %{
-  predicate(vector_length(n) == 4 && UseAVX <= 2);
+  predicate(Matcher::vector_length(n) == 4 && UseAVX <= 2);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst,$src\t! using $vtmp as TEMP" %}
   effect(TEMP dst, TEMP vtmp);
@@ -7699,8 +7666,8 @@ instruct vstoreMask8B_evex(vec dst, vec src, immI_8 size) %{
 %}
 
 instruct vmaskcast(vec dst) %{
-  predicate((vector_length(n) == vector_length(n->in(1))) &&
-            (vector_length_in_bytes(n) == vector_length_in_bytes(n->in(1))));
+  predicate((Matcher::vector_length(n) == Matcher::vector_length(n->in(1))) &&
+            (Matcher::vector_length_in_bytes(n) == Matcher::vector_length_in_bytes(n->in(1))));
   match(Set dst (VectorMaskCast dst));
   ins_cost(0);
   format %{ "vector_mask_cast $dst" %}
@@ -7713,12 +7680,12 @@ instruct vmaskcast(vec dst) %{
 //-------------------------------- Load Iota Indices ----------------------------------
 
 instruct loadIotaIndices(vec dst, immI_0 src, rRegP scratch) %{
-  predicate(vector_element_basic_type(n) == T_BYTE);
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorLoadConst src));
   effect(TEMP scratch);
   format %{ "vector_load_iota $dst CONSTANT_MEMORY\t! load iota indices" %}
   ins_encode %{
-     int vlen_in_bytes = vector_length_in_bytes(this);
+     int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
      __ load_iota_indices($dst$$XMMRegister, $scratch$$Register, vlen_in_bytes);
   %}
   ins_pipe( pipe_slow );
@@ -7729,7 +7696,7 @@ instruct loadIotaIndices(vec dst, immI_0 src, rRegP scratch) %{
 // LoadShuffle/Rearrange for Byte
 
 instruct loadShuffleB(vec dst) %{
-  predicate(vector_element_basic_type(n) == T_BYTE);
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE);
   match(Set dst (VectorLoadShuffle dst));
   format %{ "vector_load_shuffle $dst, $dst" %}
   ins_encode %{
@@ -7739,8 +7706,8 @@ instruct loadShuffleB(vec dst) %{
 %}
 
 instruct rearrangeB(vec dst, vec shuffle) %{
-  predicate(vector_element_basic_type(n) == T_BYTE &&
-            vector_length(n) < 32);
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE &&
+            Matcher::vector_length(n) < 32);
   match(Set dst (VectorRearrange dst shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $dst" %}
   ins_encode %{
@@ -7751,8 +7718,8 @@ instruct rearrangeB(vec dst, vec shuffle) %{
 %}
 
 instruct rearrangeB_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVec vtmp2, rRegP scratch) %{
-  predicate(vector_element_basic_type(n) == T_BYTE &&
-            vector_length(n) == 32 && !VM_Version::supports_avx512_vbmi());
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE &&
+            Matcher::vector_length(n) == 32 && !VM_Version::supports_avx512_vbmi());
   match(Set dst (VectorRearrange src shuffle));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2, TEMP scratch);
   format %{ "vector_rearrange $dst, $shuffle, $src\t! using $vtmp1, $vtmp2, $scratch as TEMP" %}
@@ -7773,8 +7740,8 @@ instruct rearrangeB_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVe
 %}
 
 instruct rearrangeB_evex(vec dst, vec src, vec shuffle) %{
-  predicate(vector_element_basic_type(n) == T_BYTE &&
-            vector_length(n) >= 32 && VM_Version::supports_avx512_vbmi());
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE &&
+            Matcher::vector_length(n) >= 32 && VM_Version::supports_avx512_vbmi());
   match(Set dst (VectorRearrange src shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $src" %}
   ins_encode %{
@@ -7787,15 +7754,15 @@ instruct rearrangeB_evex(vec dst, vec src, vec shuffle) %{
 // LoadShuffle/Rearrange for Short
 
 instruct loadShuffleS(vec dst, vec src, vec vtmp, rRegP scratch) %{
-  predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) <= 16 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
+  predicate(Matcher::vector_element_basic_type(n) == T_SHORT &&
+            Matcher::vector_length(n) <= 16 && !VM_Version::supports_avx512bw()); // NB! aligned with rearrangeS
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
   ins_encode %{
     // Create a byte shuffle mask from short shuffle mask
     // only byte shuffle instruction available on these platforms
-    int vlen_in_bytes = vector_length_in_bytes(this);
+    int vlen_in_bytes = Matcher::vector_length_in_bytes(this);
     if (UseAVX == 0) {
       assert(vlen_in_bytes <= 16, "required");
       // Multiply each shuffle by two to get byte index
@@ -7829,8 +7796,8 @@ instruct loadShuffleS(vec dst, vec src, vec vtmp, rRegP scratch) %{
 %}
 
 instruct rearrangeS(vec dst, vec shuffle) %{
-  predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) <= 8 && !VM_Version::supports_avx512bw());
+  predicate(Matcher::vector_element_basic_type(n) == T_SHORT &&
+            Matcher::vector_length(n) <= 8 && !VM_Version::supports_avx512bw());
   match(Set dst (VectorRearrange dst shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $dst" %}
   ins_encode %{
@@ -7841,8 +7808,8 @@ instruct rearrangeS(vec dst, vec shuffle) %{
 %}
 
 instruct rearrangeS_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVec vtmp2, rRegP scratch) %{
-  predicate(vector_element_basic_type(n) == T_SHORT &&
-            vector_length(n) == 16 && !VM_Version::supports_avx512bw());
+  predicate(Matcher::vector_element_basic_type(n) == T_SHORT &&
+            Matcher::vector_length(n) == 16 && !VM_Version::supports_avx512bw());
   match(Set dst (VectorRearrange src shuffle));
   effect(TEMP dst, TEMP vtmp1, TEMP vtmp2, TEMP scratch);
   format %{ "vector_rearrange $dst, $shuffle, $src\t! using $vtmp1, $vtmp2, $scratch as TEMP" %}
@@ -7863,7 +7830,7 @@ instruct rearrangeS_avx(legVec dst, legVec src, vec shuffle, legVec vtmp1, legVe
 %}
 
 instruct loadShuffleS_evex(vec dst, vec src) %{
-  predicate(vector_element_basic_type(n) == T_SHORT &&
+  predicate(Matcher::vector_element_basic_type(n) == T_SHORT &&
             VM_Version::supports_avx512bw());
   match(Set dst (VectorLoadShuffle src));
   format %{ "vector_load_shuffle $dst, $src" %}
@@ -7878,7 +7845,7 @@ instruct loadShuffleS_evex(vec dst, vec src) %{
 %}
 
 instruct rearrangeS_evex(vec dst, vec src, vec shuffle) %{
-  predicate(vector_element_basic_type(n) == T_SHORT &&
+  predicate(Matcher::vector_element_basic_type(n) == T_SHORT &&
             VM_Version::supports_avx512bw());
   match(Set dst (VectorRearrange src shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $src" %}
@@ -7895,8 +7862,8 @@ instruct rearrangeS_evex(vec dst, vec src, vec shuffle) %{
 // LoadShuffle/Rearrange for Integer and Float
 
 instruct loadShuffleI(vec dst, vec src, vec vtmp, rRegP scratch) %{
-  predicate((vector_element_basic_type(n) == T_INT || vector_element_basic_type(n) == T_FLOAT) &&
-            vector_length(n) == 4 && UseAVX < 2);
+  predicate((Matcher::vector_element_basic_type(n) == T_INT || Matcher::vector_element_basic_type(n) == T_FLOAT) &&
+            Matcher::vector_length(n) == 4 && UseAVX < 2);
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
@@ -7925,8 +7892,8 @@ instruct loadShuffleI(vec dst, vec src, vec vtmp, rRegP scratch) %{
 %}
 
 instruct rearrangeI(vec dst, vec shuffle) %{
- predicate((vector_element_basic_type(n) == T_INT || vector_element_basic_type(n) == T_FLOAT) &&
-           vector_length(n) == 4 && UseAVX < 2);
+ predicate((Matcher::vector_element_basic_type(n) == T_INT || Matcher::vector_element_basic_type(n) == T_FLOAT) &&
+           Matcher::vector_length(n) == 4 && UseAVX < 2);
   match(Set dst (VectorRearrange dst shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $dst" %}
   ins_encode %{
@@ -7937,7 +7904,7 @@ instruct rearrangeI(vec dst, vec shuffle) %{
 %}
 
 instruct loadShuffleI_avx(vec dst, vec src) %{
-  predicate((vector_element_basic_type(n) == T_INT || vector_element_basic_type(n) == T_FLOAT) &&
+  predicate((Matcher::vector_element_basic_type(n) == T_INT || Matcher::vector_element_basic_type(n) == T_FLOAT) &&
             UseAVX >= 2);
   match(Set dst (VectorLoadShuffle src));
   format %{ "vector_load_shuffle $dst, $src" %}
@@ -7949,7 +7916,7 @@ instruct loadShuffleI_avx(vec dst, vec src) %{
 %}
 
 instruct rearrangeI_avx(vec dst, vec src, vec shuffle) %{
-  predicate((vector_element_basic_type(n) == T_INT || vector_element_basic_type(n) == T_FLOAT) &&
+  predicate((Matcher::vector_element_basic_type(n) == T_INT || Matcher::vector_element_basic_type(n) == T_FLOAT) &&
             UseAVX >= 2);
   match(Set dst (VectorRearrange src shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $src" %}
@@ -7966,8 +7933,8 @@ instruct rearrangeI_avx(vec dst, vec src, vec shuffle) %{
 // LoadShuffle/Rearrange for Long and Double
 
 instruct loadShuffleL(vec dst, vec src, vec vtmp, rRegP scratch) %{
-  predicate(is_double_word_type(vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
-            vector_length(n) < 8 && !VM_Version::supports_avx512vl());
+  predicate(is_double_word_type(Matcher::vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
+            Matcher::vector_length(n) < 8 && !VM_Version::supports_avx512vl());
   match(Set dst (VectorLoadShuffle src));
   effect(TEMP dst, TEMP vtmp, TEMP scratch);
   format %{ "vector_load_shuffle $dst, $src\t! using $vtmp and $scratch as TEMP" %}
@@ -7993,8 +7960,8 @@ instruct loadShuffleL(vec dst, vec src, vec vtmp, rRegP scratch) %{
 %}
 
 instruct rearrangeL(vec dst, vec src, vec shuffle) %{
-  predicate(is_double_word_type(vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
-            vector_length(n) < 8 && !VM_Version::supports_avx512vl());
+  predicate(is_double_word_type(Matcher::vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
+            Matcher::vector_length(n) < 8 && !VM_Version::supports_avx512vl());
   match(Set dst (VectorRearrange src shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $src" %}
   ins_encode %{
@@ -8007,8 +7974,8 @@ instruct rearrangeL(vec dst, vec src, vec shuffle) %{
 %}
 
 instruct loadShuffleL_evex(vec dst, vec src) %{
-  predicate(is_double_word_type(vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
-            (vector_length(n) == 8 || VM_Version::supports_avx512vl()));
+  predicate(is_double_word_type(Matcher::vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
+            (Matcher::vector_length(n) == 8 || VM_Version::supports_avx512vl()));
   match(Set dst (VectorLoadShuffle src));
   format %{ "vector_load_shuffle $dst, $src" %}
   ins_encode %{
@@ -8021,8 +7988,8 @@ instruct loadShuffleL_evex(vec dst, vec src) %{
 %}
 
 instruct rearrangeL_evex(vec dst, vec src, vec shuffle) %{
-  predicate(is_double_word_type(vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
-            (vector_length(n) == 8 || VM_Version::supports_avx512vl()));
+  predicate(is_double_word_type(Matcher::vector_element_basic_type(n)) && // T_LONG, T_DOUBLE
+            (Matcher::vector_length(n) == 8 || VM_Version::supports_avx512vl()));
   match(Set dst (VectorRearrange src shuffle));
   format %{ "vector_rearrange $dst, $shuffle, $src" %}
   ins_encode %{
@@ -8053,7 +8020,7 @@ instruct vfmaF_reg(vec a, vec b, vec c) %{
 %}
 
 instruct vfmaF_mem(vec a, memory b, vec c) %{
-  predicate(vector_length_in_bytes(n->in(1)) > 8);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) > 8);
   match(Set c (FmaVF  c (Binary a (LoadVector b))));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packedF" %}
   ins_cost(150);
@@ -8078,7 +8045,7 @@ instruct vfmaD_reg(vec a, vec b, vec c) %{
 %}
 
 instruct vfmaD_mem(vec a, memory b, vec c) %{
-  predicate(vector_length_in_bytes(n->in(1)) > 8);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)) > 8);
   match(Set c (FmaVD  c (Binary a (LoadVector b))));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packedD" %}
   ins_cost(150);
@@ -8118,7 +8085,7 @@ instruct vpternlog(vec dst, vec src2, vec src3, immU8 func) %{
 %}
 
 instruct vpternlog_mem(vec dst, vec src2, memory src3, immU8 func) %{
-  predicate(vector_length_in_bytes(n->in(1)->in(1)) > 8);
+  predicate(Matcher::vector_length_in_bytes(n->in(1)->in(1)) > 8);
   match(Set dst (MacroLogicV (Binary dst src2) (Binary (LoadVector src3) func)));
   effect(TEMP dst);
   format %{ "vpternlogd $dst,$src2,$src3,$func\t! vector ternary logic" %}
@@ -8183,7 +8150,7 @@ instruct vmask_truecount_evex(rRegI dst, vec mask, rRegL tmp, kReg ktmp, vec xtm
   ins_encode %{
     int opcode = this->ideal_Opcode();
     int vlen_enc = vector_length_encoding(this, $mask);
-    int mask_len = vector_length(this, $mask);
+    int mask_len = Matcher::vector_length(this, $mask);
     __ vector_mask_operation(opcode, $dst$$Register, $mask$$XMMRegister, $xtmp$$XMMRegister,
                              $tmp$$Register, $ktmp$$KRegister, mask_len, vlen_enc);
   %}
@@ -8199,7 +8166,7 @@ instruct vmask_first_or_last_true_evex(rRegI dst, vec mask, rRegL tmp, kReg ktmp
   ins_encode %{
     int opcode = this->ideal_Opcode();
     int vlen_enc = vector_length_encoding(this, $mask);
-    int mask_len = vector_length(this, $mask);
+    int mask_len = Matcher::vector_length(this, $mask);
     __ vector_mask_operation(opcode, $dst$$Register, $mask$$XMMRegister, $xtmp$$XMMRegister,
                              $tmp$$Register, $ktmp$$KRegister, mask_len, vlen_enc);
   %}
@@ -8214,7 +8181,7 @@ instruct vmask_truecount_avx(rRegI dst, vec mask, rRegL tmp, vec xtmp, vec xtmp1
   ins_encode %{
     int opcode = this->ideal_Opcode();
     int vlen_enc = vector_length_encoding(this, $mask);
-    int mask_len = vector_length(this, $mask);
+    int mask_len = Matcher::vector_length(this, $mask);
     __ vector_mask_operation(opcode, $dst$$Register, $mask$$XMMRegister, $xtmp$$XMMRegister,
                              $xtmp1$$XMMRegister, $tmp$$Register, mask_len, vlen_enc);
   %}
@@ -8230,7 +8197,7 @@ instruct vmask_first_or_last_true_avx(rRegI dst, vec mask, rRegL tmp, vec xtmp, 
   ins_encode %{
     int opcode = this->ideal_Opcode();
     int vlen_enc = vector_length_encoding(this, $mask);
-    int mask_len = vector_length(this, $mask);
+    int mask_len = Matcher::vector_length(this, $mask);
     __ vector_mask_operation(opcode, $dst$$Register, $mask$$XMMRegister, $xtmp$$XMMRegister,
                              $xtmp1$$XMMRegister, $tmp$$Register, mask_len, vlen_enc);
   %}

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -763,6 +763,7 @@ static enum RC rc_class( OptoReg::Name reg ) {
     assert(UseSSE < 2, "shouldn't be used in SSE2+ mode");
     return rc_float;
   }
+  if (r->is_KRegister()) return rc_kreg;
   assert(r->is_XMMRegister(), "must be");
   return rc_xmm;
 }
@@ -1285,26 +1286,6 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
     return size;
   }
 
-  assert( size > 0, "missed a case" );
-
-  // --------------------------------------------------------------------
-  // Check for second bits still needing moving.
-  if( src_second == dst_second )
-    return size;               // Self copy; no move
-  assert( src_second_rc != rc_bad && dst_second_rc != rc_bad, "src_second & dst_second cannot be Bad" );
-
-  // Check for second word int-int move
-  if( src_second_rc == rc_int && dst_second_rc == rc_int )
-    return impl_mov_helper(cbuf,do_size,src_second,dst_second,size, st);
-
-  // Check for second word integer store
-  if( src_second_rc == rc_int && dst_second_rc == rc_stack )
-    return impl_helper(cbuf,do_size,false,ra_->reg2offset(dst_second),src_second,0x89,"MOV ",size, st);
-
-  // Check for second word integer load
-  if( dst_second_rc == rc_int && src_second_rc == rc_stack )
-    return impl_helper(cbuf,do_size,true ,ra_->reg2offset(src_second),dst_second,0x8B,"MOV ",size, st);
-
   // AVX-512 opmask specific spilling.
   if (src_first_rc == rc_stack && dst_first_rc == rc_kreg) {
     assert((src_first & 1) == 0 && src_first + 1 == src_second, "invalid register pair");
@@ -1341,6 +1322,26 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
     __ kmov(as_KRegister(Matcher::_regEncode[dst_first]), as_KRegister(Matcher::_regEncode[src_first]));
     return 0;
   }
+
+  assert( size > 0, "missed a case" );
+
+  // --------------------------------------------------------------------
+  // Check for second bits still needing moving.
+  if( src_second == dst_second )
+    return size;               // Self copy; no move
+  assert( src_second_rc != rc_bad && dst_second_rc != rc_bad, "src_second & dst_second cannot be Bad" );
+
+  // Check for second word int-int move
+  if( src_second_rc == rc_int && dst_second_rc == rc_int )
+    return impl_mov_helper(cbuf,do_size,src_second,dst_second,size, st);
+
+  // Check for second word integer store
+  if( src_second_rc == rc_int && dst_second_rc == rc_stack )
+    return impl_helper(cbuf,do_size,false,ra_->reg2offset(dst_second),src_second,0x89,"MOV ",size, st);
+
+  // Check for second word integer load
+  if( dst_second_rc == rc_int && src_second_rc == rc_stack )
+    return impl_helper(cbuf,do_size,true ,ra_->reg2offset(src_second),dst_second,0x8B,"MOV ",size, st);
 
   Unimplemented();
   return 0; // Mute compiler

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1020,17 +1020,6 @@ static void match_alias_type(Compile* C, Node* n, Node* m) {
 }
 #endif
 
-BasicType Matcher::vector_element_basic_type(const Node* n) {
-  const TypeVect* vt = n->bottom_type()->is_vect();
-  return vt->element_basic_type();
-}
-
-BasicType Matcher::vector_element_basic_type(const MachNode* use, const MachOper* opnd) {
-  int def_idx = use->operand_index(opnd);
-  Node* def = use->in(def_idx);
-  return def->bottom_type()->is_vect()->element_basic_type();
-}
-
 //------------------------------xform------------------------------------------
 // Given a Node in old-space, Match him (Label/Reduce) to produce a machine
 // Node in new-space.  Given a new-space Node, recursively walk his children.
@@ -2731,6 +2720,39 @@ void Matcher::specialize_generic_vector_operands() {
       }
     }
   }
+}
+
+uint Matcher::vector_length(const Node* n) {
+  const TypeVect* vt = n->bottom_type()->is_vect();
+  return vt->length();
+}
+
+uint Matcher::vector_length(const MachNode* use, const MachOper* opnd) {
+  int def_idx = use->operand_index(opnd);
+  Node* def = use->in(def_idx);
+  return def->bottom_type()->is_vect()->length();
+}
+
+uint Matcher::vector_length_in_bytes(const Node* n) {
+  const TypeVect* vt = n->bottom_type()->is_vect();
+  return vt->length_in_bytes();
+}
+
+uint Matcher::vector_length_in_bytes(const MachNode* use, const MachOper* opnd) {
+  uint def_idx = use->operand_index(opnd);
+  Node* def = use->in(def_idx);
+  return def->bottom_type()->is_vect()->length_in_bytes();
+}
+
+BasicType Matcher::vector_element_basic_type(const Node* n) {
+  const TypeVect* vt = n->bottom_type()->is_vect();
+  return vt->element_basic_type();
+}
+
+BasicType Matcher::vector_element_basic_type(const MachNode* use, const MachOper* opnd) {
+  int def_idx = use->operand_index(opnd);
+  Node* def = use->in(def_idx);
+  return def->bottom_type()->is_vect()->element_basic_type();
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -341,6 +341,14 @@ public:
   // Vector ideal reg
   static const uint vector_ideal_reg(int len);
 
+  // Vector length
+  static uint vector_length(const Node* n);
+  static uint vector_length(const MachNode* use, const MachOper* opnd);
+
+  // Vector length in bytes
+  static uint vector_length_in_bytes(const Node* n);
+  static uint vector_length_in_bytes(const MachNode* use, const MachOper* opnd);
+
   // Vector element basic type
   static BasicType vector_element_basic_type(const Node* n);
   static BasicType vector_element_basic_type(const MachNode* use, const MachOper* opnd);

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -313,6 +313,21 @@ Node* PhaseVector::expand_vbox_node_helper(Node* vbox,
     }
     new_phi = C->initial_gvn()->transform(new_phi);
     return new_phi;
+  } else if (vbox->is_Phi() && (vect->is_Vector() || vect->is_LoadVector())) {
+    // Handle the case when the allocation input to VectorBoxNode is a phi
+    // but the vector input is not, which can definitely be the case if the
+    // vector input has been value-numbered. It seems to be safe to do by
+    // construction because VectorBoxNode and VectorBoxAllocate come in a
+    // specific order as a result of expanding an intrinsic call. After that, if
+    // any of the inputs to VectorBoxNode are value-numbered they can only
+    // move up and are guaranteed to dominate.
+    Node* new_phi = new PhiNode(vbox->as_Phi()->region(), box_type);
+    for (uint i = 1; i < vbox->req(); i++) {
+      Node* new_box = expand_vbox_node_helper(vbox->in(i), vect, box_type, vect_type);
+      new_phi->set_req(i, new_box);
+    }
+    new_phi = C->initial_gvn()->transform(new_phi);
+    return new_phi;
   } else if (vbox->is_Proj() && vbox->in(0)->Opcode() == Op_VectorBoxAllocate) {
     VectorBoxAllocateNode* vbox_alloc = static_cast<VectorBoxAllocateNode*>(vbox->in(0));
     return expand_vbox_alloc_node(vbox_alloc, vect, box_type, vect_type);

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1674,8 +1674,7 @@ bool LibraryCallKit::inline_vector_convert() {
     if (num_elem_from < num_elem_to) {
       // Since input and output number of elements are not consistent, we need to make sure we
       // properly size. Thus, first make a cast that retains the number of elements from source.
-      // In case the size exceeds the arch size, we do the minimum.
-      int num_elem_for_cast = MIN2(num_elem_from, Matcher::max_vector_size(elem_bt_to));
+      int num_elem_for_cast = num_elem_from;
 
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.
@@ -1694,7 +1693,7 @@ bool LibraryCallKit::inline_vector_convert() {
     } else if (num_elem_from > num_elem_to) {
       // Since number elements from input is larger than output, simply reduce size of input (we are supposed to
       // drop top elements anyway).
-      int num_elem_for_resize = MAX2(num_elem_to, Matcher::min_vector_size(elem_bt_from));
+      int num_elem_for_resize = num_elem_to;
 
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.


### PR DESCRIPTION
…er file

Summary: 8270519: Move several vector helper methods to shared header file
         aarch64 related changes not included.

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/dragonwell-project/dragonwell11/issues/575