### PR TITLE
[Misc] Fix testcase that depend on docker build

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -122,6 +122,17 @@ public class DockerTestUtils {
         return true;
     }
 
+    /**
+     * Build a container image that contains JDK under test.
+     * The jdk will be placed under the "/jdk/" folder inside the image/container file system.
+     *
+     * @param imageName name of the image to be created, including version tag
+     * @throws Exception
+     */
+    public static void buildJdkContainerImage(String imageName) throws Exception {
+        buildJdkContainerImage(imageName, "jdk-docker");
+    }
+
      /**
      * Build a container image that contains JDK under test.
      * The jdk will be placed under the "/jdk/" folder inside the image/container file system.


### PR DESCRIPTION
Summary: A previous CRaC pactch change the signature of DockerTestUtils.buildJdkContainerImage(String imageName).All testcases depend on docker build will compile failed.

Testing: TestMemoryWithCgroupV1.java

Reviewed-by: yansendao.ysd,lvfei.lv

Issue: https://github.com/dragonwell-project/dragonwell11/issues/872