### PR TITLE
[Backport] 8290496: riscv: Fix build warnings-as-errors with GCC 11

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -313,18 +313,14 @@ class NativeCall: public NativeInstruction {
 inline NativeCall* nativeCall_at(address addr) {
   assert_cond(addr != NULL);
   NativeCall* call = (NativeCall*)(addr - NativeCall::instruction_offset);
-#ifdef ASSERT
-  call->verify();
-#endif
+  DEBUG_ONLY(call->verify());
   return call;
 }
 
 inline NativeCall* nativeCall_before(address return_address) {
   assert_cond(return_address != NULL);
   NativeCall* call = (NativeCall*)(return_address - NativeCall::return_address_offset);
-#ifdef ASSERT
-  call->verify();
-#endif
+  DEBUG_ONLY(call->verify());
   return call;
 }
 
@@ -364,7 +360,7 @@ class NativeMovConstReg: public NativeInstruction {
   }
 
   intptr_t data() const;
-  void  set_data(intptr_t x);
+  void set_data(intptr_t x);
 
   void flush() {
     if (!maybe_cpool_ref(instruction_address())) {
@@ -372,8 +368,8 @@ class NativeMovConstReg: public NativeInstruction {
     }
   }
 
-  void  verify();
-  void  print();
+  void verify();
+  void print();
 
   // Creation
   inline friend NativeMovConstReg* nativeMovConstReg_at(address addr);
@@ -383,55 +379,53 @@ class NativeMovConstReg: public NativeInstruction {
 inline NativeMovConstReg* nativeMovConstReg_at(address addr) {
   assert_cond(addr != NULL);
   NativeMovConstReg* test = (NativeMovConstReg*)(addr - NativeMovConstReg::instruction_offset);
-#ifdef ASSERT
-  test->verify();
-#endif
+  DEBUG_ONLY(test->verify());
   return test;
 }
 
 inline NativeMovConstReg* nativeMovConstReg_before(address addr) {
   assert_cond(addr != NULL);
   NativeMovConstReg* test = (NativeMovConstReg*)(addr - NativeMovConstReg::instruction_size - NativeMovConstReg::instruction_offset);
-#ifdef ASSERT
-  test->verify();
-#endif
+  DEBUG_ONLY(test->verify());
   return test;
 }
 
-// RISCV should not use C1 runtime patching, so just leave NativeMovRegMem Unimplemented.
+// RISCV should not use C1 runtime patching, but still implement
+// NativeMovRegMem to keep some compilers happy.
 class NativeMovRegMem: public NativeInstruction {
  public:
-  int instruction_start() const {
-    Unimplemented();
-    return 0;
-  }
+  enum RISCV_specific_constants {
+    instruction_size            =    NativeInstruction::instruction_size,
+    instruction_offset          =    0,
+    data_offset                 =    0,
+    next_instruction_offset     =    NativeInstruction::instruction_size
+  };
 
-  address instruction_address() const {
-    Unimplemented();
-    return NULL;
-  }
+  int instruction_start() const { return instruction_offset; }
 
-  int num_bytes_to_end_of_patch() const {
-    Unimplemented();
-    return 0;
-  }
+  address instruction_address() const { return addr_at(instruction_offset); }
+
+  int num_bytes_to_end_of_patch() const { return instruction_offset + instruction_size; }
 
   int offset() const;
 
   void set_offset(int x);
 
-  void add_offset_in_bytes(int add_offset) { Unimplemented(); }
+  void add_offset_in_bytes(int add_offset) {
+    set_offset(offset() + add_offset);
+  }
 
   void verify();
   void print();
 
  private:
-  inline friend NativeMovRegMem* nativeMovRegMem_at (address addr);
+  inline friend NativeMovRegMem* nativeMovRegMem_at(address addr);
 };
 
-inline NativeMovRegMem* nativeMovRegMem_at (address addr) {
-  Unimplemented();
-  return NULL;
+inline NativeMovRegMem* nativeMovRegMem_at(address addr) {
+  NativeMovRegMem* test = (NativeMovRegMem*)(addr - NativeMovRegMem::instruction_offset);
+  DEBUG_ONLY(test->verify());
+  return test;
 }
 
 class NativeJump: public NativeInstruction {
@@ -462,9 +456,7 @@ class NativeJump: public NativeInstruction {
 
 inline NativeJump* nativeJump_at(address addr) {
   NativeJump* jump = (NativeJump*)(addr - NativeJump::instruction_offset);
-#ifdef ASSERT
-  jump->verify();
-#endif
+  DEBUG_ONLY(jump->verify());
   return jump;
 }
 

--- a/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
@@ -171,7 +171,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // Entry arguments:
-  //  t2: CompiledICHolder
+  //  t1: CompiledICHolder
   //  j_rarg0: Receiver
 
   // This stub is called from compiled code which has no callee-saved registers,


### PR DESCRIPTION
Summary: Clean backport of JDK-8290496, this backport has been merged to riscv-port-jdk11u

Testing: CI pipeline

Reviewers: kuaiwei.kw, xingqizheng.xqz

Issue: https://github.com/dragonwell-project/dragonwell11/issues/818


待办事项：

- [x] linux x64、aarch64、riscv64二进制构建
- [x] linux riscv64全量测试