### PR TITLE
[Backport] CHA inline

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2017,8 +2017,9 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
   }
 
   if (cha_monomorphic_target != NULL) {
+    assert(!target->can_be_statically_bound() || target == cha_monomorphic_target, "");
     assert(!cha_monomorphic_target->is_abstract(), "");
-    if (!(target->is_final_method())) {
+    if (!cha_monomorphic_target->can_be_statically_bound(actual_recv)) {
       // If we inlined because CHA revealed only a single target method,
       // then we are dependent on that target method not getting overridden
       // by dynamic class loading.  Be sure to test the "static" receiver

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1988,8 +1988,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       // no point in inlining.
       ciInstanceKlass* singleton = NULL;
       ciInstanceKlass* declared_interface = callee_holder;
-      if (declared_interface->nof_implementors() == 1 &&
-          (!target->is_default_method() || target->is_overpass()) /* CHA doesn't support default methods yet. */) {
+      if (declared_interface->nof_implementors() == 1) {
         singleton = declared_interface->implementor();
         assert(singleton != NULL && singleton != declared_interface, "");
         cha_monomorphic_target = target->find_monomorphic_target(calling_klass, declared_interface, singleton);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1971,7 +1971,8 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       // Use CHA on the receiver to select a more precise method.
       cha_monomorphic_target = target->find_monomorphic_target(calling_klass, callee_holder, actual_recv);
     } else if (code == Bytecodes::_invokeinterface && callee_holder->is_loaded() && receiver != NULL) {
-      // if there is only one implementor of this interface then we
+      assert(callee_holder->is_interface(), "invokeinterface to non interface?");
+      // If there is only one implementor of this interface then we
       // may be able bind this invoke directly to the implementing
       // klass but we need both a dependence on the single interface
       // and on the method we bind to.  Additionally since all we know
@@ -1979,53 +1980,44 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
       // interface we have to insert a check that it's the class we
       // expect.  Interface types are not checked by the verifier so
       // they are roughly equivalent to Object.
+      // The number of implementors for declared_interface is less or
+      // equal to the number of implementors for target->holder() so
+      // if number of implementors of target->holder() == 1 then
+      // number of implementors for decl_interface is 0 or 1. If
+      // it's 0 then no class implements decl_interface and there's
+      // no point in inlining.
       ciInstanceKlass* singleton = NULL;
-      if (target->holder()->nof_implementors() == 1) {
-        singleton = target->holder()->implementor();
-        assert(singleton != NULL && singleton != target->holder(),
-               "just checking");
-
-        assert(holder->is_interface(), "invokeinterface to non interface?");
-        ciInstanceKlass* decl_interface = (ciInstanceKlass*)holder;
-        // the number of implementors for decl_interface is less or
-        // equal to the number of implementors for target->holder() so
-        // if number of implementors of target->holder() == 1 then
-        // number of implementors for decl_interface is 0 or 1. If
-        // it's 0 then no class implements decl_interface and there's
-        // no point in inlining.
-        if (!holder->is_loaded() || decl_interface->nof_implementors() != 1 || decl_interface->has_nonstatic_concrete_methods()) {
-          singleton = NULL;
-        }
-      }
-      if (singleton) {
-        cha_monomorphic_target = target->find_monomorphic_target(calling_klass, target->holder(), singleton);
+      ciInstanceKlass* declared_interface = callee_holder;
+      if (declared_interface->nof_implementors() == 1 &&
+          (!target->is_default_method() || target->is_overpass()) /* CHA doesn't support default methods yet. */) {
+        singleton = declared_interface->implementor();
+        assert(singleton != NULL && singleton != declared_interface, "");
+        cha_monomorphic_target = target->find_monomorphic_target(calling_klass, declared_interface, singleton);
         if (cha_monomorphic_target != NULL) {
-          ciInstanceKlass* holder = cha_monomorphic_target->holder();
-          klass = (holder->is_subtype_of(singleton) ? holder : singleton); // avoid upcasts
-          actual_recv = target->holder();
+          if (cha_monomorphic_target->holder() != compilation()->env()->Object_klass()) {
+            // If CHA is able to bind this invoke then update the class
+            // to match that class, otherwise klass will refer to the
+            // interface.
+            klass = cha_monomorphic_target->holder();
+            actual_recv = declared_interface;
 
-          // insert a check it's really the expected class.
-          CheckCast* c = new CheckCast(klass, receiver, copy_state_for_exception());
-          c->set_incompatible_class_change_check();
-          c->set_direct_compare(klass->is_final());
-          // pass the result of the checkcast so that the compiler has
-          // more accurate type info in the inlinee
-          better_receiver = append_split(c);
-
-          dependency_recorder()->assert_unique_implementor(target->holder(), singleton);
+            // insert a check it's really the expected class.
+            CheckCast* c = new CheckCast(klass, receiver, copy_state_for_exception());
+            c->set_incompatible_class_change_check();
+            c->set_direct_compare(klass->is_final());
+            // pass the result of the checkcast so that the compiler has
+            // more accurate type info in the inlinee
+            better_receiver = append_split(c);
+          } else {
+            cha_monomorphic_target = NULL; // subtype check against Object is useless
+          }
         }
       }
     }
   }
 
   if (cha_monomorphic_target != NULL) {
-    if (cha_monomorphic_target->is_abstract()) {
-      // Do not optimize for abstract methods
-      cha_monomorphic_target = NULL;
-    }
-  }
-
-  if (cha_monomorphic_target != NULL) {
+    assert(!cha_monomorphic_target->is_abstract(), "");
     if (!(target->is_final_method())) {
       // If we inlined because CHA revealed only a single target method,
       // then we are dependent on that target method not getting overridden

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -347,6 +347,9 @@ void BCEscapeAnalyzer::invoke(StateInfo &state, Bytecodes::Code code, ciMethod* 
           (code == Bytecodes::_invokevirtual && !target->is_final_method())) {
         _dependencies.append(actual_recv);
         _dependencies.append(inline_target);
+        _dependencies.append(callee_holder);
+        _dependencies.append(target);
+        assert(callee_holder->is_interface() == (code == Bytecodes::_invokeinterface), "sanity");
       }
       _dependencies.appendAll(analyzer.dependencies());
     }
@@ -1496,9 +1499,11 @@ void BCEscapeAnalyzer::copy_dependencies(Dependencies *deps) {
     // callee will trigger recompilation.
     deps->assert_evol_method(method());
   }
-  for (int i = 0; i < _dependencies.length(); i+=2) {
-    ciKlass *k = _dependencies.at(i)->as_klass();
-    ciMethod *m = _dependencies.at(i+1)->as_method();
-    deps->assert_unique_concrete_method(k, m);
+  for (int i = 0; i < _dependencies.length(); i+=4) {
+    ciKlass*  recv_klass      = _dependencies.at(i+0)->as_klass();
+    ciMethod* target          = _dependencies.at(i+1)->as_method();
+    ciKlass*  resolved_klass  = _dependencies.at(i+2)->as_klass();
+    ciMethod* resolved_method = _dependencies.at(i+3)->as_method();
+    deps->assert_unique_concrete_method(recv_klass, target, resolved_klass, resolved_method);
   }
 }

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -70,7 +70,7 @@ private:
   // The possible values of the _implementor fall into following three cases:
   //   NULL: no implementor.
   //   A ciInstanceKlass that's not itself: one implementor.
-  //   Itsef: more than one implementors.
+  //   Itself: more than one implementor.
   ciInstanceKlass*       _implementor;
 
   void compute_injected_fields();

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -764,6 +764,14 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
 }
 
 // ------------------------------------------------------------------
+// ciMethod::can_be_statically_bound
+//
+// Tries to determine whether a method can be statically bound in some context.
+bool ciMethod::can_be_statically_bound(ciInstanceKlass* context) const {
+  return (holder() == context) && can_be_statically_bound();
+}
+
+// ------------------------------------------------------------------
 // ciMethod::resolve_invoke
 //
 // Given a known receiver klass, find the target for the call.

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -688,23 +688,26 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
     return NULL;
   }
 
-  ciMethod* root_m = resolve_invoke(caller, actual_recv, check_access);
+  ciMethod* root_m = resolve_invoke(caller, actual_recv, check_access, true /* allow_abstract */);
   if (root_m == NULL) {
     // Something went wrong looking up the actual receiver method.
     return NULL;
   }
-  assert(!root_m->is_abstract(), "resolve_invoke promise");
 
   // Make certain quick checks even if UseCHA is false.
 
   // Is it private or final?
   if (root_m->can_be_statically_bound()) {
+    assert(!root_m->is_abstract(), "sanity");
     return root_m;
   }
 
   if (actual_recv->is_leaf_type() && actual_recv == root_m->holder()) {
     // Easy case.  There is no other place to put a method, so don't bother
     // to go through the VM_ENTRY_MARK and all the rest.
+    if (root_m->is_abstract()) {
+      return NULL;
+    }
     return root_m;
   }
 
@@ -733,6 +736,9 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
                                                                               callee_holder->get_Klass(),
                                                                               this->get_Method()));
     } else {
+      if (root_m->is_abstract()) {
+        return NULL; // not supported
+      }
       target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context, root_m->get_Method()));
     }
     assert(target() == NULL || !target()->is_abstract(), "not allowed");
@@ -766,7 +772,6 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
     // with the same name but different vtable indexes.
     return NULL;
   }
-  assert(!target()->is_abstract(), "not allowed");
   return CURRENT_THREAD_ENV->get_method(target());
 }
 
@@ -783,48 +788,46 @@ bool ciMethod::can_be_statically_bound(ciInstanceKlass* context) const {
 //
 // Given a known receiver klass, find the target for the call.
 // Return NULL if the call has no target or the target is abstract.
-ciMethod* ciMethod::resolve_invoke(ciKlass* caller, ciKlass* exact_receiver, bool check_access) {
-   check_is_loaded();
-   VM_ENTRY_MARK;
+ciMethod* ciMethod::resolve_invoke(ciKlass* caller, ciKlass* exact_receiver, bool check_access, bool allow_abstract) {
+  check_is_loaded();
+  VM_ENTRY_MARK;
 
-   Klass* caller_klass = caller->get_Klass();
-   Klass* recv         = exact_receiver->get_Klass();
-   Klass* resolved     = holder()->get_Klass();
-   Symbol* h_name      = name()->get_symbol();
-   Symbol* h_signature = signature()->get_symbol();
+  Klass* caller_klass = caller->get_Klass();
+  Klass* recv         = exact_receiver->get_Klass();
+  Klass* resolved     = holder()->get_Klass();
+  Symbol* h_name      = name()->get_symbol();
+  Symbol* h_signature = signature()->get_symbol();
 
-   LinkInfo link_info(resolved, h_name, h_signature, caller_klass,
-                      check_access ? LinkInfo::needs_access_check : LinkInfo::skip_access_check);
-   methodHandle m;
-   // Only do exact lookup if receiver klass has been linked.  Otherwise,
-   // the vtable has not been setup, and the LinkResolver will fail.
-   if (recv->is_array_klass()
-        ||
-       (InstanceKlass::cast(recv)->is_linked() && !exact_receiver->is_interface())) {
-     if (holder()->is_interface()) {
-       m = LinkResolver::resolve_interface_call_or_null(recv, link_info);
-     } else {
-       m = LinkResolver::resolve_virtual_call_or_null(recv, link_info);
-     }
-   }
+  LinkInfo link_info(resolved, h_name, h_signature, caller_klass,
+                     check_access ? LinkInfo::needs_access_check : LinkInfo::skip_access_check);
+  methodHandle m;
+  // Only do exact lookup if receiver klass has been linked.  Otherwise,
+  // the vtable has not been setup, and the LinkResolver will fail.
+  if (recv->is_array_klass()
+       ||
+      (InstanceKlass::cast(recv)->is_linked() && !exact_receiver->is_interface())) {
+    if (holder()->is_interface()) {
+      m = LinkResolver::resolve_interface_call_or_null(recv, link_info);
+    } else {
+      m = LinkResolver::resolve_virtual_call_or_null(recv, link_info);
+    }
+  }
 
-   if (m.is_null()) {
-     // Return NULL only if there was a problem with lookup (uninitialized class, etc.)
-     return NULL;
-   }
+  if (m.is_null()) {
+    // Return NULL only if there was a problem with lookup (uninitialized class, etc.)
+    return NULL;
+  }
 
-   ciMethod* result = this;
-   if (m() != get_Method()) {
-     result = CURRENT_THREAD_ENV->get_method(m());
-   }
+  ciMethod* result = this;
+  if (m() != get_Method()) {
+    result = CURRENT_THREAD_ENV->get_method(m());
+  }
 
-   // Don't return abstract methods because they aren't
-   // optimizable or interesting.
-   if (result->is_abstract()) {
-     return NULL;
-   } else {
-     return result;
-   }
+  if (result->is_abstract() && !allow_abstract) {
+    // Don't return abstract methods because they aren't optimizable or interesting.
+    return NULL;
+  }
+  return result;
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -727,8 +727,15 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
   {
     MutexLocker locker(Compile_lock);
     Klass* context = actual_recv->get_Klass();
-    target = Dependencies::find_unique_concrete_method(context,
-                                                       root_m->get_Method());
+    if (UseVtableBasedCHA) {
+      target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context,
+                                                                              root_m->get_Method(),
+                                                                              callee_holder->get_Klass(),
+                                                                              this->get_Method()));
+    } else {
+      target = methodHandle(THREAD, Dependencies::find_unique_concrete_method(context, root_m->get_Method()));
+    }
+    assert(target() == NULL || !target()->is_abstract(), "not allowed");
     // %%% Should upgrade this ciMethod API to look for 1 or 2 concrete methods.
   }
 

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -721,11 +721,6 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
 
   VM_ENTRY_MARK;
 
-  // Disable CHA for default methods for now
-  if (root_m->is_default_method()) {
-    return NULL;
-  }
-
   methodHandle target;
   {
     MutexLocker locker(Compile_lock);

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -89,6 +89,7 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   _is_c2_compilable   = !h_m()->is_not_c2_compilable();
   _can_be_parsed      = true;
   _has_reserved_stack_access = h_m()->has_reserved_stack_access();
+  _is_overpass        = h_m()->is_overpass();
   // Lazy fields, filled in on demand.  Require allocation.
   _code               = NULL;
   _exception_handlers = NULL;
@@ -718,7 +719,7 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
   VM_ENTRY_MARK;
 
   // Disable CHA for default methods for now
-  if (root_m->get_Method()->is_default_method()) {
+  if (root_m->is_default_method()) {
     return NULL;
   }
 
@@ -758,6 +759,7 @@ ciMethod* ciMethod::find_monomorphic_target(ciInstanceKlass* caller,
     // with the same name but different vtable indexes.
     return NULL;
   }
+  assert(!target()->is_abstract(), "not allowed");
   return CURRENT_THREAD_ENV->get_method(target());
 }
 
@@ -871,6 +873,14 @@ ciMethod* ciMethod::get_method_at_bci(int bci, bool &will_link, ciSignature* *de
   iter.reset_to_bci(bci);
   iter.next();
   return iter.get_method(will_link, declared_signature);
+}
+
+// ------------------------------------------------------------------
+ciKlass* ciMethod::get_declared_method_holder_at_bci(int bci) {
+  ciBytecodeStream iter(this);
+  iter.reset_to_bci(bci);
+  iter.next();
+  return iter.get_declared_method_holder();
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -353,6 +353,8 @@ class ciMethod : public ciMetadata {
   bool is_vector_method() const;
   bool is_object_initializer() const;
 
+  bool can_be_statically_bound(ciInstanceKlass* context) const;
+
   // Replay data methods
   void dump_name_as_ascii(outputStream* st);
   void dump_replay_data(outputStream* st);

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -89,6 +89,7 @@ class ciMethod : public ciMetadata {
   bool _can_be_parsed;
   bool _can_be_statically_bound;
   bool _has_reserved_stack_access;
+  bool _is_overpass;
 
   // Lazy fields, filled in on demand
   address              _code;
@@ -266,6 +267,8 @@ class ciMethod : public ciMetadata {
     return get_method_at_bci(bci, ignored_will_link, &ignored_declared_signature);
   }
 
+  ciKlass*      get_declared_method_holder_at_bci(int bci);
+
   ciSignature*  get_declared_signature_at_bci(int bci) {
     bool ignored_will_link;
     ciSignature* declared_signature;
@@ -334,6 +337,9 @@ class ciMethod : public ciMetadata {
   bool is_empty_method() const;
   bool is_vanilla_constructor() const;
   bool is_final_method() const                   { return is_final() || holder()->is_final(); }
+  bool is_default_method() const                 { return !is_abstract() && !is_private() &&
+                                                          holder()->is_interface(); }
+  bool is_overpass    () const                   { check_is_loaded(); return _is_overpass; }
   bool has_loops      () const;
   bool has_jsrs       () const;
   bool is_getter      () const;

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -287,7 +287,7 @@ class ciMethod : public ciMetadata {
 
   // Given a known receiver klass, find the target for the call.
   // Return NULL if the call has no target or is abstract.
-  ciMethod* resolve_invoke(ciKlass* caller, ciKlass* exact_receiver, bool check_access = true);
+  ciMethod* resolve_invoke(ciKlass* caller, ciKlass* exact_receiver, bool check_access = true, bool allow_abstract = false);
 
   // Find the proper vtable index to invoke this method.
   int resolve_vtable_index(ciKlass* caller, ciKlass* receiver);

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -352,18 +352,7 @@ int ciBytecodeStream::get_field_signature_index() {
 // If this is a method invocation bytecode, get the constant pool
 // index of the invoked method.
 int ciBytecodeStream::get_method_index() {
-#ifdef ASSERT
-  switch (cur_bc()) {
-  case Bytecodes::_invokeinterface:
-  case Bytecodes::_invokevirtual:
-  case Bytecodes::_invokespecial:
-  case Bytecodes::_invokestatic:
-  case Bytecodes::_invokedynamic:
-    break;
-  default:
-    ShouldNotReachHere();
-  }
-#endif
+  assert(Bytecodes::is_invoke(cur_bc()), "invalid bytecode: %s", Bytecodes::name(cur_bc()));
   if (has_index_u4())
     return get_index_u4();  // invokedynamic
   return get_index_u2_cpcache();

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -108,6 +108,7 @@ void Dependencies::assert_concrete_with_no_concrete_subtype(ciKlass* ctxk) {
 
 void Dependencies::assert_unique_concrete_method(ciKlass* ctxk, ciMethod* uniqm) {
   check_ctxk(ctxk);
+  check_unique_method(ctxk, uniqm);
   assert_common_2(unique_concrete_method, ctxk, uniqm);
 }
 
@@ -193,6 +194,7 @@ void Dependencies::assert_unique_implementor(InstanceKlass* ctxk, InstanceKlass*
 
 void Dependencies::assert_unique_concrete_method(Klass* ctxk, Method* uniqm) {
   check_ctxk(ctxk);
+  check_unique_method(ctxk, uniqm);
   assert_common_2(unique_concrete_method, DepValue(_oop_recorder, ctxk), DepValue(_oop_recorder, uniqm));
 }
 

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -2113,6 +2113,9 @@ Method* Dependencies::find_unique_concrete_method(Klass* ctxk, Method* m, Klass*
   if (m->is_old()) {
     return NULL;
   }
+  if (m->is_default_method()) {
+    return NULL; // not supported
+  }
   ClassHierarchyWalker wf(m);
   assert(wf.check_method_context(ctxk, m), "proper context");
   wf.record_witnesses(1);

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1206,7 +1206,11 @@ class ClassHierarchyWalker {
 
   bool is_witness(Klass* k) {
     if (doing_subtype_search()) {
-      return Dependencies::is_concrete_klass(k);
+      if (Dependencies::is_concrete_klass(k)) {
+        return record_witness(k); // concrete subtype
+      } else {
+        return false; // not a concrete class
+      }
     } else if (!k->is_instance_klass()) {
       return false; // no methods to find in an array type
     } else {
@@ -1214,7 +1218,9 @@ class ClassHierarchyWalker {
       // Search class hierarchy first, skipping private implementations
       // as they never override any inherited methods
       Method* m = ik->find_instance_method(_name, _signature, Klass::skip_private);
-      if (!Dependencies::is_concrete_method(m, ik)) {
+      if (Dependencies::is_concrete_method(m, ik)) {
+        return record_witness(k, m); // concrete method found
+      } else {
         // Check for re-abstraction of method
         if (!ik->is_interface() && m != NULL && m->is_abstract()) {
           // Found a matching abstract method 'm' in the class hierarchy.
@@ -1228,23 +1234,20 @@ class ClassHierarchyWalker {
               // Found a concrete subtype 'w' which does not override abstract method 'm'.
               // Bail out because 'm' could be called with 'w' as receiver (leading to an
               // AbstractMethodError) and thus the method we are looking for is not unique.
-              _found_methods[_num_participants] = m;
-              return true;
+              return record_witness(k, m);
             }
           }
         }
         // Check interface defaults also, if any exist.
         Array<Method*>* default_methods = ik->default_methods();
-        if (default_methods == NULL)
-            return false;
-        m = ik->find_method(default_methods, _name, _signature);
-        if (!Dependencies::is_concrete_method(m, NULL))
-            return false;
+        if (default_methods != NULL) {
+          Method* dm = ik->find_method(default_methods, _name, _signature);
+          if (Dependencies::is_concrete_method(dm, NULL)) {
+            return record_witness(k, dm); // default method found
+          }
+        }
+        return false; // no concrete method found
       }
-      _found_methods[_num_participants] = m;
-      // Note:  If add_participant(k) is called,
-      // the method m will already be memoized for it.
-      return true;
     }
   }
 
@@ -1257,13 +1260,22 @@ class ClassHierarchyWalker {
       return in_list(k, &_participants[1]);
     }
   }
-  bool ignore_witness(Klass* witness) {
+
+  bool record_witness(Klass* witness, Method* m) {
+    _found_methods[_num_participants] = m;
+    return record_witness(witness);
+  }
+
+  // It is used by is_witness() to fill up participant list (of predefined size)
+  // and to report the first witness candidate which doesn't fit into the list.
+  // Returns true when no more witnesses can be recorded.
+  bool record_witness(Klass* witness) {
     if (_record_witnesses == 0) {
-      return false;
+      return true; // report the witness
     } else {
       --_record_witnesses;
       add_participant(witness);
-      return true;
+      return false; // record the witness
     }
   }
   static bool in_list(Klass* x, Klass** list) {
@@ -1399,7 +1411,7 @@ Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
     }
   }
 
-  if (is_witness(new_type) && !ignore_witness(new_type)) {
+  if (is_witness(new_type)) {
     return new_type;
   }
 
@@ -1454,7 +1466,7 @@ Klass* ClassHierarchyWalker::find_witness_anywhere(InstanceKlass* context_type, 
       if (participants_hide_witnesses) {
         iter.skip_subclasses();
       }
-    } else if (is_witness(sub) && !ignore_witness(sub)) {
+    } else if (is_witness(sub)) {
       return sub; // found a witness
     }
   }

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -1210,17 +1210,18 @@ class ClassHierarchyWalker {
     } else if (!k->is_instance_klass()) {
       return false; // no methods to find in an array type
     } else {
+      InstanceKlass* ik = InstanceKlass::cast(k);
       // Search class hierarchy first, skipping private implementations
       // as they never override any inherited methods
-      Method* m = InstanceKlass::cast(k)->find_instance_method(_name, _signature, Klass::skip_private);
-      if (!Dependencies::is_concrete_method(m, k)) {
+      Method* m = ik->find_instance_method(_name, _signature, Klass::skip_private);
+      if (!Dependencies::is_concrete_method(m, ik)) {
         // Check for re-abstraction of method
-        if (!k->is_interface() && m != NULL && m->is_abstract()) {
+        if (!ik->is_interface() && m != NULL && m->is_abstract()) {
           // Found a matching abstract method 'm' in the class hierarchy.
           // This is fine iff 'k' is an abstract class and all concrete subtypes
           // of 'k' override 'm' and are participates of the current search.
           ClassHierarchyWalker wf(_participants, _num_participants);
-          Klass* w = wf.find_witness_subtype(k);
+          Klass* w = wf.find_witness_subtype(ik);
           if (w != NULL) {
             Method* wm = InstanceKlass::cast(w)->find_instance_method(_name, _signature, Klass::skip_private);
             if (!Dependencies::is_concrete_method(wm, w)) {
@@ -1233,10 +1234,10 @@ class ClassHierarchyWalker {
           }
         }
         // Check interface defaults also, if any exist.
-        Array<Method*>* default_methods = InstanceKlass::cast(k)->default_methods();
+        Array<Method*>* default_methods = ik->default_methods();
         if (default_methods == NULL)
             return false;
-        m = InstanceKlass::cast(k)->find_method(default_methods, _name, _signature);
+        m = ik->find_method(default_methods, _name, _signature);
         if (!Dependencies::is_concrete_method(m, NULL))
             return false;
       }
@@ -1276,17 +1277,18 @@ class ClassHierarchyWalker {
 
  private:
   // the actual search method:
-  Klass* find_witness_anywhere(Klass* context_type,
-                                 bool participants_hide_witnesses,
-                                 bool top_level_call = true);
+  Klass* find_witness_anywhere(InstanceKlass* context_type,
+                               bool participants_hide_witnesses);
   // the spot-checking version:
   Klass* find_witness_in(KlassDepChange& changes,
-                         Klass* context_type,
+                         InstanceKlass* context_type,
                          bool participants_hide_witnesses);
  public:
   bool witnessed_reabstraction_in_supers(Klass* k);
-  Klass* find_witness_subtype(Klass* context_type, KlassDepChange* changes = NULL) {
+  Klass* find_witness_subtype(Klass* k, KlassDepChange* changes = NULL) {
     assert(doing_subtype_search(), "must set up a subtype search");
+    assert(k->is_instance_klass(), "required");
+    InstanceKlass* context_type = InstanceKlass::cast(k);
     // When looking for unexpected concrete types,
     // do not look beneath expected ones.
     const bool participants_hide_witnesses = true;
@@ -1298,8 +1300,10 @@ class ClassHierarchyWalker {
       return find_witness_anywhere(context_type, participants_hide_witnesses);
     }
   }
-  Klass* find_witness_definer(Klass* context_type, KlassDepChange* changes = NULL) {
+  Klass* find_witness_definer(Klass* k, KlassDepChange* changes = NULL) {
     assert(!doing_subtype_search(), "must set up a method definer search");
+    assert(k->is_instance_klass(), "required");
+    InstanceKlass* context_type = InstanceKlass::cast(k);
     // When looking for unexpected concrete methods,
     // look beneath expected ones, to see if there are overrides.
     const bool participants_hide_witnesses = true;
@@ -1359,8 +1363,8 @@ static bool count_find_witness_calls() {
 #endif //PRODUCT
 
 Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
-                                               Klass* context_type,
-                                               bool participants_hide_witnesses) {
+                                             InstanceKlass* context_type,
+                                             bool participants_hide_witnesses) {
   assert(changes.involves_context(context_type), "irrelevant dependency");
   Klass* new_type = changes.new_type();
 
@@ -1372,7 +1376,7 @@ Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
   // Must not move the class hierarchy during this check:
   assert_locked_or_safepoint(Compile_lock);
 
-  int nof_impls = InstanceKlass::cast(context_type)->nof_implementors();
+  int nof_impls = context_type->nof_implementors();
   if (nof_impls > 1) {
     // Avoid this case: *I.m > { A.m, C }; B.m > C
     // %%% Until this is fixed more systematically, bail out.
@@ -1403,13 +1407,7 @@ Klass* ClassHierarchyWalker::find_witness_in(KlassDepChange& changes,
 }
 
 // Walk hierarchy under a context type, looking for unexpected types.
-// Do not report participant types, and recursively walk beneath
-// them only if participants_hide_witnesses is false.
-// If top_level_call is false, skip testing the context type,
-// because the caller has already considered it.
-Klass* ClassHierarchyWalker::find_witness_anywhere(Klass* context_type,
-                                                     bool participants_hide_witnesses,
-                                                     bool top_level_call) {
+Klass* ClassHierarchyWalker::find_witness_anywhere(InstanceKlass* context_type, bool participants_hide_witnesses) {
   // Current thread must be in VM (not native mode, as in CI):
   assert(must_be_in_vm(), "raw oops here");
   // Must not move the class hierarchy during this check:
@@ -1418,106 +1416,50 @@ Klass* ClassHierarchyWalker::find_witness_anywhere(Klass* context_type,
   bool do_counts = count_find_witness_calls();
 
   // Check the root of the sub-hierarchy first.
-  if (top_level_call) {
-    if (do_counts) {
-      NOT_PRODUCT(deps_find_witness_calls++);
-      NOT_PRODUCT(deps_find_witness_steps++);
-    }
-    if (is_participant(context_type)) {
-      if (participants_hide_witnesses)  return NULL;
-      // else fall through to search loop...
-    } else if (is_witness(context_type) && !ignore_witness(context_type)) {
-      // The context is an abstract class or interface, to start with.
-      return context_type;
-    }
+  if (do_counts) {
+    NOT_PRODUCT(deps_find_witness_calls++);
   }
 
-  // Now we must check each implementor and each subclass.
-  // Use a short worklist to avoid blowing the stack.
-  // Each worklist entry is a *chain* of subklass siblings to process.
-  const int CHAINMAX = 100;  // >= 1 + InstanceKlass::implementors_limit
-  Klass* chains[CHAINMAX];
-  int    chaini = 0;  // index into worklist
-  Klass* chain;       // scratch variable
-#define ADD_SUBCLASS_CHAIN(k)                     {  \
-    assert(chaini < CHAINMAX, "oob");                \
-    chain = k->subklass();                           \
-    if (chain != NULL)  chains[chaini++] = chain;    }
-
-  // Look for non-abstract subclasses.
-  // (Note:  Interfaces do not have subclasses.)
-  ADD_SUBCLASS_CHAIN(context_type);
-
+  // (Note: Interfaces do not have subclasses.)
   // If it is an interface, search its direct implementors.
-  // (Their subclasses are additional indirect implementors.
-  // See InstanceKlass::add_implementor.)
-  // (Note:  nof_implementors is always zero for non-interfaces.)
-  if (top_level_call) {
-    int nof_impls = InstanceKlass::cast(context_type)->nof_implementors();
-    if (nof_impls > 1) {
+  // (Their subclasses are additional indirect implementors. See InstanceKlass::add_implementor().)
+  if (context_type->is_interface()) {
+    int nof_impls = context_type->nof_implementors();
+    if (nof_impls == 0) {
+      return NULL; // no implementors
+    } else if (nof_impls == 1) { // unique implementor
+      assert(context_type != context_type->implementor(), "not unique");
+      context_type = InstanceKlass::cast(context_type->implementor());
+    } else { // nof_impls >= 2
       // Avoid this case: *I.m > { A.m, C }; B.m > C
       // Here, I.m has 2 concrete implementations, but m appears unique
       // as A.m, because the search misses B.m when checking C.
       // The inherited method B.m was getting missed by the walker
       // when interface 'I' was the starting point.
       // %%% Until this is fixed more systematically, bail out.
-      // (Old CHA had the same limitation.)
       return context_type;
     }
-    if (nof_impls > 0) {
-      Klass* impl = InstanceKlass::cast(context_type)->implementor();
-      assert(impl != NULL, "just checking");
-      // If impl is the same as the context_type, then more than one
-      // implementor has seen. No exact info in this case.
-      if (impl == context_type) {
-        return context_type;  // report an inexact witness to this sad affair
-      }
-      if (do_counts)
-        { NOT_PRODUCT(deps_find_witness_steps++); }
-      if (is_participant(impl)) {
-        if (!participants_hide_witnesses) {
-          ADD_SUBCLASS_CHAIN(impl);
-        }
-      } else if (is_witness(impl) && !ignore_witness(impl)) {
-        return impl;
-      } else {
-        ADD_SUBCLASS_CHAIN(impl);
-      }
-    }
   }
 
-  // Recursively process each non-trivial sibling chain.
-  while (chaini > 0) {
-    Klass* chain = chains[--chaini];
-    for (Klass* sub = chain; sub != NULL; sub = sub->next_sibling()) {
-      if (do_counts) { NOT_PRODUCT(deps_find_witness_steps++); }
-      if (is_participant(sub)) {
-        if (participants_hide_witnesses)  continue;
-        // else fall through to process this guy's subclasses
-      } else if (is_witness(sub) && !ignore_witness(sub)) {
-        return sub;
+  assert(!context_type->is_interface(), "not allowed");
+
+  for (ClassHierarchyIterator iter(context_type); !iter.done(); iter.next()) {
+    Klass* sub = iter.klass();
+
+    if (do_counts) { NOT_PRODUCT(deps_find_witness_steps++); }
+
+    // Do not report participant types.
+    if (is_participant(sub)) {
+      // Walk beneath a participant only when it doesn't hide witnesses.
+      if (participants_hide_witnesses) {
+        iter.skip_subclasses();
       }
-      if (chaini < (VerifyDependencies? 2: CHAINMAX)) {
-        // Fast path.  (Partially disabled if VerifyDependencies.)
-        ADD_SUBCLASS_CHAIN(sub);
-      } else {
-        // Worklist overflow.  Do a recursive call.  Should be rare.
-        // The recursive call will have its own worklist, of course.
-        // (Note that sub has already been tested, so that there is
-        // no need for the recursive call to re-test.  That's handy,
-        // since the recursive call sees sub as the context_type.)
-        if (do_counts) { NOT_PRODUCT(deps_find_witness_recursions++); }
-        Klass* witness = find_witness_anywhere(sub,
-                                                 participants_hide_witnesses,
-                                                 /*top_level_call=*/ false);
-        if (witness != NULL)  return witness;
-      }
+    } else if (is_witness(sub) && !ignore_witness(sub)) {
+      return sub; // found a witness
     }
   }
-
   // No witness found.  The dependency remains unbroken.
   return NULL;
-#undef ADD_SUBCLASS_CHAIN
 }
 
 bool ClassHierarchyWalker::witnessed_reabstraction_in_supers(Klass* k) {

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -2236,10 +2236,12 @@ Method* Dependencies::find_unique_concrete_method(Klass* ctxk, Method* m, Klass*
   assert(fm == NULL || !fm->is_abstract(), "sanity");
   // Old CHA conservatively reports concrete methods in abstract classes
   // irrespective of whether they have concrete subclasses or not.
+  // Also, abstract root method case is not fully supported.
 #ifdef ASSERT
   Klass*  uniqp = NULL;
   Method* uniqm = Dependencies::find_unique_concrete_method(ctxk, m, &uniqp);
   assert(uniqm == NULL || uniqm == fm ||
+         m->is_abstract() ||
          uniqm->method_holder()->is_abstract() ||
          (fm == NULL && uniqm != NULL && uniqp != NULL && !InstanceKlass::cast(uniqp)->is_linked()),
          "sanity");

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -28,6 +28,7 @@
 #include "ci/ciCallSite.hpp"
 #include "ci/ciInstanceKlass.hpp"
 #include "ci/ciKlass.hpp"
+#include "ci/ciMethod.hpp"
 #include "ci/ciMethodHandle.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "code/compressedStream.hpp"
@@ -348,6 +349,9 @@ class Dependencies: public ResourceObj {
   static void check_unique_implementor(ciInstanceKlass* ctxk, ciInstanceKlass* uniqk) {
     assert(ctxk->implementor() == uniqk, "not a unique implementor");
   }
+  static void check_unique_method(ciKlass* ctxk, ciMethod* m) {
+    assert(!m->can_be_statically_bound(ctxk->as_instance_klass()), "redundant");
+  }
 
   void assert_common_1(DepType dept, ciBaseObject* x);
   void assert_common_2(DepType dept, ciBaseObject* x0, ciBaseObject* x1);
@@ -376,6 +380,10 @@ class Dependencies: public ResourceObj {
     check_ctxk(ctxk);
     assert(ctxk->is_abstract(), "must be abstract");
   }
+  static void check_unique_method(Klass* ctxk, Method* m) {
+    assert(!m->can_be_statically_bound(InstanceKlass::cast(ctxk)), "redundant");
+  }
+
   void assert_common_1(DepType dept, DepValue x);
   void assert_common_2(DepType dept, DepValue x0, DepValue x1);
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -4047,3 +4047,24 @@ void InstanceKlass::set_init_thread(Thread *thread)  {
   }
   _init_thread = thread;
 }
+
+// Make a step iterating over the class hierarchy under the root class.
+// Skips subclasses if requested.
+void ClassHierarchyIterator::next() {
+  assert(_current != NULL, "required");
+  if (_visit_subclasses && _current->subklass() != NULL) {
+    _current = _current->subklass();
+    return; // visit next subclass
+  }
+  _visit_subclasses = true; // reset
+  while (_current->next_sibling() == NULL && _current != _root) {
+    _current = _current->superklass(); // backtrack; no more sibling subclasses left
+  }
+  if (_current == _root) {
+    // Iteration is over (back at root after backtracking). Invalidate the iterator.
+    _current = NULL;
+    return;
+  }
+  _current = _current->next_sibling();
+  return; // visit next sibling subclass
+}

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1495,4 +1495,40 @@ class InnerClassesIterator : public StackObj {
   }
 };
 
+// Iterator over class hierarchy under a particular class. Implements depth-first pre-order traversal.
+// Usage:
+//  for (ClassHierarchyIterator iter(root_klass); !iter.done(); iter.next()) {
+//    Klass* k = iter.klass();
+//    ...
+//  }
+class ClassHierarchyIterator : public StackObj {
+ private:
+  InstanceKlass* _root;
+  Klass*         _current;
+  bool           _visit_subclasses;
+
+ public:
+  ClassHierarchyIterator(InstanceKlass* root) : _root(root), _current(root), _visit_subclasses(true) {
+    assert(!root->is_interface(), "no subclasses");
+    assert(_root == _current, "required"); // initial state
+  }
+
+  bool done() {
+    return (_current == NULL);
+  }
+
+  // Make a step iterating over the class hierarchy under the root class.
+  // Skips subclasses if requested.
+  void next();
+
+  Klass* klass() {
+    assert(!done(), "sanity");
+    return _current;
+  }
+
+  // Skip subclasses of the current class.
+  void skip_subclasses() {
+    _visit_subclasses = false;
+  }
+};
 #endif // SHARE_VM_OOPS_INSTANCEKLASS_HPP

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1167,6 +1167,8 @@ public:
   // Java itable
   klassItable itable() const;        // return klassItable wrapper
   Method* method_at_itable(Klass* holder, int index, TRAPS);
+  Method* method_at_itable_or_null(InstanceKlass* holder, int index, bool& itable_entry_found);
+  int vtable_index_of_interface_method(Method* method);
 
 #if INCLUDE_JVMTI
   void adjust_default_methods(InstanceKlass* holder, bool* trace_name_printed);

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -659,6 +659,10 @@ bool Method::can_be_statically_bound() const {
   return can_be_statically_bound(method_holder()->access_flags());
 }
 
+bool Method::can_be_statically_bound(InstanceKlass* context) const {
+  return (method_holder() == context) && can_be_statically_bound();
+}
+
 bool Method::is_accessor() const {
   return is_getter() || is_setter();
 }

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -617,6 +617,7 @@ class Method : public Metadata {
 
   // true if method needs no dynamic dispatch (final and/or no vtable entry)
   bool can_be_statically_bound() const;
+  bool can_be_statically_bound(InstanceKlass* context) const;
   bool can_be_statically_bound(AccessFlags class_access_flags) const;
 
   // returns true if the method has any backward branches.

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -665,11 +665,13 @@ class PredictedCallGenerator : public CallGenerator {
   CallGenerator* _if_missed;
   CallGenerator* _if_hit;
   float          _hit_prob;
+  bool           _exact_check;
 
 public:
   PredictedCallGenerator(ciKlass* predicted_receiver,
                          CallGenerator* if_missed,
-                         CallGenerator* if_hit, float hit_prob)
+                         CallGenerator* if_hit, bool exact_check,
+                         float hit_prob)
     : CallGenerator(if_missed->method())
   {
     // The call profile data may predict the hit_prob as extreme as 0 or 1.
@@ -681,6 +683,7 @@ public:
     _if_missed          = if_missed;
     _if_hit             = if_hit;
     _hit_prob           = hit_prob;
+    _exact_check        = exact_check;
   }
 
   virtual bool      is_virtual()   const    { return true; }
@@ -695,9 +698,16 @@ CallGenerator* CallGenerator::for_predicted_call(ciKlass* predicted_receiver,
                                                  CallGenerator* if_missed,
                                                  CallGenerator* if_hit,
                                                  float hit_prob) {
-  return new PredictedCallGenerator(predicted_receiver, if_missed, if_hit, hit_prob);
+  return new PredictedCallGenerator(predicted_receiver, if_missed, if_hit,
+                                    /*exact_check=*/true, hit_prob);
 }
 
+CallGenerator* CallGenerator::for_guarded_call(ciKlass* guarded_receiver,
+                                               CallGenerator* if_missed,
+                                               CallGenerator* if_hit) {
+  return new PredictedCallGenerator(guarded_receiver, if_missed, if_hit,
+                                    /*exact_check=*/false, PROB_ALWAYS);
+}
 
 JVMState* PredictedCallGenerator::generate(JVMState* jvms) {
   GraphKit kit(jvms);
@@ -708,8 +718,8 @@ JVMState* PredictedCallGenerator::generate(JVMState* jvms) {
   Node* receiver = kit.argument(0);
   CompileLog* log = kit.C->log();
   if (log != NULL) {
-    log->elem("predicted_call bci='%d' klass='%d'",
-              jvms->bci(), log->identify(_predicted_receiver));
+    log->elem("predicted_call bci='%d' exact='%d' klass='%d'",
+              jvms->bci(), (_exact_check ? 1 : 0), log->identify(_predicted_receiver));
   }
 
   receiver = kit.null_check_receiver_before_call(method());
@@ -721,10 +731,15 @@ JVMState* PredictedCallGenerator::generate(JVMState* jvms) {
   ReplacedNodes replaced_nodes = kit.map()->replaced_nodes();
   replaced_nodes.clone();
 
-  Node* exact_receiver = receiver;  // will get updated in place...
-  Node* slow_ctl = kit.type_check_receiver(receiver,
-                                           _predicted_receiver, _hit_prob,
-                                           &exact_receiver);
+  Node* casted_receiver = receiver;  // will get updated in place...
+  Node* slow_ctl = NULL;
+  if (_exact_check) {
+    slow_ctl = kit.type_check_receiver(receiver, _predicted_receiver, _hit_prob,
+                                       &casted_receiver);
+  } else {
+    slow_ctl = kit.subtype_check_receiver(receiver, _predicted_receiver,
+                                          &casted_receiver);
+  }
 
   SafePointNode* slow_map = NULL;
   JVMState* slow_jvms = NULL;
@@ -749,7 +764,7 @@ JVMState* PredictedCallGenerator::generate(JVMState* jvms) {
   }
 
   // fall through if the instance exactly matches the desired type
-  kit.replace_in_map(receiver, exact_receiver);
+  kit.replace_in_map(receiver, casted_receiver);
 
   // Make the hot call:
   JVMState* new_jvms = _if_hit->generate(kit.sync_jvms());

--- a/src/hotspot/share/opto/callGenerator.hpp
+++ b/src/hotspot/share/opto/callGenerator.hpp
@@ -145,6 +145,10 @@ class CallGenerator : public ResourceObj {
                                            CallGenerator* if_hit,
                                            float hit_prob);
 
+  static CallGenerator* for_guarded_call(ciKlass* predicted_receiver,
+                                         CallGenerator* if_missed,
+                                         CallGenerator* if_hit);
+
   // How to make a call that optimistically assumes a MethodHandle target:
   static CallGenerator* for_predicted_dynamic_call(ciMethodHandle* predicted_method_handle,
                                                    CallGenerator* if_missed,

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1060,7 +1060,7 @@ class Compile : public Phase {
                                   const TypeOopPtr* receiver_type, bool is_virtual,
                                   bool &call_does_dispatch, int &vtable_index,
                                   bool check_access = true);
-  ciMethod* optimize_inlining(ciMethod* caller, int bci, ciInstanceKlass* klass,
+  ciMethod* optimize_inlining(ciMethod* caller, ciInstanceKlass* klass, ciKlass* holder,
                               ciMethod* callee, const TypeOopPtr* receiver_type,
                               bool check_access = true);
 

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -1165,14 +1165,19 @@ ciMethod* Compile::optimize_inlining(ciMethod* caller, int bci, ciInstanceKlass*
       cha_monomorphic_target = NULL;
     }
   }
+
   if (cha_monomorphic_target != NULL) {
     // Hardwiring a virtual.
-    // If we inlined because CHA revealed only a single target method,
-    // then we are dependent on that target method not getting overridden
-    // by dynamic class loading.  Be sure to test the "static" receiver
-    // dest_method here, as opposed to the actual receiver, which may
-    // falsely lead us to believe that the receiver is final or private.
-    dependencies()->assert_unique_concrete_method(actual_receiver, cha_monomorphic_target);
+    assert(!callee->can_be_statically_bound(), "should have been handled earlier");
+    assert(!cha_monomorphic_target->is_abstract(), "");
+    if (!cha_monomorphic_target->can_be_statically_bound(actual_receiver)) {
+      // If we inlined because CHA revealed only a single target method,
+      // then we are dependent on that target method not getting overridden
+      // by dynamic class loading.  Be sure to test the "static" receiver
+      // dest_method here, as opposed to the actual receiver, which may
+      // falsely lead us to believe that the receiver is final or private.
+      dependencies()->assert_unique_concrete_method(actual_receiver, cha_monomorphic_target);
+    }
     return cha_monomorphic_target;
   }
 

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -296,6 +296,51 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
         }
       }
     }
+
+    // If there is only one implementor of this interface then we
+    // may be able to bind this invoke directly to the implementing
+    // klass but we need both a dependence on the single interface
+    // and on the method we bind to. Additionally since all we know
+    // about the receiver type is that it's supposed to implement the
+    // interface we have to insert a check that it's the class we
+    // expect.  Interface types are not checked by the verifier so
+    // they are roughly equivalent to Object.
+    // The number of implementors for declared_interface is less or
+    // equal to the number of implementors for target->holder() so
+    // if number of implementors of target->holder() == 1 then
+    // number of implementors for decl_interface is 0 or 1. If
+    // it's 0 then no class implements decl_interface and there's
+    // no point in inlining.
+    if (call_does_dispatch && bytecode == Bytecodes::_invokeinterface) {
+      ciInstanceKlass* declared_interface =
+          caller->get_declared_method_holder_at_bci(bci)->as_instance_klass();
+
+      if (declared_interface->nof_implementors() == 1 &&
+          (!callee->is_default_method() || callee->is_overpass()) /* CHA doesn't support default methods yet */) {
+        ciInstanceKlass* singleton = declared_interface->implementor();
+        ciMethod* cha_monomorphic_target =
+            callee->find_monomorphic_target(caller->holder(), declared_interface, singleton);
+
+        if (cha_monomorphic_target != NULL &&
+            cha_monomorphic_target->holder() != env()->Object_klass()) { // subtype check against Object is useless
+          ciKlass* holder = cha_monomorphic_target->holder();
+
+          // Try to inline the method found by CHA. Inlined method is guarded by the type check.
+          CallGenerator* hit_cg = call_generator(cha_monomorphic_target,
+              vtable_index, !call_does_dispatch, jvms, allow_inline, prof_factor);
+
+          // Deoptimize on type check fail. The interpreter will throw ICCE for us.
+          CallGenerator* miss_cg = CallGenerator::for_uncommon_trap(callee,
+              Deoptimization::Reason_class_check, Deoptimization::Action_none);
+
+          CallGenerator* cg = CallGenerator::for_guarded_call(holder, miss_cg, hit_cg);
+          if (hit_cg != NULL && cg != NULL) {
+            dependencies()->assert_unique_concrete_method(declared_interface, cha_monomorphic_target);
+            return cg;
+          }
+        }
+      }
+    }
   }
 
   // Nothing claimed the intrinsic, we go with straight-forward inlining

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -315,8 +315,7 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
       ciInstanceKlass* declared_interface =
           caller->get_declared_method_holder_at_bci(bci)->as_instance_klass();
 
-      if (declared_interface->nof_implementors() == 1 &&
-          (!callee->is_default_method() || callee->is_overpass()) /* CHA doesn't support default methods yet */) {
+      if (declared_interface->nof_implementors() == 1) {
         ciInstanceKlass* singleton = declared_interface->implementor();
         ciMethod* cha_monomorphic_target =
             callee->find_monomorphic_target(caller->holder(), declared_interface, singleton);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2833,6 +2833,22 @@ Node* GraphKit::type_check_receiver(Node* receiver, ciKlass* klass,
   return fail;
 }
 
+//------------------------------subtype_check_receiver-------------------------
+Node* GraphKit::subtype_check_receiver(Node* receiver, ciKlass* klass,
+                                       Node** casted_receiver) {
+  const TypeKlassPtr* tklass = TypeKlassPtr::make(klass);
+  Node* recv_klass = load_object_klass(receiver);
+  Node* want_klass = makecon(tklass);
+
+  Node* slow_ctl = gen_subtype_check(recv_klass, want_klass);
+
+  // Cast receiver after successful check
+  const TypeOopPtr* recv_type = tklass->cast_to_exactness(false)->is_klassptr()->as_instance_type();
+  Node* cast = new CheckCastPPNode(control(), receiver, recv_type);
+  (*casted_receiver) = _gvn.transform(cast);
+
+  return slow_ctl;
+}
 
 //------------------------------seems_never_null-------------------------------
 // Use null_seen information if it is available from the profile.

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -845,6 +845,10 @@ class GraphKit : public Phase {
   Node* type_check_receiver(Node* receiver, ciKlass* klass, float prob,
                             Node* *casted_receiver);
 
+  // Inexact type check used for predicted calls.
+  Node* subtype_check_receiver(Node* receiver, ciKlass* klass,
+                               Node** casted_receiver);
+
   // implementation of object creation
   Node* set_output_for_allocation(AllocateNode* alloc,
                                   const TypeOopPtr* oop_type,

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1222,6 +1222,9 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   develop(bool, UseCHA, true,                                               \
           "Enable CHA")                                                     \
                                                                             \
+  diagnostic(bool, UseVtableBasedCHA, true,                                 \
+          "Use vtable information during CHA")                              \
+                                                                            \
   product(bool, UseTypeProfile, true,                                       \
           "Check interpreter profile for historically monomorphic calls")   \
                                                                             \

--- a/test/hotspot/jtreg/compiler/cha/AbstractRootMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/AbstractRootMethod.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires !vm.graal.enabled & vm.opt.final.UseVtableBasedCHA == true
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ *          java.base/jdk.internal.vm.annotation
+ * @library /test/lib /
+ * @compile Utils.java
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*::m
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=dontinline,*::test
+ *                   -Xbatch -Xmixed -XX:+WhiteBoxAPI
+ *                   -XX:-TieredCompilation
+ *                      compiler.cha.AbstractRootMethod
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*::m
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=dontinline,*::test
+ *                   -Xbatch -Xmixed -XX:+WhiteBoxAPI
+ *                   -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+ *                      compiler.cha.AbstractRootMethod
+ */
+package compiler.cha;
+
+import static compiler.cha.Utils.*;
+
+public class AbstractRootMethod {
+    public static void main(String[] args) {
+        run(AbstractClass.class);
+        run(AbstractInterface.class);
+    }
+
+    public static class AbstractClass extends ATest<AbstractClass.C> {
+        public AbstractClass() {
+            super(C.class, D.class);
+        }
+
+        interface I1 { Object m(); }
+        interface I2 { default Object m() { return "I2.m"; } }
+
+        static abstract class C            { public abstract Object m(); }
+
+        static abstract class D  extends C {
+            final Object ret = CORRECT;
+            public Object m() {
+                return ret;
+            }
+        }
+
+        static abstract class E1 extends C { /* empty */ }
+        static abstract class E2 extends C { public abstract Object m(); }
+        static abstract class E3 extends C { public Object m() { return "E3.m"; } }
+
+        static abstract class F1 extends C implements I1 { }
+        static abstract class F2 extends C implements I2 { }
+
+        static          class G  extends C { public Object m() { return CORRECT; } }
+
+        @Override
+        public Object test(C obj) {
+            return obj.m(); // invokevirtual C.m()
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            // nothing to do: concrete class types are enforced by the verifier
+        }
+
+        @TestCase
+        public void test() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // Dn <: D.m <: C.m ABSTRACT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = C, method = D.m
+
+            // 1. No invalidation: abstract classes don't participate in CHA.
+            initialize(E1.class,  // ABSTRACT E1            <: C.m ABSTRACT
+                       E2.class,  // ABSTRACT E2.m ABSTRACT <: C.m ABSTRACT
+                       E3.class,  // ABSTRACT E3.m          <: C.m ABSTRACT
+                       F1.class,  // ABSTRACT F1            <: C.m ABSTRACT, I1.m ABSTRACT
+                       F2.class); // ABSTRACT F2            <: C.m ABSTRACT, I2.m DEFAULT
+            assertCompiled();
+
+            // 2. Dependency invalidation: G.m <: C.m ABSTRACT
+            load(G.class);
+            assertCompiled();
+
+            // 3. Dependency invalidation: G.m <: C.m ABSTRACT
+            initialize(G.class);
+            assertNotCompiled();
+
+            // 4. Recompilation: no inlining, no dependencies
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; } }); //  Cn.m <: C.m ABSTRACT
+            call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C.m ABSTRACT
+            assertCompiled();
+        }
+    }
+    public static class AbstractInterface extends ATest<AbstractInterface.C> {
+        public AbstractInterface() {
+            super(C.class, D.class);
+        }
+
+        interface I1 { Object m(); }
+        interface I2 extends I { default Object m() { return "I2.m"; } }
+
+        interface I { Object m(); }
+
+        static abstract class C implements I { /* inherited from I */}
+
+        static abstract class D  extends C {
+            final Object ret = CORRECT;
+            public Object m() {
+                return ret;
+            }
+        }
+
+        static abstract class E1 extends C { /* empty */ }
+        static abstract class E2 extends C { public abstract Object m(); }
+        static abstract class E3 extends C { public Object m() { return "E3.m"; } }
+
+        static abstract class F1 extends C implements I1 { }
+        static abstract class F2 extends C implements I2 { }
+
+        static          class G  extends C { public Object m() { return CORRECT; } }
+
+        @Override
+        public Object test(C obj) {
+            return obj.m(); // invokevirtual C.m()
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            // nothing to do: concrete class types are enforced by the verifier
+        }
+
+        @TestCase
+        public void test() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // Dn <: D.m <: C <: I.m ABSTRACT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = C, method = D.m
+
+            // 1. No invalidation: abstract classes don't participate in CHA.
+            initialize(E1.class,  // ABSTRACT E1            <: C <: I.m ABSTRACT
+                       E2.class,  // ABSTRACT E2.m ABSTRACT <: C <: I.m ABSTRACT
+                       E3.class,  // ABSTRACT E3.m          <: C <: I.m ABSTRACT
+                       F1.class,  // ABSTRACT F1            <: C <: I.m ABSTRACT, I1.m ABSTRACT
+                       F2.class); // ABSTRACT F2            <: C <: I.m ABSTRACT, I2.m DEFAULT
+            assertCompiled();
+
+            // 2. Dependency invalidation: G.m <: C <: I.m ABSTRACT
+            load(G.class);
+            assertCompiled();
+
+            // 3. Dependency invalidation: G.m <: C <: I.m ABSTRACT
+            initialize(G.class);
+            assertNotCompiled();
+
+            // 4. Recompilation: no inlining, no dependencies
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; } }); //  Cn.m <: C <: I.m ABSTRACT
+            call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C <: I.m ABSTRACT
+            assertCompiled();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/cha/DefaultRootMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/DefaultRootMethod.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires !vm.graal.enabled & vm.opt.final.UseVtableBasedCHA == true
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ *          java.base/jdk.internal.vm.annotation
+ * @library /test/lib /
+ * @compile Utils.java
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*::m
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=dontinline,*::test
+ *                   -Xbatch -Xmixed -XX:+WhiteBoxAPI
+ *                   -XX:-TieredCompilation
+ *                      compiler.cha.DefaultRootMethod
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*::m
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=dontinline,*::test
+ *                   -Xbatch -Xmixed -XX:+WhiteBoxAPI
+ *                   -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+ *                      compiler.cha.DefaultRootMethod
+ */
+package compiler.cha;
+
+import static compiler.cha.Utils.*;
+
+public class DefaultRootMethod {
+    public static void main(String[] args) {
+        run(DefaultRoot.class);
+        run(InheritedDefault.class);
+        System.out.println("TEST PASSED");
+    }
+
+    public static class DefaultRoot extends ATest<DefaultRoot.C> {
+        public DefaultRoot() {
+            super(C.class, D.class);
+        }
+
+        interface I { default Object m() { return CORRECT; } }
+
+        static class C implements I { /* inherited I.m */}
+
+        static class D extends C { /* inherited I.m */ }
+
+        static abstract class E1 extends C { /* empty */ }
+        static abstract class E2 extends C { public abstract Object m(); }
+        static abstract class E3 extends C { public Object m() { return "E3.m"; } }
+
+        interface I1 extends I { Object m(); }
+        interface I2 extends I { default Object m() { return "I2.m"; } }
+
+        static abstract class F1 extends C implements I1 { }
+        static abstract class F2 extends C implements I2 { }
+
+        static          class G  extends C { public Object m() { return CORRECT; } }
+
+        @Override
+        public Object test(C obj) {
+            return obj.m(); // invokevirtual C.m()
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            // nothing to do: concrete class types are enforced by the verifier
+        }
+
+        @TestCase
+        public void test() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // Dn <: D.m <: C <: I.m DEFAULT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = C, method = D.m
+
+            // 1. No invalidation: abstract classes don't participate in CHA.
+            initialize(E1.class,  // ABSTRACT E1            <: C <: I.m DEFAULT
+                       E2.class,  // ABSTRACT E2.m ABSTRACT <: C <: I.m DEFAULT
+                       E3.class,  // ABSTRACT E3.m          <: C <: I.m DEFAULT
+                       F1.class,  // ABSTRACT F1            <: C <: I.m DEFAULT, I1.m ABSTRACT
+                       F2.class); // ABSTRACT F2            <: C <: I.m DEFAULT, I2.m DEFAULT
+            assertCompiled();
+
+            // 2. Dependency invalidation: G.m <: C <: I.m DEFAULT
+            load(G.class);
+            assertCompiled();
+
+            // 3. Dependency invalidation: G.m <: C <: I.m DEFAULT
+            initialize(G.class);
+            assertNotCompiled();
+
+            // 4. Recompilation: no inlining, no dependencies
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; } }); //  Cn.m <: C <: I.m DEFAULT
+            call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C <: I.m DEFAULT
+            assertCompiled();
+        }
+    }
+
+    public static class InheritedDefault extends ATest<InheritedDefault.C> {
+        public InheritedDefault() {
+            super(C.class, D.class);
+        }
+
+        interface I           { Object m(); }
+        interface J extends I { default Object m() { return CORRECT; } }
+
+        static abstract class C implements I { /* inherits I.m ABSTRACT */}
+
+        // NB! The class is marked abstract to avoid abstract_with_unique_concrete_subtype dependency
+        static abstract class D extends C implements J { /* inherits J.m DEFAULT*/ }
+
+        static abstract class E1 extends C { /* empty */ }
+        static abstract class E2 extends C { public abstract Object m(); }
+        static abstract class E3 extends C { public Object m() { return "E3.m"; } }
+
+        interface I1 extends I { Object m(); }
+        interface I2 extends I { default Object m() { return "I2.m"; } }
+
+        static abstract class F1 extends C implements I1 { }
+        static abstract class F2 extends C implements I2 { }
+
+        interface K extends I { default Object m() { return CORRECT; } }
+        static class G extends C implements K { /* inherits K.m DEFAULT */ }
+
+        @Override
+        public Object test(C obj) {
+            return obj.m(); // invokevirtual C.m()
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            // nothing to do: concrete class types are enforced by the verifier
+        }
+
+        @TestCase
+        public void test() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // Dn <: D.m <: C <: I.m ABSTRACT, J.m DEFAULT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = C, method = D.m
+
+            // 1. No invalidation: abstract classes don't participate in CHA.
+            initialize(E1.class,  // ABSTRACT E1            <: C <: I.m ABSTRACT
+                       E2.class,  // ABSTRACT E2.m ABSTRACT <: C <: I.m ABSTRACT
+                       E3.class,  // ABSTRACT E3.m          <: C <: I.m ABSTRACT
+                       F1.class,  // ABSTRACT F1            <: C <: I.m ABSTRACT, I1.m ABSTRACT
+                       F2.class); // ABSTRACT F2            <: C <: I.m ABSTRACT, I2.m DEFAULT
+            assertCompiled();
+
+            // 2. No invalidation: not yet linked classes don't participate in CHA.
+            load(G.class);
+            assertCompiled();
+
+            // 3. Dependency invalidation: G.m <: C <: I.m DEFAULT
+            initialize(G.class);
+            assertNotCompiled();
+
+            // 4. Recompilation: no inlining, no dependencies
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; } }); //  Cn.m <: C <: I.m DEFAULT
+            call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C <: I.m DEFAULT
+            assertCompiled();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
+++ b/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
@@ -1,0 +1,970 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires !vm.graal.enabled
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.misc
+ *          java.base/jdk.internal.vm.annotation
+ * @library /test/lib /
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
+ *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed
+ *                   -XX:-TieredCompilation
+ *                      compiler.cha.StrengthReduceInterfaceCall
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
+ *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed
+ *                   -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+ *                      compiler.cha.StrengthReduceInterfaceCall
+ */
+package compiler.cha;
+
+import jdk.internal.misc.Unsafe;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.vm.annotation.DontInline;
+import sun.hotspot.WhiteBox;
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+
+import static jdk.test.lib.Asserts.*;
+import static jdk.internal.org.objectweb.asm.ClassWriter.*;
+import static jdk.internal.org.objectweb.asm.Opcodes.*;
+
+public class StrengthReduceInterfaceCall {
+    public static void main(String[] args) {
+        run(ObjectToString.class);
+        run(ObjectHashCode.class);
+        run(TwoLevelHierarchyLinear.class);
+        run(ThreeLevelHierarchyLinear.class);
+        run(ThreeLevelHierarchyAbstractVsDefault.class);
+        run(ThreeLevelDefaultHierarchy.class);
+        run(ThreeLevelDefaultHierarchy1.class);
+    }
+
+    public static class ObjectToString extends ATest<ObjectToString.I> {
+        public ObjectToString() { super(I.class, C.class); }
+
+        interface J           { String toString(); }
+        interface I extends J {}
+
+        static class C implements I {}
+
+        interface K1 extends I {}
+        interface K2 extends I { String toString(); } // K2.tS() ABSTRACT
+        // interface K3 extends I { default String toString() { return "K3"; } // K2.tS() DEFAULT
+
+        static class D implements I { public String toString() { return "D"; }}
+
+        static class DJ1 implements J {}
+        static class DJ2 implements J { public String toString() { return "DJ2"; }}
+
+        @Override
+        public Object test(I i) { return ObjectToStringHelper.test(i); /* invokeinterface I.toString() */ }
+
+        @TestCase
+        public void testMono() {
+            // 0. Trigger compilation of a monomorphic call site
+            compile(monomophic()); // C1 <: C <: intf I <: intf J <: Object.toString()
+            assertCompiled();
+
+            // Dependency: none
+
+            call(new C() { public String toString() { return "Cn"; }}); // Cn.tS <: C.tS <: intf I
+            assertCompiled();
+        }
+
+        @TestCase
+        public void testBi() {
+            // 0. Trigger compilation of a bimorphic call site
+            compile(bimorphic()); // C1 <: C <: intf I <: intf J <: Object.toString()
+            assertCompiled();
+
+            // Dependency: none
+
+            call(new C() { public String toString() { return "Cn"; }}); // Cn.tS <: C.tS <: intf I
+            assertCompiled();
+        }
+
+        @TestCase
+        public void testMega() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C <: intf I <: intf J <: Object.toString()
+            assertCompiled();
+
+            // Dependency: none
+            // compiler.cha.StrengthReduceInterfaceCall$ObjectToString::test (5 bytes)
+            //     @ 1   compiler.cha.StrengthReduceInterfaceCall$ObjectToStringHelper::test (7 bytes)   inline (hot)
+            //       @ 1   java.lang.Object::toString (36 bytes)   virtual call
+
+            // No dependency - no invalidation
+            repeat(100, () -> call(new C(){})); // Cn <: C <: intf I
+            assertCompiled();
+
+            initialize(K1.class,   // intf  K1             <: intf I <: intf J
+                       K2.class,   // intf  K2.tS ABSTRACT <: intf I <: intf J
+                       DJ1.class,  //      DJ1                       <: intf J
+                       DJ2.class); //      DJ2.tS                    <: intf J
+            assertCompiled();
+
+            initialize(D.class); // D.tS <: intf I <: intf J
+            assertCompiled();
+
+            call(new C() { public String toString() { return "Cn"; }}); // Cn.tS <: C.tS <: intf I
+            assertCompiled();
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I o = (I) unsafeCastMH(I.class).invokeExact(new Object()); // unrelated
+                test(o);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J() {}); // super interface
+                test(j);
+            });
+            assertCompiled();
+        }
+    }
+
+    public static class ObjectHashCode extends ATest<ObjectHashCode.I> {
+        public ObjectHashCode() { super(I.class, C.class); }
+
+        interface J {}
+        interface I extends J {}
+
+        static class C implements I {}
+
+        interface K1 extends I {}
+        interface K2 extends I { int hashCode(); } // K2.hC() ABSTRACT
+        // interface K3 extends I { default int hashCode() { return CORRECT; } // K2.hC() DEFAULT
+
+        static class D implements I { public int hashCode() { return super.hashCode(); }}
+
+        static class DJ1 implements J {}
+        static class DJ2 implements J { public int hashCode() { return super.hashCode(); }}
+
+        @Override
+        public Object test(I i) {
+            return ObjectHashCodeHelper.test(i); /* invokeinterface I.hashCode() */
+        }
+
+        @TestCase
+        public void testMono() {
+            // 0. Trigger compilation of a monomorphic call site
+            compile(monomophic()); // C1 <: C <: intf I <: intf J <: Object.hashCode()
+            assertCompiled();
+
+            // Dependency: none
+
+            call(new C() { public int hashCode() { return super.hashCode(); }}); // Cn.hC <: C.hC <: intf I
+            assertCompiled();
+        }
+
+        @TestCase
+        public void testBi() {
+            // 0. Trigger compilation of a bimorphic call site
+            compile(bimorphic()); // C1 <: C <: intf I <: intf J <: Object.toString()
+            assertCompiled();
+
+            // Dependency: none
+
+            call(new C() { public int hashCode() { return super.hashCode(); }}); // Cn.hC <: C.hC <: intf I
+            assertCompiled();
+        }
+
+        @TestCase
+        public void testMega() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C <: intf I <: intf J <: Object.hashCode()
+            assertCompiled();
+
+            // Dependency: none
+
+            // No dependency - no invalidation
+            repeat(100, () -> call(new C(){})); // Cn <: C <: intf I
+            assertCompiled();
+
+            initialize(K1.class,   // intf  K1             <: intf I <: intf J
+                       K2.class,   // intf  K2.hC ABSTRACT <: intf I <: intf J
+                       DJ1.class,  //      DJ1                       <: intf J
+                       DJ2.class); //      DJ2.hC                    <: intf J
+            assertCompiled();
+
+            initialize(D.class); // D.hC <: intf I <: intf J
+            assertCompiled();
+
+            call(new C() { public int hashCode() { return super.hashCode(); }}); // Cn.hC <: C.hC <: intf I
+            assertCompiled();
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I o = (I) unsafeCastMH(I.class).invokeExact(new Object()); // unrelated
+                test(o);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J() {}); // super interface
+                test(j);
+            });
+            assertCompiled();
+        }
+    }
+
+    public static class TwoLevelHierarchyLinear extends ATest<TwoLevelHierarchyLinear.I> {
+        public TwoLevelHierarchyLinear() { super(I.class, C.class); }
+
+        interface J { default Object m() { return WRONG; } }
+
+        interface I extends J { Object m(); }
+        static class C implements I { public Object m() { return CORRECT; }}
+
+        interface K1 extends I {}
+        interface K2 extends I { Object m(); }
+        interface K3 extends I { default Object m() { return WRONG; }}
+
+        static class D implements I { public Object m() { return WRONG;   }}
+
+        static class DJ1 implements J {}
+        static class DJ2 implements J { public Object m() { return WRONG; }}
+
+        @DontInline
+        public Object test(I i) {
+            return i.m();
+        }
+
+        @TestCase
+        public void testMega1() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I.m ABSTRACT <: intf J.m ABSTRACT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check is preserved
+
+            // 1. No deoptimization/invalidation on not-yet-seen receiver
+            repeat(100, () -> call(new C(){})); // Cn <: C.m <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertCompiled();
+
+            // 2. No dependency invalidation on class loading of unrelated classes: different context
+            initialize(K1.class,   // intf  K1            <: intf I.m ABSTRACT <: intf J.m DEFAULT
+                       K2.class,   // intf  K2.m ABSTRACT <: intf I.m ABSTRACT <: intf J.m DEFAULT
+                       DJ1.class,  //      DJ1                                 <: intf J.m DEFAULT
+                       DJ2.class); //      DJ2.m                               <: intf J.m DEFAULT
+            assertCompiled();
+
+            // 3. Dependency invalidation on D <: I
+            initialize(D.class); // D.m <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertNotCompiled();
+
+            // 4. Recompilation: no inlining, no dependencies
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; }}); // Cn.m <: C.m <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertCompiled();
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+        }
+
+        @TestCase
+        public void testMega2() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // 1. Dependency invalidation
+            initialize(K3.class); // intf K3.m DEFAULT <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertNotCompiled();
+
+            // 2. Recompilation: still inlines
+            // FIXME: no default method support in CHA yet
+            compile(megamorphic());
+            call(new K3() { public Object m() { return CORRECT; }}); // K3n.m <: intf K3.m DEFAULT <: intf I.m ABSTRACT <: intf J.m ABSTRACT
+            assertNotCompiled();
+
+            // 3. Recompilation: no inlining, no dependencies
+            compile(megamorphic());
+            call(new K3() { public Object m() { return CORRECT; }}); // Kn.m <: intf K3.m DEFAULT  <: intf I.m ABSTRACT <: intf J.m DEFAULT
+            assertCompiled();
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I o = (I) unsafeCastMH(I.class).invokeExact(new Object()); // unrelated
+                test(o);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J() {}); // super interface
+                test(j);
+            });
+            assertCompiled();
+        }
+    }
+
+    public static class ThreeLevelHierarchyLinear extends ATest<ThreeLevelHierarchyLinear.I> {
+        public ThreeLevelHierarchyLinear() { super(I.class, C.class); }
+
+        interface J           { Object m(); }
+        interface I extends J {}
+
+        interface K1 extends I {}
+        interface K2 extends I { Object m(); }
+        interface K3 extends I { default Object m() { return WRONG; }}
+
+        static class C  implements I { public Object m() { return CORRECT; }}
+
+        static class DI implements I { public Object m() { return WRONG;   }}
+        static class DJ implements J { public Object m() { return WRONG;   }}
+
+        @DontInline
+        public Object test(I i) {
+            return i.m(); // I <: J.m ABSTRACT
+        }
+
+        @TestCase
+        public void testMega1() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // 1. No deoptimization/invalidation on not-yet-seen receiver
+            repeat(100, () -> call(new C(){})); // Cn <: C.m <: intf I
+            assertCompiled(); // No deopt on not-yet-seen receiver
+
+            // 2. No dependency invalidation: different context
+            initialize(DJ.class,  //      DJ.m                    <: intf J.m ABSTRACT
+                       K1.class,  // intf K1            <: intf I <: intf J.m ABSTRACT
+                       K2.class); // intf K2.m ABSTRACT <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+
+            // 3. Dependency invalidation: DI.m <: I
+            initialize(DI.class); //      DI.m          <: intf I <: intf J.m ABSTRACT
+            assertNotCompiled();
+
+            // 4. Recompilation w/o a dependency
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; }}); // Cn.m <: C.m <: intf I <: intf J.m ABSTRACT
+            assertCompiled(); // no dependency
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+        }
+
+        @TestCase
+        public void testMega2() {
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // Dependency invalidation
+            initialize(K3.class); // intf K3.m DEFAULT <: intf I;
+            assertNotCompiled(); // FIXME: default methods in sub-interfaces shouldn't be taken into account by CHA
+
+            // Recompilation with a dependency
+            compile(megamorphic());
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            call(new K3() { public Object m() { return CORRECT; }}); // Kn.m <: K3.m DEFAULT <: intf I <: intf J.m ABSTRACT
+            assertNotCompiled();
+
+            // Recompilation w/o a dependency
+            compile(megamorphic());
+            // Dependency: none
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+            call(new C() { public Object m() { return CORRECT; }}); // Cn.m <: C.m <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I o = (I) unsafeCastMH(I.class).invokeExact(new Object()); // unrelated
+                test(o);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J() { public Object m() { return WRONG; }}); // super interface
+                test(j);
+            });
+            assertCompiled();
+        }
+    }
+
+    public static class ThreeLevelHierarchyAbstractVsDefault extends ATest<ThreeLevelHierarchyAbstractVsDefault.I> {
+        public ThreeLevelHierarchyAbstractVsDefault() { super(I.class, C.class); }
+
+        interface J1                { default Object m() { return WRONG; } } // intf J1.m DEFAULT
+        interface J2 extends J1     { Object m(); }                          // intf J2.m ABSTRACT <: intf J1
+        interface I  extends J1, J2 {}                                       // intf  I.m OVERPASS <: intf J1,J2
+
+        static class C  implements I { public Object m() { return CORRECT; }}
+
+        @DontInline
+        public Object test(I i) {
+            return i.m(); // intf I.m OVERPASS
+        }
+
+        static class DI implements I { public Object m() { return WRONG;   }}
+
+        static class DJ11 implements J1 {}
+        static class DJ12 implements J1 { public Object m() { return WRONG; }}
+
+        static class DJ2 implements J2 { public Object m() { return WRONG;   }}
+
+        interface K11 extends J1 {}
+        interface K12 extends J1 { Object m(); }
+        interface K13 extends J1 { default Object m() { return WRONG; }}
+        interface K21 extends J2 {}
+        interface K22 extends J2 { Object m(); }
+        interface K23 extends J2 { default Object m() { return WRONG; }}
+
+
+        public void testMega1() {
+            // 0. Trigger compilation of megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I.m OVERPASS <: intf J2.m ABSTRACT <: intf J1.m DEFAULT
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // 1. No deopt/invalidation on not-yet-seen receiver
+            repeat(100, () -> call(new C(){})); // Cn <: C.m <: intf I.m OVERPASS <: intf J2.m ABSTRACT <: intf J1.m DEFAULT
+            assertCompiled();
+
+            // 2. No dependency invalidation: different context
+            initialize(K11.class, K12.class, K13.class,
+                       K21.class, K22.class, K23.class);
+
+            // 3. Dependency invalidation: Cn.m <: C <: I
+            call(new C() { public Object m() { return CORRECT; }}); // Cn.m <: C.m <: intf I.m OVERPASS <: intf J2.m ABSTRACT <: intf J1.m DEFAULT
+            assertNotCompiled();
+
+            // 4. Recompilation w/o a dependency
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; }});
+            assertCompiled(); // no inlining
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+        }
+
+        public void testMega2() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic());
+            assertCompiled();
+
+            // Dependency: type = unique_concrete_method, context = I, method = C.m
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // 1. No dependency invalidation: different context
+            initialize(DJ11.class,
+                       DJ12.class,
+                       DJ2.class);
+            assertCompiled();
+
+            // 2. Dependency invalidation: DI.m <: I
+            initialize(DI.class);
+            assertNotCompiled();
+
+            // 3. Recompilation w/o a dependency
+            compile(megamorphic());
+            call(new C() { public Object m() { return CORRECT; }});
+            assertCompiled(); // no inlining
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I o = (I) unsafeCastMH(I.class).invokeExact(new Object()); // unrelated
+                test(o);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J1() {}); // super interface
+                test(j);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J2() { public Object m() { return WRONG; }}); // super interface
+                test(j);
+            });
+            assertCompiled();
+        }
+    }
+
+    public static class ThreeLevelDefaultHierarchy extends ATest<ThreeLevelDefaultHierarchy.I> {
+        public ThreeLevelDefaultHierarchy() { super(I.class, C.class); }
+
+        interface J           { default Object m() { return WRONG; }}
+        interface I extends J {}
+
+        static class C  implements I { public Object m() { return CORRECT; }}
+
+        interface K1 extends I {}
+        interface K2 extends I { Object m(); }
+        interface K3 extends I { default Object m() { return WRONG; }}
+
+        static class DI implements I { public Object m() { return WRONG; }}
+        static class DJ implements J { public Object m() { return WRONG; }}
+
+        @DontInline
+        public Object test(I i) {
+            return i.m(); // no inlining since J.m is a default method
+        }
+
+        @TestCase
+        public void testMega() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic()); // C1,C2,C3 <: C.m <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+
+            // Dependency: none
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // 1. No deoptimization/invalidation on not-yet-seen receiver
+            repeat(100, () -> call(new C() {}));
+            assertCompiled();
+
+            // 2. No dependency and no inlining
+            initialize(DJ.class,  //      DJ.m                    <: intf J.m ABSTRACT
+                       DI.class,  //      DI.m          <: intf I <: intf J.m ABSTRACT
+                       K1.class,  // intf K1            <: intf I <: intf J.m ABSTRACT
+                       K2.class); // intf K2.m ABSTRACT <: intf I <: intf J.m ABSTRACT
+            assertCompiled();
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I o = (I) unsafeCastMH(I.class).invokeExact(new Object()); // unrelated
+                test(o);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J() {}); // super interface
+                test(j);
+            });
+            assertCompiled();
+        }
+    }
+
+    public static class ThreeLevelDefaultHierarchy1 extends ATest<ThreeLevelDefaultHierarchy1.I> {
+        public ThreeLevelDefaultHierarchy1() { super(I.class, C.class); }
+
+        interface J1                { Object m();}
+        interface J2 extends J1     { default Object m() { return WRONG; }  }
+        interface I  extends J1, J2 {}
+
+        static class C  implements I { public Object m() { return CORRECT; }}
+
+        interface K1 extends I {}
+        interface K2 extends I { Object m(); }
+        interface K3 extends I { default Object m() { return WRONG; }}
+
+        static class DI implements I { public Object m() { return WRONG; }}
+        static class DJ1 implements J1 { public Object m() { return WRONG; }}
+        static class DJ2 implements J2 { public Object m() { return WRONG; }}
+
+        @DontInline
+        public Object test(I i) {
+            return i.m(); // no inlining since J.m is a default method
+        }
+
+        @TestCase
+        public void testMega() {
+            // 0. Trigger compilation of a megamorphic call site
+            compile(megamorphic());
+            assertCompiled();
+
+            // Dependency: none
+
+            checkInvalidReceiver(); // ensure proper type check on receiver is preserved
+
+            // 1. No deoptimization/invalidation on not-yet-seen receiver
+            repeat(100, () -> call(new C() {}));
+            assertCompiled();
+
+            // 2. No dependency, no inlining
+            // CHA doesn't support default methods yet.
+            initialize(DJ1.class,
+                       DJ2.class,
+                       DI.class,
+                       K1.class,
+                       K2.class,
+                       K3.class);
+            assertCompiled();
+        }
+
+        @Override
+        public void checkInvalidReceiver() {
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I o = (I) unsafeCastMH(I.class).invokeExact(new Object()); // unrelated
+                test(o);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J1() { public Object m() { return WRONG; } }); // super interface
+                test(j);
+            });
+            assertCompiled();
+
+            shouldThrow(IncompatibleClassChangeError.class, () -> {
+                I j = (I) unsafeCastMH(I.class).invokeExact((Object)new J2() {}); // super interface
+                test(j);
+            });
+            assertCompiled();
+        }
+    }
+
+    /* =========================================================== */
+
+    interface Action {
+        int run();
+    }
+
+    public static final Unsafe U = Unsafe.getUnsafe();
+
+    interface Test<T> {
+        boolean isCompiled();
+        void assertNotCompiled();
+        void assertCompiled();
+
+        void call(T o);
+        T receiver(int id);
+
+        default Runnable monomophic() {
+            return () -> {
+                call(receiver(0)); // 100%
+            };
+        }
+
+        default Runnable bimorphic() {
+            return () -> {
+                call(receiver(0)); // 50%
+                call(receiver(1)); // 50%
+            };
+        }
+
+        default Runnable polymorphic() {
+            return () -> {
+                for (int i = 0; i < 23; i++) {
+                    call(receiver(0)); // 92%
+                }
+                call(receiver(1)); // 4%
+                call(receiver(2)); // 4%
+            };
+        }
+
+        default Runnable megamorphic() {
+            return () -> {
+                call(receiver(0)); // 33%
+                call(receiver(1)); // 33%
+                call(receiver(2)); // 33%
+            };
+        }
+
+        default void compile(Runnable r) {
+            assertNotCompiled();
+            while(!isCompiled()) {
+                r.run();
+            }
+            assertCompiled();
+        }
+
+        default void initialize(Class<?>... cs) {
+            for (Class<?> c : cs) {
+                U.ensureClassInitialized(c);
+            }
+        }
+
+        default void repeat(int cnt, Runnable r) {
+            for (int i = 0; i < cnt; i++) {
+                r.run();
+            }
+        }
+    }
+
+    public static abstract class ATest<T> implements Test<T> {
+        public static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+        public static final Object CORRECT = new Object();
+        public static final Object WRONG   = new Object();
+
+        final Method TEST;
+        private final Class<T> declared;
+        private final Class<?> receiver;
+
+        private final HashMap<Integer, T> receivers = new HashMap<>();
+
+        public ATest(Class<T> declared, Class<?> receiver) {
+            this.declared = declared;
+            this.receiver = receiver;
+            TEST = compute(() -> this.getClass().getDeclaredMethod("test", declared));
+        }
+
+        @DontInline
+        public abstract Object test(T i);
+
+        public abstract void checkInvalidReceiver();
+
+        public T receiver(int id) {
+            return receivers.computeIfAbsent(id, (i -> {
+                try {
+                    MyClassLoader cl = (MyClassLoader) receiver.getClassLoader();
+                    Class<?> sub = cl.subclass(receiver, i);
+                    return (T)sub.getDeclaredConstructor().newInstance();
+                } catch (Exception e) {
+                    throw new Error(e);
+                }
+            }));
+        }
+
+        @Override
+        public boolean isCompiled()     { return WB.isMethodCompiled(TEST); }
+
+        @Override
+        public void assertNotCompiled() { assertFalse(isCompiled()); }
+
+        @Override
+        public void assertCompiled()    { assertTrue(isCompiled()); }
+
+        @Override
+        public void call(T i) {
+            assertTrue(test(i) != WRONG);
+        }
+    }
+
+    @Retention(value = RetentionPolicy.RUNTIME)
+    public @interface TestCase {}
+
+    static void run(Class<?> test) {
+        try {
+            for (Method m : test.getDeclaredMethods()) {
+                if (m.isAnnotationPresent(TestCase.class)) {
+                    System.out.println(m.toString());
+                    ClassLoader cl = new MyClassLoader(test);
+                    Class<?> c = cl.loadClass(test.getName());
+                    c.getMethod(m.getName()).invoke(c.getDeclaredConstructor().newInstance());
+                }
+            }
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    static class ObjectToStringHelper {
+        static Object test(Object o) {
+            throw new Error("not used");
+        }
+    }
+    static class ObjectHashCodeHelper {
+        static int test(Object o) {
+        throw new Error("not used");
+    }
+    }
+
+    static final class MyClassLoader extends ClassLoader {
+        private final Class<?> test;
+
+        MyClassLoader(Class<?> test) {
+            this.test = test;
+        }
+
+        static String intl(String s) {
+            return s.replace('.', '/');
+        }
+
+        Class<?> subclass(Class<?> c, int id) {
+            String name = c.getName() + id;
+            Class<?> sub = findLoadedClass(name);
+            if (sub == null) {
+                ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
+                cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, intl(c.getName()), null);
+
+                { // Default constructor: <init>()V
+                    MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+                    mv.visitCode();
+                    mv.visitVarInsn(ALOAD, 0);
+                    mv.visitMethodInsn(INVOKESPECIAL, intl(c.getName()), "<init>", "()V", false);
+                    mv.visitInsn(RETURN);
+                    mv.visitMaxs(0, 0);
+                    mv.visitEnd();
+                }
+
+                byte[] classFile = cw.toByteArray();
+                return defineClass(name, classFile, 0, classFile.length);
+            }
+            return sub;
+        }
+
+        protected Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException
+        {
+            // First, check if the class has already been loaded
+            Class<?> c = findLoadedClass(name);
+            if (c == null) {
+                try {
+                    c = getParent().loadClass(name);
+                    if (name.endsWith("ObjectToStringHelper")) {
+                        ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
+                        cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, "java/lang/Object", null);
+
+                        {
+                            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "test", "(Ljava/lang/Object;)Ljava/lang/Object;", null, null);
+                            mv.visitCode();
+                            mv.visitVarInsn(ALOAD, 0);
+                            mv.visitMethodInsn(INVOKEINTERFACE, intl(test.getName()) + "$I", "toString", "()Ljava/lang/String;", true);
+                            mv.visitInsn(ARETURN);
+                            mv.visitMaxs(0, 0);
+                            mv.visitEnd();
+                        }
+
+                        byte[] classFile = cw.toByteArray();
+                        return defineClass(name, classFile, 0, classFile.length);
+                    } else if (name.endsWith("ObjectHashCodeHelper")) {
+                        ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
+                        cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, "java/lang/Object", null);
+
+                        {
+                            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "test", "(Ljava/lang/Object;)I", null, null);
+                            mv.visitCode();
+                            mv.visitVarInsn(ALOAD, 0);
+                            mv.visitMethodInsn(INVOKEINTERFACE, intl(test.getName()) + "$I", "hashCode", "()I", true);
+                            mv.visitInsn(IRETURN);
+                            mv.visitMaxs(0, 0);
+                            mv.visitEnd();
+                        }
+
+                        byte[] classFile = cw.toByteArray();
+                        return defineClass(name, classFile, 0, classFile.length);
+                    } else if (c == test || name.startsWith(test.getName())) {
+                        try {
+                            String path = name.replace('.', '/') + ".class";
+                            byte[] classFile = getParent().getResourceAsStream(path).readAllBytes();
+                            return defineClass(name, classFile, 0, classFile.length);
+                        } catch (IOException e) {
+                            throw new Error(e);
+                        }
+                    }
+                } catch (ClassNotFoundException e) {
+                    // ClassNotFoundException thrown if class not found
+                    // from the non-null parent class loader
+                }
+
+                if (c == null) {
+                    // If still not found, then invoke findClass in order
+                    // to find the class.
+                    c = findClass(name);
+                }
+            }
+            if (resolve) {
+                resolveClass(c);
+            }
+            return c;
+        }
+    }
+
+    public interface RunnableWithException {
+        void run() throws Throwable;
+    }
+
+    public static void shouldThrow(Class<? extends Throwable> expectedException, RunnableWithException r) {
+        try {
+            r.run();
+            throw new AssertionError("Exception not thrown: " + expectedException.getName());
+        } catch(Throwable e) {
+            if (expectedException == e.getClass()) {
+                // success: proper exception is thrown
+            } else {
+                throw new Error(expectedException.getName() + " is expected", e);
+            }
+        }
+    }
+
+    public static MethodHandle unsafeCastMH(Class<?> cls) {
+        try {
+            MethodHandle mh = MethodHandles.identity(Object.class);
+            return MethodHandles.explicitCastArguments(mh, mh.type().changeReturnType(cls));
+        } catch (Throwable e) {
+            throw new Error(e);
+        }
+    }
+
+    static <T> T compute(Callable<T> c) {
+        try {
+            return c.call();
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
+++ b/test/hotspot/jtreg/compiler/cha/StrengthReduceInterfaceCall.java
@@ -28,44 +28,34 @@
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /
+ * @compile Utils.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
- *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
- *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed
+ *                   -XX:CompileCommand=compileonly,*::m
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=dontinline,*::test
+ *                   -XX:CompileCommand=compileonly,*::testHelper -XX:CompileCommand=inline,*::testHelper
+ *                   -Xbatch -Xmixed -XX:+WhiteBoxAPI
  *                   -XX:-TieredCompilation
  *                      compiler.cha.StrengthReduceInterfaceCall
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+PrintCompilation -XX:+PrintInlining -XX:+TraceDependencies -verbose:class -XX:CompileCommand=quiet
- *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=compileonly,*::m -XX:CompileCommand=dontinline,*::test
- *                   -Xbatch -XX:+WhiteBoxAPI -Xmixed
+ *                   -XX:CompileCommand=compileonly,*::m
+ *                   -XX:CompileCommand=compileonly,*::test -XX:CompileCommand=dontinline,*::test
+ *                   -XX:CompileCommand=compileonly,*::testHelper -XX:CompileCommand=inline,*::testHelper
+ *                   -Xbatch -Xmixed -XX:+WhiteBoxAPI
  *                   -XX:+TieredCompilation -XX:TieredStopAtLevel=1
  *                      compiler.cha.StrengthReduceInterfaceCall
  */
 package compiler.cha;
 
-import jdk.internal.misc.Unsafe;
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
 import jdk.internal.vm.annotation.DontInline;
-import sun.hotspot.WhiteBox;
 
-import java.io.IOException;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.concurrent.Callable;
-
-import static jdk.test.lib.Asserts.*;
-import static jdk.internal.org.objectweb.asm.ClassWriter.*;
-import static jdk.internal.org.objectweb.asm.Opcodes.*;
+import static compiler.cha.Utils.*;
 
 public class StrengthReduceInterfaceCall {
     public static void main(String[] args) {
@@ -76,6 +66,7 @@ public class StrengthReduceInterfaceCall {
         run(ThreeLevelHierarchyAbstractVsDefault.class);
         run(ThreeLevelDefaultHierarchy.class);
         run(ThreeLevelDefaultHierarchy1.class);
+        System.out.println("TEST PASSED");
     }
 
     public static class ObjectToString extends ATest<ObjectToString.I> {
@@ -96,7 +87,7 @@ public class StrengthReduceInterfaceCall {
         static class DJ2 implements J { public String toString() { return "DJ2"; }}
 
         @Override
-        public Object test(I i) { return ObjectToStringHelper.test(i); /* invokeinterface I.toString() */ }
+        public Object test(I i) { return ObjectToStringHelper.testHelper(i); /* invokeinterface I.toString() */ }
 
         @TestCase
         public void testMono() {
@@ -185,7 +176,7 @@ public class StrengthReduceInterfaceCall {
 
         @Override
         public Object test(I i) {
-            return ObjectHashCodeHelper.test(i); /* invokeinterface I.hashCode() */
+            return ObjectHashCodeHelper.testHelper(i); /* invokeinterface I.hashCode() */
         }
 
         @TestCase
@@ -733,288 +724,6 @@ public class StrengthReduceInterfaceCall {
                 test(j);
             });
             assertCompiled();
-        }
-    }
-
-    /* =========================================================== */
-
-    interface Action {
-        int run();
-    }
-
-    public static final Unsafe U = Unsafe.getUnsafe();
-
-    interface Test<T> {
-        boolean isCompiled();
-        void assertNotCompiled();
-        void assertCompiled();
-
-        void call(T o);
-        T receiver(int id);
-
-        default Runnable monomophic() {
-            return () -> {
-                call(receiver(0)); // 100%
-            };
-        }
-
-        default Runnable bimorphic() {
-            return () -> {
-                call(receiver(0)); // 50%
-                call(receiver(1)); // 50%
-            };
-        }
-
-        default Runnable polymorphic() {
-            return () -> {
-                for (int i = 0; i < 23; i++) {
-                    call(receiver(0)); // 92%
-                }
-                call(receiver(1)); // 4%
-                call(receiver(2)); // 4%
-            };
-        }
-
-        default Runnable megamorphic() {
-            return () -> {
-                call(receiver(0)); // 33%
-                call(receiver(1)); // 33%
-                call(receiver(2)); // 33%
-            };
-        }
-
-        default void compile(Runnable r) {
-            assertNotCompiled();
-            while(!isCompiled()) {
-                r.run();
-            }
-            assertCompiled();
-        }
-
-        default void initialize(Class<?>... cs) {
-            for (Class<?> c : cs) {
-                U.ensureClassInitialized(c);
-            }
-        }
-
-        default void repeat(int cnt, Runnable r) {
-            for (int i = 0; i < cnt; i++) {
-                r.run();
-            }
-        }
-    }
-
-    public static abstract class ATest<T> implements Test<T> {
-        public static final WhiteBox WB = WhiteBox.getWhiteBox();
-
-        public static final Object CORRECT = new Object();
-        public static final Object WRONG   = new Object();
-
-        final Method TEST;
-        private final Class<T> declared;
-        private final Class<?> receiver;
-
-        private final HashMap<Integer, T> receivers = new HashMap<>();
-
-        public ATest(Class<T> declared, Class<?> receiver) {
-            this.declared = declared;
-            this.receiver = receiver;
-            TEST = compute(() -> this.getClass().getDeclaredMethod("test", declared));
-        }
-
-        @DontInline
-        public abstract Object test(T i);
-
-        public abstract void checkInvalidReceiver();
-
-        public T receiver(int id) {
-            return receivers.computeIfAbsent(id, (i -> {
-                try {
-                    MyClassLoader cl = (MyClassLoader) receiver.getClassLoader();
-                    Class<?> sub = cl.subclass(receiver, i);
-                    return (T)sub.getDeclaredConstructor().newInstance();
-                } catch (Exception e) {
-                    throw new Error(e);
-                }
-            }));
-        }
-
-        @Override
-        public boolean isCompiled()     { return WB.isMethodCompiled(TEST); }
-
-        @Override
-        public void assertNotCompiled() { assertFalse(isCompiled()); }
-
-        @Override
-        public void assertCompiled()    { assertTrue(isCompiled()); }
-
-        @Override
-        public void call(T i) {
-            assertTrue(test(i) != WRONG);
-        }
-    }
-
-    @Retention(value = RetentionPolicy.RUNTIME)
-    public @interface TestCase {}
-
-    static void run(Class<?> test) {
-        try {
-            for (Method m : test.getDeclaredMethods()) {
-                if (m.isAnnotationPresent(TestCase.class)) {
-                    System.out.println(m.toString());
-                    ClassLoader cl = new MyClassLoader(test);
-                    Class<?> c = cl.loadClass(test.getName());
-                    c.getMethod(m.getName()).invoke(c.getDeclaredConstructor().newInstance());
-                }
-            }
-        } catch (Exception e) {
-            throw new Error(e);
-        }
-    }
-
-    static class ObjectToStringHelper {
-        static Object test(Object o) {
-            throw new Error("not used");
-        }
-    }
-    static class ObjectHashCodeHelper {
-        static int test(Object o) {
-        throw new Error("not used");
-    }
-    }
-
-    static final class MyClassLoader extends ClassLoader {
-        private final Class<?> test;
-
-        MyClassLoader(Class<?> test) {
-            this.test = test;
-        }
-
-        static String intl(String s) {
-            return s.replace('.', '/');
-        }
-
-        Class<?> subclass(Class<?> c, int id) {
-            String name = c.getName() + id;
-            Class<?> sub = findLoadedClass(name);
-            if (sub == null) {
-                ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
-                cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, intl(c.getName()), null);
-
-                { // Default constructor: <init>()V
-                    MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-                    mv.visitCode();
-                    mv.visitVarInsn(ALOAD, 0);
-                    mv.visitMethodInsn(INVOKESPECIAL, intl(c.getName()), "<init>", "()V", false);
-                    mv.visitInsn(RETURN);
-                    mv.visitMaxs(0, 0);
-                    mv.visitEnd();
-                }
-
-                byte[] classFile = cw.toByteArray();
-                return defineClass(name, classFile, 0, classFile.length);
-            }
-            return sub;
-        }
-
-        protected Class<?> loadClass(String name, boolean resolve)
-                throws ClassNotFoundException
-        {
-            // First, check if the class has already been loaded
-            Class<?> c = findLoadedClass(name);
-            if (c == null) {
-                try {
-                    c = getParent().loadClass(name);
-                    if (name.endsWith("ObjectToStringHelper")) {
-                        ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
-                        cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, "java/lang/Object", null);
-
-                        {
-                            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "test", "(Ljava/lang/Object;)Ljava/lang/Object;", null, null);
-                            mv.visitCode();
-                            mv.visitVarInsn(ALOAD, 0);
-                            mv.visitMethodInsn(INVOKEINTERFACE, intl(test.getName()) + "$I", "toString", "()Ljava/lang/String;", true);
-                            mv.visitInsn(ARETURN);
-                            mv.visitMaxs(0, 0);
-                            mv.visitEnd();
-                        }
-
-                        byte[] classFile = cw.toByteArray();
-                        return defineClass(name, classFile, 0, classFile.length);
-                    } else if (name.endsWith("ObjectHashCodeHelper")) {
-                        ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
-                        cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, "java/lang/Object", null);
-
-                        {
-                            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "test", "(Ljava/lang/Object;)I", null, null);
-                            mv.visitCode();
-                            mv.visitVarInsn(ALOAD, 0);
-                            mv.visitMethodInsn(INVOKEINTERFACE, intl(test.getName()) + "$I", "hashCode", "()I", true);
-                            mv.visitInsn(IRETURN);
-                            mv.visitMaxs(0, 0);
-                            mv.visitEnd();
-                        }
-
-                        byte[] classFile = cw.toByteArray();
-                        return defineClass(name, classFile, 0, classFile.length);
-                    } else if (c == test || name.startsWith(test.getName())) {
-                        try {
-                            String path = name.replace('.', '/') + ".class";
-                            byte[] classFile = getParent().getResourceAsStream(path).readAllBytes();
-                            return defineClass(name, classFile, 0, classFile.length);
-                        } catch (IOException e) {
-                            throw new Error(e);
-                        }
-                    }
-                } catch (ClassNotFoundException e) {
-                    // ClassNotFoundException thrown if class not found
-                    // from the non-null parent class loader
-                }
-
-                if (c == null) {
-                    // If still not found, then invoke findClass in order
-                    // to find the class.
-                    c = findClass(name);
-                }
-            }
-            if (resolve) {
-                resolveClass(c);
-            }
-            return c;
-        }
-    }
-
-    public interface RunnableWithException {
-        void run() throws Throwable;
-    }
-
-    public static void shouldThrow(Class<? extends Throwable> expectedException, RunnableWithException r) {
-        try {
-            r.run();
-            throw new AssertionError("Exception not thrown: " + expectedException.getName());
-        } catch(Throwable e) {
-            if (expectedException == e.getClass()) {
-                // success: proper exception is thrown
-            } else {
-                throw new Error(expectedException.getName() + " is expected", e);
-            }
-        }
-    }
-
-    public static MethodHandle unsafeCastMH(Class<?> cls) {
-        try {
-            MethodHandle mh = MethodHandles.identity(Object.class);
-            return MethodHandles.explicitCastArguments(mh, mh.type().changeReturnType(cls));
-        } catch (Throwable e) {
-            throw new Error(e);
-        }
-    }
-
-    static <T> T compute(Callable<T> c) {
-        try {
-            return c.call();
-        } catch (Exception e) {
-            throw new Error(e);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/cha/Utils.java
+++ b/test/hotspot/jtreg/compiler/cha/Utils.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.cha;
+
+import jdk.internal.misc.Unsafe;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.vm.annotation.DontInline;
+import sun.hotspot.WhiteBox;
+import sun.hotspot.code.NMethod;
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+
+import static jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static jdk.internal.org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
+import static jdk.internal.org.objectweb.asm.Opcodes.*;
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class Utils {
+    public static final Unsafe U = Unsafe.getUnsafe();
+
+    interface Test<T> {
+        void call(T o);
+        T receiver(int id);
+
+        default Runnable monomophic() {
+            return () -> {
+                call(receiver(0)); // 100%
+            };
+        }
+
+        default Runnable bimorphic() {
+            return () -> {
+                call(receiver(0)); // 50%
+                call(receiver(1)); // 50%
+            };
+        }
+
+        default Runnable polymorphic() {
+            return () -> {
+                for (int i = 0; i < 23; i++) {
+                    call(receiver(0)); // 92%
+                }
+                call(receiver(1)); // 4%
+                call(receiver(2)); // 4%
+            };
+        }
+
+        default Runnable megamorphic() {
+            return () -> {
+                call(receiver(0)); // 33%
+                call(receiver(1)); // 33%
+                call(receiver(2)); // 33%
+            };
+        }
+
+        default void load(Class<?>... cs) {
+            // nothing to do
+        }
+
+        default void initialize(Class<?>... cs) {
+            for (Class<?> c : cs) {
+                U.ensureClassInitialized(c);
+            }
+        }
+
+        default void repeat(int cnt, Runnable r) {
+            for (int i = 0; i < cnt; i++) {
+                r.run();
+            }
+        }
+    }
+
+    public static abstract class ATest<T> implements Test<T> {
+        public static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+        public static final Object CORRECT = new Object();
+        public static final Object WRONG   = new Object();
+
+        final Method TEST;
+        private final Class<T> declared;
+        private final Class<?> receiver;
+
+        private final HashMap<Integer, T> receivers = new HashMap<>();
+
+        public ATest(Class<T> declared, Class<?> receiver) {
+            this.declared = declared;
+            this.receiver = receiver;
+            TEST = compute(() -> this.getClass().getDeclaredMethod("test", declared));
+        }
+
+        @DontInline
+        public abstract Object test(T i);
+
+        public abstract void checkInvalidReceiver();
+
+        public T receiver(int id) {
+            return receivers.computeIfAbsent(id, (i -> {
+                try {
+                    MyClassLoader cl = (MyClassLoader) receiver.getClassLoader();
+                    Class<?> sub = cl.subclass(receiver, i);
+                    return (T)sub.getDeclaredConstructor().newInstance();
+                } catch (Exception e) {
+                    throw new Error(e);
+                }
+            }));
+        }
+
+
+        public void compile(Runnable r) {
+            while (!WB.isMethodCompiled(TEST)) {
+                for (int i = 0; i < 100; i++) {
+                    r.run();
+                }
+            }
+            assertCompiled(); // record nmethod info
+        }
+
+        private NMethod prevNM = null;
+
+        public void assertNotCompiled() {
+            NMethod curNM = NMethod.get(TEST, false);
+            assertTrue(prevNM != null); // was previously compiled
+            assertTrue(curNM == null || prevNM.compile_id != curNM.compile_id); // either no nmethod present or recompiled
+            prevNM = curNM; // update nmethod info
+        }
+
+        public void assertCompiled() {
+            NMethod curNM = NMethod.get(TEST, false);
+            assertTrue(curNM != null); // nmethod is present
+            assertTrue(prevNM == null || prevNM.compile_id == curNM.compile_id); // no recompilations if nmethod present
+            prevNM = curNM; // update nmethod info
+        }
+
+        @Override
+        public void call(T i) {
+            assertTrue(test(i) != WRONG);
+        }
+    }
+
+    @Retention(value = RetentionPolicy.RUNTIME)
+    public @interface TestCase {}
+
+    static void run(Class<?> test) {
+        try {
+            for (Method m : test.getDeclaredMethods()) {
+                if (m.isAnnotationPresent(TestCase.class)) {
+                    System.out.println(m.toString());
+                    ClassLoader cl = new MyClassLoader(test);
+                    Class<?> c = cl.loadClass(test.getName());
+                    c.getMethod(m.getName()).invoke(c.getDeclaredConstructor().newInstance());
+                }
+            }
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    static class ObjectToStringHelper {
+        static Object testHelper(Object o) {
+            throw new Error("not used");
+        }
+    }
+    static class ObjectHashCodeHelper {
+        static int testHelper(Object o) {
+            throw new Error("not used");
+        }
+    }
+
+    static final class MyClassLoader extends ClassLoader {
+        private final Class<?> test;
+
+        MyClassLoader(Class<?> test) {
+            this.test = test;
+        }
+
+        static String intl(String s) {
+            return s.replace('.', '/');
+        }
+
+        Class<?> subclass(Class<?> c, int id) {
+            String name = c.getName() + id;
+            Class<?> sub = findLoadedClass(name);
+            if (sub == null) {
+                ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
+                cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, intl(c.getName()), null);
+
+                { // Default constructor: <init>()V
+                    MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+                    mv.visitCode();
+                    mv.visitVarInsn(ALOAD, 0);
+                    mv.visitMethodInsn(INVOKESPECIAL, intl(c.getName()), "<init>", "()V", false);
+                    mv.visitInsn(RETURN);
+                    mv.visitMaxs(0, 0);
+                    mv.visitEnd();
+                }
+
+                byte[] classFile = cw.toByteArray();
+                return defineClass(name, classFile, 0, classFile.length);
+            }
+            return sub;
+        }
+
+        protected Class<?> loadClass(String name, boolean resolve)
+                throws ClassNotFoundException
+        {
+            // First, check if the class has already been loaded
+            Class<?> c = findLoadedClass(name);
+            if (c == null) {
+                try {
+                    c = getParent().loadClass(name);
+                    if (name.endsWith("ObjectToStringHelper")) {
+                        ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
+                        cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, "java/lang/Object", null);
+
+                        {
+                            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testHelper", "(Ljava/lang/Object;)Ljava/lang/Object;", null, null);
+                            mv.visitCode();
+                            mv.visitVarInsn(ALOAD, 0);
+                            mv.visitMethodInsn(INVOKEINTERFACE, intl(test.getName()) + "$I", "toString", "()Ljava/lang/String;", true);
+                            mv.visitInsn(ARETURN);
+                            mv.visitMaxs(0, 0);
+                            mv.visitEnd();
+                        }
+
+                        byte[] classFile = cw.toByteArray();
+                        return defineClass(name, classFile, 0, classFile.length);
+                    } else if (name.endsWith("ObjectHashCodeHelper")) {
+                        ClassWriter cw = new ClassWriter(COMPUTE_MAXS | COMPUTE_FRAMES);
+                        cw.visit(52, ACC_PUBLIC | ACC_SUPER, intl(name), null, "java/lang/Object", null);
+
+                        {
+                            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testHelper", "(Ljava/lang/Object;)I", null, null);
+                            mv.visitCode();
+                            mv.visitVarInsn(ALOAD, 0);
+                            mv.visitMethodInsn(INVOKEINTERFACE, intl(test.getName()) + "$I", "hashCode", "()I", true);
+                            mv.visitInsn(IRETURN);
+                            mv.visitMaxs(0, 0);
+                            mv.visitEnd();
+                        }
+
+                        byte[] classFile = cw.toByteArray();
+                        return defineClass(name, classFile, 0, classFile.length);
+                    } else if (c == test || name.startsWith(test.getName())) {
+                        try {
+                            String path = name.replace('.', '/') + ".class";
+                            byte[] classFile = getParent().getResourceAsStream(path).readAllBytes();
+                            return defineClass(name, classFile, 0, classFile.length);
+                        } catch (IOException e) {
+                            throw new Error(e);
+                        }
+                    }
+                } catch (ClassNotFoundException e) {
+                    // ClassNotFoundException thrown if class not found
+                    // from the non-null parent class loader
+                }
+
+                if (c == null) {
+                    // If still not found, then invoke findClass in order
+                    // to find the class.
+                    c = findClass(name);
+                }
+            }
+            if (resolve) {
+                resolveClass(c);
+            }
+            return c;
+        }
+    }
+
+    public interface RunnableWithException {
+        void run() throws Throwable;
+    }
+
+    public static void shouldThrow(Class<? extends Throwable> expectedException, RunnableWithException r) {
+        try {
+            r.run();
+            throw new AssertionError("Exception not thrown: " + expectedException.getName());
+        } catch(Throwable e) {
+            if (expectedException == e.getClass()) {
+                // success: proper exception is thrown
+            } else {
+                throw new Error(expectedException.getName() + " is expected", e);
+            }
+        }
+    }
+
+    public static MethodHandle unsafeCastMH(Class<?> cls) {
+        try {
+            MethodHandle mh = MethodHandles.identity(Object.class);
+            return MethodHandles.explicitCastArguments(mh, mh.type().changeReturnType(cls));
+        } catch (Throwable e) {
+            throw new Error(e);
+        }
+    }
+
+    static <T> T compute(Callable<T> c) {
+        try {
+            return c.call();
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+}


### PR DESCRIPTION
### Introduction
With this backport, interface call could be inlined if there is only one implementation of the invoked method after class hierarchy analysis, as shown in the following case.
```
interface I1 {
    public int m();
}
    
abstract class C1 implements I1 {}

class C2 extends C1 {
    public int m() {
        return 0;
    }
}

class Test {
    public static void main(String[] args) {
    	run(new C2());
    }

    public static void run(C1 c1) {
        c1.m(); // will inline C2.m because only class C2 implements method m after Class Hierarchy Analysis
    }
}
```

### Test results
benchmark: renaissance 
platform: x86
config:4C8G
![image](https://github.com/dragonwell-project/dragonwell11/assets/88874527/3c7ffa50-c0c9-47d1-8005-3470e12b6669)

benchmark: renaissance
platform: aarch64
config:4C8G
![image](https://github.com/dragonwell-project/dragonwell11/assets/88874527/53da2fa5-a915-4e3f-beb5-6c2ca2452099)

There isn't any change for SPECjbb on x86 and aarch64 platform.

### Corresponding upstream commit
[6986483](https://github.com/openjdk/jdk/commit/ac3711e9cd4b06853619db82025f55cfc9f2712d)CHA: optimize calls through interfaces
[8223171](https://github.com/openjdk/jdk/commit/75d4f24c971)Redundant nmethod dependencies for effectively final methods
[8261954](https://github.com/openjdk/jdk/commit/0a4e710f)Dependencies: Improve iteration over class hierarchy under context class
[8264548](https://github.com/openjdk/jdk/commit/f60e81bf7b4cb2a0ba569c8935c4e4eb0510d5f2)Dependencies: ClassHierarchyWalker::is_witness() cleanups
[8266074](https://github.com/openjdk/jdk/commit/127bfe44f7d0) Vtable-based CHA implementation
[8065760](https://github.com/openjdk/jdk/commit/20479c3de93) CHA: Improve abstract method support
[8036580](https://github.com/openjdk/jdk/commit/74b70a56774) CHA: improve default method support

### Others
1. Because the absence of `JDK-8264873 Dependencies: Split ClassHierarchyWalker` in JDK11, the implementation of class `LinkedConcreteMethodFinder` in backported JDK-8266074 is little different with upstream, but keeps functionality consistent.
2. Total number of new lines of this backport is about 2400, including 1500 lines for test cases and 900 lines for feature code.