### PR TITLE
[JIT] Disable UseVtableBasedCHA by default

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1222,7 +1222,7 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   develop(bool, UseCHA, true,                                               \
           "Enable CHA")                                                     \
                                                                             \
-  diagnostic(bool, UseVtableBasedCHA, true,                                 \
+  diagnostic(bool, UseVtableBasedCHA, false,                                \
           "Use vtable information during CHA")                              \
                                                                             \
   product(bool, UseTypeProfile, true,                                       \


### PR DESCRIPTION
Summary: Disable CHA inline by default, could be enabled by option -XX:+UnlockDiagnosticVMOptions -XX:+UseVtableBasedCHA

Testing: jtreg

Reviewers: kuaiwei.kw, maoliang.ml

Issue: https://github.com/dragonwell-project/dragonwell11/issues/774