### PR TITLE
[Misc] Add swp file type and .vscode directory into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ NashornProfile.txt
 **/JTwork/**
 /compile_commands.json
 /.cache
+*.swp
+.vscode/*


### PR DESCRIPTION
Summary: Add swp file type and .vscode directory into .gitignore

Testing: CI pipeline

Reviewers: kuaiwei.kw, xingqizheng.xqz

Issue: https://github.com/dragonwell-project/dragonwell11/issues/835