### PR TITLE
[GC] Fix option type in IOPrioritySizePolicy

### DIFF
--- a/src/hotspot/share/gc/parallel/parallel_globals.hpp
+++ b/src/hotspot/share/gc/parallel/parallel_globals.hpp
@@ -83,7 +83,7 @@
   product(bool, UseIOPrioritySizePolicy, false,                             \
           "eagerly decrease heap when io wait is high")                     \
                                                                             \
-  product(float, IOPrioritySizePolicyEdenScale, 8.0,                        \
+  product(uint, IOPrioritySizePolicyEdenScale, 8,                           \
           "how much eden to decrease when io wait is high")                 \
 
 #endif // SHARE_GC_PARALLEL_PARALLEL_GLOBALS_HPP


### PR DESCRIPTION
Summary: change type from float to uint for IOPrioritySizePolicyEdenScale to avoid build failure on aarch64

Testing: jtreg

Reviewers: maoliang.ml, yude.lyd

Issue: https://github.com/dragonwell-project/dragonwell11/issues/

CR: https://github.com/dragonwell-project/dragonwell11/pull/