### PR TITLE
[Backport] 8246718: ParallelGC should not check for forward objects for copy task queue

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -93,7 +93,6 @@ class PSPromotionManager {
   static MutableSpace* young_space() { return _young_space; }
 
   inline static PSPromotionManager* manager_array(uint index);
-  template <class T> inline void claim_or_forward_internal_depth(T* p);
 
   // On the task queues we push reference locations as well as
   // partially-scanned arrays (in the latter case, we push an oop to

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -35,6 +35,7 @@
 #include "logging/log.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/prefetch.inline.hpp"
 
 inline PSPromotionManager* PSPromotionManager::manager_array(uint index) {
   assert(_manager_array != NULL, "access of NULL manager_array");
@@ -48,28 +49,12 @@ inline void PSPromotionManager::push_depth(T* p) {
 }
 
 template <class T>
-inline void PSPromotionManager::claim_or_forward_internal_depth(T* p) {
-  if (p != NULL) { // XXX: error if p != NULL here
-    oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
-    if (o->is_forwarded()) {
-      o = o->forwardee();
-      // Card mark
-      if (PSScavenge::is_obj_in_young(o)) {
-        PSScavenge::card_table()->inline_write_ref_field_gc(p, o);
-      }
-      RawAccess<IS_NOT_NULL>::oop_store(p, o);
-    } else {
-      push_depth(p);
-    }
-  }
-}
-
-template <class T>
 inline void PSPromotionManager::claim_or_forward_depth(T* p) {
   assert(should_scavenge(p, true), "revisiting object?");
   assert(ParallelScavengeHeap::heap()->is_in(p), "pointer outside heap");
-
-  claim_or_forward_internal_depth(p);
+  oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
+  Prefetch::write(obj->mark_addr_raw(), 0);
+  push_depth(p);
 }
 
 inline void PSPromotionManager::promotion_trace_event(oop new_obj, Klass* klass,


### PR DESCRIPTION
After port [JDK-8246718](https://bugs.openjdk.org/browse/JDK-8246718) form JDK15, the critical-jOPS of SPECjbb has a nearly 8% improvement on g8a and g8i with a configuration of 8 cores and 16G memory, while max-jOPS was not seen evident changes. Also both the max-jOPS and critical-jOPS have no significant differences on g8y.

![image](https://github.com/dragonwell-project/dragonwell11/assets/88874527/779f3e72-32da-4425-89e6-68e7716ab699)

And those test results are basically similar with [JDK-8246718](https://bugs.openjdk.org/browse/JDK-8246718)
![image](https://github.com/dragonwell-project/dragonwell11/assets/88874527/4891bd33-c51b-40e8-bc7b-21c0b4d48215)
