### PR TITLE
[Misc] Disable ArrayBaseOffsets.java#no-coh-no-ccp when test with -XX:+UseCompactObjectHeaders

### DIFF
--- a/test/hotspot/jtreg/runtime/FieldLayout/ArrayBaseOffsets.java
+++ b/test/hotspot/jtreg/runtime/FieldLayout/ArrayBaseOffsets.java
@@ -42,6 +42,7 @@
  * @library /test/lib
  * @requires vm.bits == "64"
  * @requires vm.opt.UseCompressedClassPointers != false
+ * @requires vm.opt.UseCompactObjectHeaders != true
  * @modules java.base/jdk.internal.misc
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseCompactObjectHeaders -XX:+UseCompressedClassPointers ArrayBaseOffsets
  */
@@ -49,6 +50,7 @@
  * @test id=no-coh-no-ccp
  * @library /test/lib
  * @requires vm.bits == "64"
+ * @requires vm.opt.UseCompactObjectHeaders != true
  * @modules java.base/jdk.internal.misc
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseCompactObjectHeaders -XX:-UseCompressedClassPointers ArrayBaseOffsets
  */


### PR DESCRIPTION
Summary: Disable runtime/FieldLayout/ArrayBaseOffsets.java#no-coh-no-ccp and runtime/FieldLayout/ArrayBaseOffsets.java#no-coh-with-ccp when test with -XX:+UseCompactObjectHeaders

Testing: CI pipeline

Reviewers: maoliang.ml, lvfei.lv

Issue: https://github.com/dragonwell-project/dragonwell11/issues/812
