### PR TITLE
[JIT] Backport: 8331087: Move immutable nmethod data from CodeCache

### DIFF
--- a/src/hotspot/share/runtime/globals_ext.hpp
+++ b/src/hotspot/share/runtime/globals_ext.hpp
@@ -90,6 +90,9 @@
   product(bool, G1BarrierSimple, false,                                     \
           "Use simple G1 post barrier")                                     \
                                                                             \
+  product(bool, ReduceNMethodSize, false,                                   \
+          "Move immutable data of nmethod out of code cache")               \
+                                                                            \
   //add new AJDK specific flags here
 
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -729,6 +729,8 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   nonstatic_field(nmethod,                     _entry_point,                                  address)                               \
   nonstatic_field(nmethod,                     _verified_entry_point,                         address)                               \
   nonstatic_field(nmethod,                     _osr_entry_point,                              address)                               \
+  nonstatic_field(nmethod,                     _immutable_data,                               address)                               \
+  nonstatic_field(nmethod,                     _immutable_data_size,                          int)                                   \
   volatile_nonstatic_field(nmethod,            _lock_count,                                   jint)                                  \
   volatile_nonstatic_field(nmethod,            _stack_traversal_mark,                         long)                                  \
   nonstatic_field(nmethod,                     _compile_id,                                   int)                                   \


### PR DESCRIPTION
Summary: Add option ReduceNMethodSize. If enable, jvm will move
         immutable nmethod data out of CodeCache

Testing: CI testing

Reviewers: yueshi.zwj, lusou.zq

Issue: https://github.com/dragonwell-project/dragonwell11/issues/842