### PR TITLE
[EagerAppCDS] fix compile bugs in testcase

### DIFF
--- a/test/hotspot/jtreg/runtime/eagerappcds/TestClassLoaderWithJVMTIAgent.java
+++ b/test/hotspot/jtreg/runtime/eagerappcds/TestClassLoaderWithJVMTIAgent.java
@@ -108,7 +108,7 @@ public class TestClassLoaderWithJVMTIAgent {
     }
 
     static void traceClasses() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-Xlog:class+eagerappcds=trace",
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
@@ -149,7 +149,7 @@ public class TestClassLoaderWithJVMTIAgent {
     }
 
     static void convertClassList() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "--add-exports",
                 "java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-cp",
@@ -163,7 +163,7 @@ public class TestClassLoaderWithJVMTIAgent {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-cp",
                 TESTJAR,
                 "-XX:+UnlockExperimentalVMOptions",
@@ -188,7 +188,7 @@ public class TestClassLoaderWithJVMTIAgent {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-Dtest.classes=" + TEST_CLASS,
                 "-XX:+UnlockExperimentalVMOptions",
                 "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/Classes4CDS.java
+++ b/test/jdk/com/alibaba/cds/Classes4CDS.java
@@ -34,7 +34,7 @@ public class Classes4CDS {
     public static final String CLASSES4CDS = "com.alibaba.jvm.cds.Classes4CDS";
 
     public static ProcessBuilder invokeClasses4CDS(String cds_original_list, String cds_final_list) {
-        return ProcessTools.createJavaProcessBuilder(true,
+        return ProcessTools.createTestJvm(
                 "--add-exports",
                 "java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-cp",

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClass.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClass.java
@@ -88,7 +88,7 @@ public class TestDumpAndLoadClass {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -137,7 +137,7 @@ public class TestDumpAndLoadClass {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",
@@ -161,7 +161,7 @@ public class TestDumpAndLoadClass {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithDifferentCP.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithDifferentCP.java
@@ -71,7 +71,7 @@ public class TestDumpAndLoadClassWithDifferentCP {
     }
 
     static void dumpLoadedClasses() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
             // included in the classlist
@@ -86,7 +86,7 @@ public class TestDumpAndLoadClassWithDifferentCP {
     }
 
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:SharedClassListFile=" + CLASSLIST_FILE,
@@ -121,7 +121,7 @@ public class TestDumpAndLoadClassWithDifferentCP {
 
     static void startWithJsa() throws Exception {
         String classPath = "newpath/testSimple.jar:./test.jar";
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Xshare:on",
             "-XX:SharedArchiveFile=" + ARCHIVE_FILE,
             "-XX:+AppCDSClassFingerprintCheck",

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithException.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithException.java
@@ -79,7 +79,7 @@ public class TestDumpAndLoadClassWithException {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -103,7 +103,7 @@ public class TestDumpAndLoadClassWithException {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",
@@ -139,7 +139,7 @@ public class TestDumpAndLoadClassWithException {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithNullURL.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithNullURL.java
@@ -90,7 +90,7 @@ public class TestDumpAndLoadClassWithNullURL {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -114,7 +114,7 @@ public class TestDumpAndLoadClassWithNullURL {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",
@@ -139,7 +139,7 @@ public class TestDumpAndLoadClassWithNullURL {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithWisp.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadClassWithWisp.java
@@ -87,7 +87,7 @@ public class TestDumpAndLoadClassWithWisp {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -137,7 +137,7 @@ public class TestDumpAndLoadClassWithWisp {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",
@@ -162,7 +162,7 @@ public class TestDumpAndLoadClassWithWisp {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadNotFound.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadNotFound.java
@@ -87,7 +87,7 @@ public class TestDumpAndLoadNotFound {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -136,7 +136,7 @@ public class TestDumpAndLoadNotFound {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",
@@ -160,7 +160,7 @@ public class TestDumpAndLoadNotFound {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/TestDumpAndLoadVerficationFailure.java
+++ b/test/jdk/com/alibaba/cds/TestDumpAndLoadVerficationFailure.java
@@ -92,7 +92,7 @@ public class TestDumpAndLoadVerficationFailure {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -143,7 +143,7 @@ public class TestDumpAndLoadVerficationFailure {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",
@@ -167,7 +167,7 @@ public class TestDumpAndLoadVerficationFailure {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/TestDumpListInParallel.java
+++ b/test/jdk/com/alibaba/cds/TestDumpListInParallel.java
@@ -71,7 +71,7 @@ public class TestDumpListInParallel {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -94,7 +94,7 @@ public class TestDumpListInParallel {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",

--- a/test/jdk/com/alibaba/cds/TestDumpUnsupportedCheck.java
+++ b/test/jdk/com/alibaba/cds/TestDumpUnsupportedCheck.java
@@ -53,7 +53,7 @@ public class TestDumpUnsupportedCheck {
     }
 
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",
             "-XX:SharedClassListFile=" + System.getProperty("test.src", ".") + File.separator + CLASSLIST_FILE,

--- a/test/jdk/com/alibaba/cds/TestLoadClassFlow.java
+++ b/test/jdk/com/alibaba/cds/TestLoadClassFlow.java
@@ -88,7 +88,7 @@ public class TestLoadClassFlow {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -137,7 +137,7 @@ public class TestLoadClassFlow {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:+UnlockExperimentalVMOptions",
@@ -161,7 +161,7 @@ public class TestLoadClassFlow {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerAppCDS",

--- a/test/jdk/com/alibaba/cds/TestWispWithAppCDS.java
+++ b/test/jdk/com/alibaba/cds/TestWispWithAppCDS.java
@@ -85,7 +85,7 @@ public class TestWispWithAppCDS {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -110,7 +110,7 @@ public class TestWispWithAppCDS {
 
     }
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-cp",
             TESTJAR,
             "-XX:SharedClassListFile=" + CLASSLIST_FILE_2,
@@ -136,7 +136,7 @@ public class TestWispWithAppCDS {
     }
 
     static void startWithJsa() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Dtest.classes=" + TEST_CLASS,
             "-Xshare:on",
             "-XX:+UnlockExperimentalVMOptions",

--- a/test/jdk/com/alibaba/quickstart/TestMultiVersionedJar.java
+++ b/test/jdk/com/alibaba/quickstart/TestMultiVersionedJar.java
@@ -43,7 +43,7 @@ public class TestMultiVersionedJar {
     }
 
     static void trace(String parentDir) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Xquickstart:path=" + parentDir + "/quickstartcache",
             "-Xquickstart:verbose",
             "-Xlog:cds+jvmti=debug",
@@ -59,7 +59,7 @@ public class TestMultiVersionedJar {
     }
 
     static void replay(String parentDir) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-Xquickstart:path=" + parentDir + "/quickstartcache",
             "-Xquickstart:verbose",
             "-Xlog:class+eagerappcds=trace",


### PR DESCRIPTION
Summary: Since upstream delete `createJavaProcessBuilder`, those testcases need to call another functions to replace it.

Testing:
com/alibaba/cds/TestDumpAndLoadClass.java
com/alibaba/cds/TestDumpAndLoadClassWithDifferentCP.java com/alibaba/cds/TestDumpAndLoadClassWithException.java com/alibaba/cds/TestDumpAndLoadClassWithNullURL.java com/alibaba/cds/TestDumpAndLoadClassWithWisp.java
com/alibaba/cds/TestDumpAndLoadNotFound.java
com/alibaba/cds/TestDumpAndLoadVerficationFailure.java com/alibaba/cds/TestDumpListInParallel.java
com/alibaba/cds/TestDumpUnsupportedCheck.java
com/alibaba/cds/TestLoadClassFlow.java
com/alibaba/cds/TestWispWithAppCDS.java
runtime/eagerappcds/TestClassLoaderWithJVMTIAgent.java com/alibaba/quickstart/TestMultiVersionedJar.java

Reviewers: lingjun-cg, yulei

Issue: https://github.com/dragonwell-project/dragonwell11/issues/731