### PR TITLE
[Misc] Fix CodecacheMemoryCheck.sh fails with -Xcomp -XX:-TieredCompilation by fastdebug build

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/CodecacheMemoryCheck.sh
+++ b/test/hotspot/jtreg/compiler/codecache/stress/CodecacheMemoryCheck.sh
@@ -92,7 +92,8 @@ useJcmdPrintMemoryUsage()
     while ! grep -q "For random generator using seed" ${javaLog}
     do
         sleep 0.1  #wait util java main function start finish
-        if [[ $i -ge 100 ]] ; then
+        if [[ $i -ge 200 ]] ; then
+            cat ${javaLog}
             echo "The tested java seems work abnormally!"
             exit 1
         fi
@@ -134,7 +135,8 @@ getMemoryUsageFromProc()
     while ! grep -q "For random generator using seed" ${javaLog}
     do
         sleep 0.1  #wait util java main function start finish
-        if [[ $i -ge 100 ]] ; then
+        if [[ $i -ge 200 ]] ; then
+            cat ${javaLog}
             echo "The tested java seems work abnormally!"
             exit 1
         fi


### PR DESCRIPTION
Summary: Fix compiler/codecache/stress/CodecacheMemoryCheck.sh fails with -Xcomp -XX:-TieredCompilation by fastdebug build

Testing: CI pipeline

Reviewers: Accelerator1996, ziyilin

Issue: https://github.com/dragonwell-project/dragonwell11/issues/906