### PR TITLE
[Runtime] CRaC: fix compile error in Alpine Linux

### DIFF
--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -152,7 +152,8 @@ static void setup_sighandler() {
     sigact.sa_flags = SA_SIGINFO;
     sigact.sa_sigaction = sighandler;
 
-    for (int sig = 1; sig < __SIGRTMIN; ++sig) {
+    const int MaxSignalValue = 31;
+    for (int sig = 1; sig <= MaxSignalValue; ++sig) {
         if (sig == SIGKILL || sig == SIGSTOP) {
             continue;
         }


### PR DESCRIPTION
Summary: There no __SIGRTMIN macro in Alpine Linux

Testing: All CRaC testcases.

Reviewers: Accelerator1996, denghui.ddh

Issue: https://github.com/dragonwell-project/dragonwell11/issues/883