### PR TITLE
[Misc] Test CdsDifferentCompactObjectHeaders.java should only run wit…

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/CdsDifferentCompactObjectHeaders.java
+++ b/test/hotspot/jtreg/runtime/cds/CdsDifferentCompactObjectHeaders.java
@@ -29,6 +29,7 @@
  *          is different from compact headers for creating a CDS file
  *          should fail when loading.
  * @requires vm.cds
+ * @requires vm.gc.G1 | vm.gc.Parallel
  * @requires vm.bits == 64
  * @library /test/lib
  * @run driver CdsDifferentCompactObjectHeaders


### PR DESCRIPTION
…h supported GC

Summary: CdsDifferentCompactObjectHeaders.java should only run with supported GC

Testing: test/hotspot/jtreg/runtime/cds/CdsDifferentCompactObjectHeaders.java

Reviewers: yifeng, yude

Issue: https://github.com/dragonwell-project/dragonwell11/issues/794