### PR TITLE
[GC] Fix an assertion that assumed ICBuffer should be cleaned

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2477,7 +2477,7 @@ G1CollectedHeap* G1CollectedHeap::heap() {
 
 void G1CollectedHeap::gc_prologue(bool full) {
   // always_do_update_barrier = false;
-  assert(InlineCacheBuffer::is_empty(), "should have cleaned up ICBuffer");
+  assert(UseCompactObjectHeaders || InlineCacheBuffer::is_empty(), "should have cleaned up ICBuffer");
 
   // This summary needs to be printed before incrementing total collections.
   g1_rem_set()->print_periodic_summary_info("Before GC RS summary", total_collections());


### PR DESCRIPTION
Summary: Since
https://github.com/dragonwell-project/dragonwell11/commit/d4c08314a2cc2f44d157c40a5b4b5215af76d78c some cleanup tasks might be skipped in UseCompactObjectHeaders. We should fix related assertions.

Testing: hotspot/jtreg

Reviewers: mmyxym, weixlu

Issue: https://github.com/dragonwell-project/dragonwell11/issues/850