### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/actions/config/action.yml
+++ b/.github/actions/config/action.yml
@@ -42,5 +42,5 @@ runs:
       run: |
         # Extract value from configuration file
         value="$(grep -h ${{ inputs.var }}= make/conf/github-actions.conf | cut -d '=' -f 2-)"
-        echo "value=$value" >> $GITHUB_OUTPUT
+        echo "value=$value" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -61,7 +61,7 @@ runs:
               $build_dir/make-support/failure-summary.log \
               $build_dir/make-support/failure-logs/* \
               failure-logs/ 2> /dev/null || true
-          echo 'failure=true' >> $GITHUB_OUTPUT
+          echo 'failure=true' >> "$GITHUB_OUTPUT"
         fi
       shell: bash
 

--- a/.github/actions/get-bootjdk/action.yml
+++ b/.github/actions/get-bootjdk/action.yml
@@ -42,7 +42,7 @@ runs:
       run: |
         # Convert platform name to upper case
         platform_prefix="$(echo ${{ inputs.platform }} | tr [a-z-] [A-Z_])"
-        echo "value=$platform_prefix" >> $GITHUB_OUTPUT
+        echo "value=$platform_prefix" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: 'Get URL configuration'
@@ -105,5 +105,5 @@ runs:
       id: path-name
       run: |
         # Export the path
-        echo 'path=bootjdk/jdk' >> $GITHUB_OUTPUT
+        echo 'path=bootjdk/jdk' >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -103,7 +103,7 @@ runs:
           tests_dir="$(cygpath $tests_dir)"
         fi
 
-        echo "jdk=$jdk_dir" >> $GITHUB_OUTPUT
-        echo "symbols=$symbols_dir" >> $GITHUB_OUTPUT
-        echo "tests=$tests_dir" >> $GITHUB_OUTPUT
+        echo "jdk=$jdk_dir" >> "$GITHUB_OUTPUT"
+        echo "symbols=$symbols_dir" >> "$GITHUB_OUTPUT"
+        echo "tests=$tests_dir" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -68,5 +68,5 @@ runs:
       id: path-name
       run: |
         # Export the path
-        echo 'path=jtreg/installed' >> $GITHUB_OUTPUT
+        echo 'path=jtreg/installed' >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -62,9 +62,9 @@ runs:
         fi
 
         if [[ "$jdk_bundle_zip$jdk_bundle_tar_gz$symbols_bundle$tests_bundle" != "" ]]; then
-          echo 'bundles-found=true' >> $GITHUB_OUTPUT
+          echo 'bundles-found=true' >> "$GITHUB_OUTPUT"
         else
-          echo 'bundles-found=false' >> $GITHUB_OUTPUT
+          echo 'bundles-found=false' >> "$GITHUB_OUTPUT"
         fi
       shell: bash
 

--- a/.github/scripts/gen-test-summary.sh
+++ b/.github/scripts/gen-test-summary.sh
@@ -42,12 +42,12 @@ error_count=$(echo $errors | wc -w || true)
 
 if [[ "$failures" = "" && "$errors" = "" ]]; then
   # We know something went wrong, but not what
-  echo 'error-message=Unspecified test suite failure. Please see log for job for details.' >> $GITHUB_OUTPUT
+  echo 'error-message=Unspecified test suite failure. Please see log for job for details.' >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
-echo 'failure=true' >> $GITHUB_OUTPUT
-echo "error-message=Test run reported $failure_count test failure(s) and $error_count error(s). See summary for details." >> $GITHUB_OUTPUT
+echo 'failure=true' >> "$GITHUB_OUTPUT"
+echo "error-message=Test run reported $failure_count test failure(s) and $error_count error(s). See summary for details." >> "$GITHUB_OUTPUT"
 
 echo '### :boom: Test failures summary' >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -95,10 +95,10 @@ jobs:
           '/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
           if [ $? -eq 0 ]; then
             echo "Toolchain is already installed"
-            echo "toolchain-installed=true" >> $GITHUB_OUTPUT
+            echo "toolchain-installed=true" >> "$GITHUB_OUTPUT"
           else
             echo "Toolchain is not yet installed"
-            echo "toolchain-installed=false" >> $GITHUB_OUTPUT
+            echo "toolchain-installed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: 'Install toolchain and dependencies'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,14 +104,14 @@ jobs:
             echo 'false'
           }
 
-          echo "linux-x64=$(check_platform linux-x64 linux x64)" >> $GITHUB_OUTPUT
-          echo "linux-x86=$(check_platform linux-x86 linux x86)" >> $GITHUB_OUTPUT
-          echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
-          echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
-          echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
-          echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
-          echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT
-          echo "windows-aarch64=$(check_platform windows-aarch64 windows aarch64)" >> $GITHUB_OUTPUT
+          echo "linux-x64=$(check_platform linux-x64 linux x64)" >> "$GITHUB_OUTPUT"
+          echo "linux-x86=$(check_platform linux-x86 linux x86)" >> "$GITHUB_OUTPUT"
+          echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> "$GITHUB_OUTPUT"
+          echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> "$GITHUB_OUTPUT"
+          echo "macos-x64=$(check_platform macos-x64 macos x64)" >> "$GITHUB_OUTPUT"
+          echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> "$GITHUB_OUTPUT"
+          echo "windows-x64=$(check_platform windows-x64 windows x64)" >> "$GITHUB_OUTPUT"
+          echo "windows-aarch64=$(check_platform windows-aarch64 windows aarch64)" >> "$GITHUB_OUTPUT"
 
   ###
   ### Build jobs

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -41,21 +41,21 @@ jobs:
     steps:
       - name: Check if submit tests should actually run depending on secrets and manual triggering
         id: check_submit
-        run: echo "should_run=${{ github.event.inputs.platforms != '' || (!secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/')) }}" >> $GITHUB_OUTPUT
+        run: echo "should_run=${{ github.event.inputs.platforms != '' || (!secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/')) }}" >> "$GITHUB_OUTPUT"
 
       - name: Check which platforms should be included
         id: check_platforms
         run: |
-          echo "platform_linux_x64=${{ contains(github.event.inputs.platforms, 'linux x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x64'))) }}" >> $GITHUB_OUTPUT
-          echo "platform_linux_aarch64=${{ contains(github.event.inputs.platforms, 'linux aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux aarch64'))) }}" >> $GITHUB_OUTPUT
-          echo "platform_windows_x64=${{ contains(github.event.inputs.platforms, 'windows x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'windows x64'))) }}" >> $GITHUB_OUTPUT
-          echo "platform_macos_x64=${{ contains(github.event.inputs.platforms, 'macos x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos x64'))) }}" >> $GITHUB_OUTPUT
-          echo "platform_macos_aarch64=${{ contains(github.event.inputs.platforms, 'macos aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos aarch64'))) }}" >> $GITHUB_OUTPUT
+          echo "platform_linux_x64=${{ contains(github.event.inputs.platforms, 'linux x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x64'))) }}" >> "$GITHUB_OUTPUT"
+          echo "platform_linux_aarch64=${{ contains(github.event.inputs.platforms, 'linux aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux aarch64'))) }}" >> "$GITHUB_OUTPUT"
+          echo "platform_windows_x64=${{ contains(github.event.inputs.platforms, 'windows x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'windows x64'))) }}" >> "$GITHUB_OUTPUT"
+          echo "platform_macos_x64=${{ contains(github.event.inputs.platforms, 'macos x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos x64'))) }}" >> "$GITHUB_OUTPUT"
+          echo "platform_macos_aarch64=${{ contains(github.event.inputs.platforms, 'macos aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos aarch64'))) }}" >> "$GITHUB_OUTPUT"
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine unique bundle identifier
         id: check_bundle_id
-        run: echo "bundle_id=${GITHUB_ACTOR}_${GITHUB_SHA:0:8}" >> $GITHUB_OUTPUT
+        run: echo "bundle_id=${GITHUB_ACTOR}_${GITHUB_SHA:0:8}" >> "$GITHUB_OUTPUT"
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Checkout the source
@@ -91,7 +91,7 @@ jobs:
           else
              V=${FEATURE}
           fi
-          echo "jdk_version=${V}" >> $GITHUB_OUTPUT
+          echo "jdk_version=${V}" >> "$GITHUB_OUTPUT"
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine the jtreg ref to checkout

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -41,21 +41,21 @@ jobs:
     steps:
       - name: Check if submit tests should actually run depending on secrets and manual triggering
         id: check_submit
-        run: echo "::set-output name=should_run::${{ github.event.inputs.platforms != '' || (!secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/')) }}"
+        run: echo "should_run=${{ github.event.inputs.platforms != '' || (!secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/')) }}" >> $GITHUB_OUTPUT
 
       - name: Check which platforms should be included
         id: check_platforms
         run: |
-          echo "::set-output name=platform_linux_x64::${{ contains(github.event.inputs.platforms, 'linux x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x64'))) }}"
-          echo "::set-output name=platform_linux_aarch64::${{ contains(github.event.inputs.platforms, 'linux aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux aarch64'))) }}"
-          echo "::set-output name=platform_windows_x64::${{ contains(github.event.inputs.platforms, 'windows x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'windows x64'))) }}"
-          echo "::set-output name=platform_macos_x64::${{ contains(github.event.inputs.platforms, 'macos x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos x64'))) }}"
-          echo "::set-output name=platform_macos_aarch64::${{ contains(github.event.inputs.platforms, 'macos aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos aarch64'))) }}"
+          echo "platform_linux_x64=${{ contains(github.event.inputs.platforms, 'linux x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux x64'))) }}" >> $GITHUB_OUTPUT
+          echo "platform_linux_aarch64=${{ contains(github.event.inputs.platforms, 'linux aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'linux aarch64'))) }}" >> $GITHUB_OUTPUT
+          echo "platform_windows_x64=${{ contains(github.event.inputs.platforms, 'windows x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'windows x64'))) }}" >> $GITHUB_OUTPUT
+          echo "platform_macos_x64=${{ contains(github.event.inputs.platforms, 'macos x64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos x64'))) }}" >> $GITHUB_OUTPUT
+          echo "platform_macos_aarch64=${{ contains(github.event.inputs.platforms, 'macos aarch64') || (github.event.inputs.platforms == '' && (secrets.JDK_SUBMIT_PLATFORMS == '' || contains(secrets.JDK_SUBMIT_PLATFORMS, 'macos aarch64'))) }}" >> $GITHUB_OUTPUT
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine unique bundle identifier
         id: check_bundle_id
-        run: echo "::set-output name=bundle_id::${GITHUB_ACTOR}_${GITHUB_SHA:0:8}"
+        run: echo "bundle_id=${GITHUB_ACTOR}_${GITHUB_SHA:0:8}" >> $GITHUB_OUTPUT
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Checkout the source
@@ -91,7 +91,7 @@ jobs:
           else
              V=${FEATURE}
           fi
-          echo "::set-output name=jdk_version::${V}"
+          echo "jdk_version=${V}" >> $GITHUB_OUTPUT
         if: steps.check_submit.outputs.should_run != 'false'
 
       - name: Determine the jtreg ref to checkout


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


