### PR TITLE
[Backport]: 8257919: [JVMCI] profiling info didn't change after reprofile

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -47,6 +47,7 @@ ciMethodData::ciMethodData(MethodData* md)
   _saw_free_extra_data(false),
   // Initialize the escape information (to "don't know.");
   _eflags(0), _arg_local(0), _arg_stack(0), _arg_returned(0),
+  _creation_mileage(0),
   _current_mileage(0),
   _invocation_counter(0),
   _backedge_counter(0),
@@ -242,6 +243,7 @@ bool ciMethodData::load_data() {
   load_remaining_extra_data();
 
   // Note:  Extra data are all BitData, and do not need translation.
+  _creation_mileage = mdo->creation_mileage();
   _current_mileage = MethodData::mileage_of(mdo->method());
   _invocation_counter = mdo->invocation_count();
   _backedge_counter = mdo->backedge_count();

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -405,6 +405,8 @@ private:
   intx _arg_stack;    // bit set of stack-allocatable arguments
   intx _arg_returned; // bit set of returned arguments
 
+  int _creation_mileage; // method mileage at MDO creation
+
   // Maturity of the oop when the snapshot is taken.
   int _current_mileage;
 
@@ -488,7 +490,7 @@ public:
   bool is_empty()  { return _state == empty_state; }
   bool is_mature() { return _state == mature_state; }
 
-  int creation_mileage() { return _orig.creation_mileage(); }
+  int creation_mileage() { return _creation_mileage; }
   int current_mileage()  { return _current_mileage; }
 
   int invocation_count() { return _invocation_counter; }

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1135,7 +1135,7 @@ void MethodData::post_initialize(BytecodeStream* stream) {
 MethodData::MethodData(const methodHandle& method)
   : _method(method()),
     _extra_data_lock(Mutex::leaf, "MDO extra data lock"),
-    _compiler_counters(method()),
+    _compiler_counters(),
     _parameters_type_data_di(parameters_uninitialized) {
   initialize();
 }
@@ -1145,6 +1145,7 @@ void MethodData::initialize() {
   ResourceMark rm;
 
   init();
+  set_creation_mileage(mileage_of(method()));
 
   // Go through the bytecodes and allocate and initialize the
   // corresponding data cells.
@@ -1211,6 +1212,7 @@ void MethodData::initialize() {
 }
 
 void MethodData::init() {
+  _compiler_counters = CompilerCounters(); // reset compiler counters
   _invocation_counter.init();
   _backedge_counter.init();
   _invocation_counter_start = 0;

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -1994,7 +1994,6 @@ public:
     friend class VMStructs;
     friend class JVMCIVMStructs;
 
-    int  _creation_mileage;           // method mileage at MDO creation
     uint _nof_decompiles;             // count of all nmethod removals
     uint _nof_overflow_recompiles;    // recompile count, excluding recomp. bits
     uint _nof_overflow_traps;         // trap count, excluding _trap_hist
@@ -2010,16 +2009,9 @@ public:
       Copy::zero_to_words((HeapWord*) &_trap_hist, size_in_words);
     }
   public:
-    CompilerCounters(Method* m) : _creation_mileage(MethodData::mileage_of(m)),
-      _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
+    CompilerCounters() : _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
       init_trap_hist();
     }
-    CompilerCounters() : _creation_mileage(0), // for ciMethodData
-      _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
-      init_trap_hist();
-    }
-
-    int      creation_mileage() const { return _creation_mileage; }
 
     // Return (uint)-1 for overflow.
     uint trap_count(int reason) const {
@@ -2070,6 +2062,7 @@ private:
   intx              _arg_local;       // bit set of non-escaping arguments
   intx              _arg_stack;       // bit set of stack-allocatable arguments
   intx              _arg_returned;    // bit set of returned arguments
+  int               _creation_mileage; // method mileage at MDO creation
 
   // How many invocations has this MDO seen?
   // These counters are used to determine the exact age of MDO.
@@ -2216,7 +2209,8 @@ public:
   void collect_statistics(KlassSizeStats *sz) const;
 #endif
 
-  int      creation_mileage() const { return _compiler_counters.creation_mileage(); }
+  int      creation_mileage() const { return _creation_mileage; }
+  void set_creation_mileage(int x)  { _creation_mileage = x; }
 
   int invocation_count() {
     if (invocation_counter()->carry()) {


### PR DESCRIPTION
Summary: 8257919: [JVMCI] profiling info didn't change after reprofile Reviewers: kuaiwei, wenjie
Testings: jtreg
Issue: https://bugs.openjdk.org/browse/JDK-8257919,
 https://github.com/dragonwell-project/dragonwell11/issues/903