### PR TITLE
[Backport] 8255000: C2: Unify IGVN processing when loop opts are over

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -58,11 +58,6 @@ bool ShenandoahBarrierC2Support::expand(Compile* C, PhaseIterGVN& igvn) {
         return false;
       }
       C->clear_major_progress();
-      if (C->range_check_cast_count() > 0) {
-        // No more loop optimizations. Remove all range check dependent CastIINodes.
-        C->remove_range_check_casts(igvn);
-        igvn.optimize();
-      }
     }
   }
   return true;

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -45,6 +45,8 @@ bool ShenandoahBarrierC2Support::expand(Compile* C, PhaseIterGVN& igvn) {
   ShenandoahBarrierSetC2State* state = ShenandoahBarrierSetC2::bsc2()->state();
   if ((state->iu_barriers_count() +
        state->load_reference_barriers_count()) > 0) {
+    assert(C->post_loop_opts_phase(), "no loop opts allowed");
+    C->reset_post_loop_opts_phase(); // ... but we know what we are doing
     bool attempt_more_loopopts = ShenandoahLoopOptsAfterExpansion;
     C->clear_major_progress();
     PhaseIdealLoop ideal_loop(igvn, LoopOptsShenandoahExpand);
@@ -58,7 +60,10 @@ bool ShenandoahBarrierC2Support::expand(Compile* C, PhaseIterGVN& igvn) {
         return false;
       }
       C->clear_major_progress();
+
+      C->process_for_post_loop_opts_igvn(igvn);
     }
+    C->set_post_loop_opts_phase(); // now for real!
   }
   return true;
 }

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2465,12 +2465,12 @@ void MemoryGraphFixer::collect_memory_nodes() {
                   Node* m = _memory_nodes[c->in(k)->_idx];
                   assert(m != NULL, "expect memory state");
                   if (u->in(k) != m) {
-                    phi = NULL;
+                    phi = NodeSentinel;
                   }
                 }
               }
             }
-            if (phi == NULL) {
+            if (phi == NodeSentinel) {
               phi = new PhiNode(c, Type::MEMORY, _phase->C->get_adr_type(_alias));
               for (uint k = 1; k < c->req(); k++) {
                 Node* m = _memory_nodes[c->in(k)->_idx];
@@ -2479,8 +2479,11 @@ void MemoryGraphFixer::collect_memory_nodes() {
               }
             }
           }
-          assert(phi != NULL, "");
-          regions.map(c->_idx, phi);
+          if (phi != NULL) {
+            regions.map(c->_idx, phi);
+          } else {
+            assert(c->unique_ctrl_out()->Opcode() == Op_Halt, "expected memory state");
+          }
         }
         Node* current_region = regions[c->_idx];
         if (current_region != prev_region) {
@@ -2491,7 +2494,7 @@ void MemoryGraphFixer::collect_memory_nodes() {
         }
       } else if (prev_mem == NULL || prev_mem->is_Phi() || ctrl_or_self(prev_mem) != c) {
         Node* m = _memory_nodes[_phase->idom(c)->_idx];
-        assert(m != NULL, "expect memory state");
+        assert(m != NULL || c->Opcode() == Op_Halt, "expect memory state");
         if (m != prev_mem) {
           _memory_nodes.map(c->_idx, m);
           progress = true;
@@ -2515,7 +2518,8 @@ void MemoryGraphFixer::collect_memory_nodes() {
     Node* c = rpo_list.at(i);
     if (c->is_Region() && (_include_lsm || !c->is_OuterStripMinedLoop())) {
       Node* n = regions[c->_idx];
-      if (n->is_Phi() && n->_idx >= last && n->in(0) == c) {
+      assert(n != NULL || c->unique_ctrl_out()->Opcode() == Op_Halt, "expected memory state");
+      if (n != NULL && n->is_Phi() && n->_idx >= last && n->in(0) == c) {
         _phase->register_new_node(n, c);
       }
     }
@@ -2524,10 +2528,12 @@ void MemoryGraphFixer::collect_memory_nodes() {
     Node* c = rpo_list.at(i);
     if (c->is_Region() && (_include_lsm || !c->is_OuterStripMinedLoop())) {
       Node* n = regions[c->_idx];
+      assert(n != NULL || c->unique_ctrl_out()->Opcode() == Op_Halt, "expected memory state");
       for (DUIterator_Fast imax, i = c->fast_outs(imax); i < imax; i++) {
         Node* u = c->fast_out(i);
         if (u->is_Phi() && u->bottom_type() == Type::MEMORY &&
             u != n) {
+          assert(c->unique_ctrl_out()->Opcode() != Op_Halt, "expected memory state");
           if (u->adr_type() == TypePtr::BOTTOM) {
             fix_memory_uses(u, n, n, c);
           } else if (_phase->C->get_alias_index(u->adr_type()) == _alias) {

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -231,35 +231,54 @@ Node *CastIINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Do not narrow the type of range check dependent CastIINodes to
   // avoid corruption of the graph if a CastII is replaced by TOP but
   // the corresponding range check is not removed.
-  if (can_reshape && !_range_check_dependency && !phase->C->major_progress()) {
-    const TypeInt* this_type = this->type()->is_int();
-    const TypeInt* in_type = phase->type(in(1))->isa_int();
-    if (in_type != NULL && this_type != NULL &&
-        (in_type->_lo != this_type->_lo ||
-         in_type->_hi != this_type->_hi)) {
-      jint lo1 = this_type->_lo;
-      jint hi1 = this_type->_hi;
-      int w1  = this_type->_widen;
+  if (can_reshape && !_range_check_dependency) {
+    if (phase->C->post_loop_opts_phase()) {
+      const TypeInt* this_type = this->type()->is_int();
+      const TypeInt* in_type = phase->type(in(1))->isa_int();
+      if (in_type != NULL && this_type != NULL &&
+          (in_type->_lo != this_type->_lo ||
+           in_type->_hi != this_type->_hi)) {
+        jint lo1 = this_type->_lo;
+        jint hi1 = this_type->_hi;
+        int w1  = this_type->_widen;
 
-      if (lo1 >= 0) {
-        // Keep a range assertion of >=0.
-        lo1 = 0;        hi1 = max_jint;
-      } else if (hi1 < 0) {
-        // Keep a range assertion of <0.
-        lo1 = min_jint; hi1 = -1;
-      } else {
-        lo1 = min_jint; hi1 = max_jint;
+        if (lo1 >= 0) {
+          // Keep a range assertion of >=0.
+          lo1 = 0;        hi1 = max_jint;
+        } else if (hi1 < 0) {
+          // Keep a range assertion of <0.
+          lo1 = min_jint; hi1 = -1;
+        } else {
+          lo1 = min_jint; hi1 = max_jint;
+        }
+        const TypeInt* wtype = TypeInt::make(MAX2(in_type->_lo, lo1),
+                                             MIN2(in_type->_hi, hi1),
+                                             MAX2((int)in_type->_widen, w1));
+        if (wtype != type()) {
+          set_type(wtype);
+          return this;
+        }
       }
-      const TypeInt* wtype = TypeInt::make(MAX2(in_type->_lo, lo1),
-                                           MIN2(in_type->_hi, hi1),
-                                           MAX2((int)in_type->_widen, w1));
-      if (wtype != type()) {
-        set_type(wtype);
-        return this;
-      }
+    } else {
+      phase->C->record_for_post_loop_opts_igvn(this);
     }
   }
   return NULL;
+}
+
+Node* CastIINode::Identity(PhaseGVN* phase) {
+  Node* progress = ConstraintCastNode::Identity(phase);
+  if (progress != this) {
+    return progress;
+  }
+  if (_range_check_dependency) {
+    if (phase->C->post_loop_opts_phase()) {
+      return this->in(1);
+    } else {
+      phase->C->record_for_post_loop_opts_igvn(this);
+    }
+  }
+  return this;
 }
 
 uint CastIINode::cmp(const Node &n) const {

--- a/src/hotspot/share/opto/castnode.hpp
+++ b/src/hotspot/share/opto/castnode.hpp
@@ -75,6 +75,7 @@ class CastIINode: public ConstraintCastNode {
   }
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegI; }
+  virtual Node* Identity(PhaseGVN* phase);
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
   const bool has_range_check() {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1989,16 +1989,21 @@ void Compile::remove_from_post_loop_opts_igvn(Node* n) {
 }
 
 void Compile::process_for_post_loop_opts_igvn(PhaseIterGVN& igvn) {
-  if (_for_post_loop_igvn.length() == 0) {
-    return; // no work to do
+  // Verify that all previous optimizations produced a valid graph
+  // at least to this point, even if no loop optimizations were done.
+  PhaseIdealLoop::verify(igvn);
+
+  C->set_post_loop_opts_phase(); // no more loop opts allowed
+
+  if (_for_post_loop_igvn.length() > 0) {
+    while (_for_post_loop_igvn.length() > 0) {
+      Node* n = _for_post_loop_igvn.pop();
+      n->remove_flag(Node::Flag_for_post_loop_opts_igvn);
+      igvn._worklist.push(n);
+    }
+    igvn.optimize();
+    assert(_for_post_loop_igvn.length() == 0, "no more delayed nodes allowed");
   }
-  while (_for_post_loop_igvn.length() > 0) {
-    Node* n = _for_post_loop_igvn.pop();
-    n->remove_flag(Node::Flag_for_post_loop_opts_igvn);
-    igvn._worklist.push(n);
-  }
-  igvn.optimize();
-  assert(_for_post_loop_igvn.length() == 0, "no more delayed nodes allowed");
 }
 
 // StringOpts and late inlining of string methods
@@ -2369,7 +2374,6 @@ void Compile::Optimize() {
     }
     if (!failing()) {
       // Verify that last round of loop opts produced a valid graph
-      TracePhase tp("idealLoopVerify", &timers[_t_idealLoopVerify]);
       PhaseIdealLoop::verify(igvn);
     }
   }
@@ -2405,15 +2409,9 @@ void Compile::Optimize() {
 
   if (failing())  return;
 
-  // Ensure that major progress is now clear
-  C->clear_major_progress();
+  C->clear_major_progress(); // ensure that major progress is now clear
 
-  {
-    // Verify that all previous optimizations produced a valid graph
-    // at least to this point, even if no loop optimizations were done.
-    TracePhase tp("idealLoopVerify", &timers[_t_idealLoopVerify]);
-    PhaseIdealLoop::verify(igvn);
-  }
+  process_for_post_loop_opts_igvn(igvn);
 
 #ifdef ASSERT
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
@@ -2439,10 +2437,6 @@ void Compile::Optimize() {
     }
   }
 #endif
-
-  C->set_post_loop_opts_phase(); // no more loop opts allowed
-
-  process_for_post_loop_opts_igvn(igvn);
 
   if (C->max_vector_size() > 0) {
     C->optimize_logic_cones(igvn);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -861,8 +861,9 @@ class Compile : public Phase {
   void remove_coarsened_lock(Node* n);
   bool coarsened_locks_consistent();
 
-  bool     post_loop_opts_phase() { return _post_loop_opts_phase; }
-  void set_post_loop_opts_phase() { _post_loop_opts_phase = true; }
+  bool       post_loop_opts_phase() { return _post_loop_opts_phase;  }
+  void   set_post_loop_opts_phase() { _post_loop_opts_phase = true;  }
+  void reset_post_loop_opts_phase() { _post_loop_opts_phase = false; }
 
   void record_for_post_loop_opts_igvn(Node* n);
   void remove_from_post_loop_opts_igvn(Node* n);

--- a/src/hotspot/share/opto/convertnode.cpp
+++ b/src/hotspot/share/opto/convertnode.cpp
@@ -287,49 +287,49 @@ Node *ConvI2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   const TypeLong* this_type = this->type()->is_long();
   Node* this_changed = NULL;
 
-  // If _major_progress, then more loop optimizations follow.  Do NOT
-  // remove this node's type assertion until no more loop ops can happen.
-  // The progress bit is set in the major loop optimizations THEN comes the
-  // call to IterGVN and any chance of hitting this code.  Cf. Opaque1Node.
-  if (can_reshape && !phase->C->major_progress()) {
-    const TypeInt* in_type = phase->type(in(1))->isa_int();
-    if (in_type != NULL && this_type != NULL &&
-        (in_type->_lo != this_type->_lo ||
-         in_type->_hi != this_type->_hi)) {
-          // Although this WORSENS the type, it increases GVN opportunities,
-          // because I2L nodes with the same input will common up, regardless
-          // of slightly differing type assertions.  Such slight differences
-          // arise routinely as a result of loop unrolling, so this is a
-          // post-unrolling graph cleanup.  Choose a type which depends only
-          // on my input.  (Exception:  Keep a range assertion of >=0 or <0.)
-          jlong lo1 = this_type->_lo;
-          jlong hi1 = this_type->_hi;
-          int   w1  = this_type->_widen;
-          if (lo1 != (jint)lo1 ||
-              hi1 != (jint)hi1 ||
-              lo1 > hi1) {
-            // Overflow leads to wraparound, wraparound leads to range saturation.
-            lo1 = min_jint; hi1 = max_jint;
-          } else if (lo1 >= 0) {
-            // Keep a range assertion of >=0.
-            lo1 = 0;        hi1 = max_jint;
-          } else if (hi1 < 0) {
-            // Keep a range assertion of <0.
-            lo1 = min_jint; hi1 = -1;
-          } else {
-            lo1 = min_jint; hi1 = max_jint;
-          }
-          const TypeLong* wtype = TypeLong::make(MAX2((jlong)in_type->_lo, lo1),
-                                                 MIN2((jlong)in_type->_hi, hi1),
-                                                 MAX2((int)in_type->_widen, w1));
-          if (wtype != type()) {
-            set_type(wtype);
-            // Note: this_type still has old type value, for the logic below.
-            this_changed = this;
-          }
+  if (can_reshape) {
+    // Do NOT remove this node's type assertion until no more loop ops can happen.
+    if (phase->C->post_loop_opts_phase()) {
+      const TypeInt* in_type = phase->type(in(1))->isa_int();
+      if (in_type != NULL && this_type != NULL &&
+          (in_type->_lo != this_type->_lo ||
+           in_type->_hi != this_type->_hi)) {
+        // Although this WORSENS the type, it increases GVN opportunities,
+        // because I2L nodes with the same input will common up, regardless
+        // of slightly differing type assertions.  Such slight differences
+        // arise routinely as a result of loop unrolling, so this is a
+        // post-unrolling graph cleanup.  Choose a type which depends only
+        // on my input.  (Exception:  Keep a range assertion of >=0 or <0.)
+        jlong lo1 = this_type->_lo;
+        jlong hi1 = this_type->_hi;
+        int   w1  = this_type->_widen;
+        if (lo1 != (jint)lo1 ||
+            hi1 != (jint)hi1 ||
+            lo1 > hi1) {
+          // Overflow leads to wraparound, wraparound leads to range saturation.
+          lo1 = min_jint; hi1 = max_jint;
+        } else if (lo1 >= 0) {
+          // Keep a range assertion of >=0.
+          lo1 = 0;        hi1 = max_jint;
+        } else if (hi1 < 0) {
+          // Keep a range assertion of <0.
+          lo1 = min_jint; hi1 = -1;
+        } else {
+          lo1 = min_jint; hi1 = max_jint;
         }
+        const TypeLong* wtype = TypeLong::make(MAX2((jlong)in_type->_lo, lo1),
+                                               MIN2((jlong)in_type->_hi, hi1),
+                                               MAX2((int)in_type->_widen, w1));
+        if (wtype != type()) {
+          set_type(wtype);
+          // Note: this_type still has old type value, for the logic below.
+          this_changed = this;
+        }
+      }
+    } else {
+      phase->C->record_for_post_loop_opts_igvn(this);
+    }
   }
-
 #ifdef _LP64
   // Convert ConvI2L(AddI(x, y)) to AddL(ConvI2L(x), ConvI2L(y))
   // but only if x and y have subranges that cannot cause 32-bit overflow,

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3061,6 +3061,8 @@ bool PhaseIdealLoop::only_has_infinite_loops() {
 // Create a PhaseLoop.  Build the ideal Loop tree.  Map each Ideal Node to
 // its corresponding LoopNode.  If 'optimize' is true, do some loop cleanups.
 void PhaseIdealLoop::build_and_optimize() {
+  assert(!C->post_loop_opts_phase(), "no loop opts allowed");
+
   bool do_split_ifs = (_mode == LoopOptsDefault || _mode == LoopOptsLastRound);
   bool skip_loop_opts = (_mode == LoopOptsNone);
 #if INCLUDE_SHENANDOAHGC

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1024,6 +1024,8 @@ public:
   // is useful to verify that all inputs properly dominate their uses.
   static void verify(PhaseIterGVN& igvn) {
 #ifdef ASSERT
+    ResourceMark rm;
+    Compile::TracePhase tp("idealLoopVerify", &timers[_t_idealLoopVerify]);
     PhaseIdealLoop v(igvn);
 #endif
   }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -499,24 +499,23 @@ Node *Node::clone() const {
     n->_in[i] = x;
     if (x != NULL) x->add_out(n);
   }
-  if (is_macro())
+  if (is_macro()) {
     C->add_macro_node(n);
-  if (is_expensive())
+  }
+  if (is_expensive()) {
     C->add_expensive_node(n);
+  }
   if (n->is_reduction()) {
     // Do not copy reduction information. This must be explicitly set by the calling code.
     n->remove_flag(Node::Flag_is_reduction);
   }
+  if (for_post_loop_opts_igvn()) {
+    // Don't add cloned node to Compile::_for_post_loop_opts_igvn list automatically.
+    // If it is applicable, it will happen anyway when the cloned node is registered with IGVN.
+    n->remove_flag(Node::Flag_for_post_loop_opts_igvn);
+  }
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->register_potential_barrier_node(n);
-  // If the cloned node is a range check dependent CastII, add it to the list.
-  CastIINode* cast = n->isa_CastII();
-  if (cast != NULL && cast->has_range_check()) {
-    C->add_range_check_cast(cast);
-  }
-  if (n->Opcode() == Op_Opaque4) {
-    C->add_opaque4_node(n);
-  }
 
   n->set_idx(C->next_unique()); // Get new unique index as well
   debug_only( n->verify_construction() );
@@ -624,14 +623,9 @@ void Node::destruct() {
   if (is_expensive()) {
     compile->remove_expensive_node(this);
   }
-  CastIINode* cast = isa_CastII();
-  if (cast != NULL && cast->has_range_check()) {
-    compile->remove_range_check_cast(cast);
+  if (for_post_loop_opts_igvn()) {
+    compile->remove_from_post_loop_opts_igvn(this);
   }
-  if (Opcode() == Op_Opaque4) {
-    compile->remove_opaque4_node(this);
-  }
-
   if (is_SafePoint()) {
     as_SafePoint()->delete_replaced_nodes();
   }
@@ -1035,7 +1029,7 @@ bool Node::verify_jvms(const JVMState* using_jvms) const {
 //------------------------------init_NodeProperty------------------------------
 void Node::init_NodeProperty() {
   assert(_max_classes <= max_jushort, "too many NodeProperty classes");
-  assert(_max_flags <= max_jushort, "too many NodeProperty flags");
+  assert(_max_flags <= max_juint, "too many NodeProperty flags");
 }
 #endif
 
@@ -1389,12 +1383,8 @@ static void kill_dead_code( Node *dead, PhaseIterGVN *igvn ) {
       if (dead->is_expensive()) {
         igvn->C->remove_expensive_node(dead);
       }
-      CastIINode* cast = dead->isa_CastII();
-      if (cast != NULL && cast->has_range_check()) {
-        igvn->C->remove_range_check_cast(cast);
-      }
-      if (dead->Opcode() == Op_Opaque4) {
-        igvn->C->remove_opaque4_node(dead);
+      if (dead->for_post_loop_opts_igvn()) {
+        igvn->C->remove_from_post_loop_opts_igvn(dead);
       }
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
       bs->unregister_potential_barrier_node(dead);

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -740,38 +740,40 @@ public:
 
   // Flags are sorted by usage frequency.
   enum NodeFlags {
-    Flag_is_Copy                     = 0x01, // should be first bit to avoid shift
-    Flag_rematerialize               = Flag_is_Copy << 1,
-    Flag_needs_anti_dependence_check = Flag_rematerialize << 1,
-    Flag_is_macro                    = Flag_needs_anti_dependence_check << 1,
-    Flag_is_Con                      = Flag_is_macro << 1,
-    Flag_is_cisc_alternate           = Flag_is_Con << 1,
-    Flag_is_dead_loop_safe           = Flag_is_cisc_alternate << 1,
-    Flag_may_be_short_branch         = Flag_is_dead_loop_safe << 1,
-    Flag_avoid_back_to_back_before   = Flag_may_be_short_branch << 1,
-    Flag_avoid_back_to_back_after    = Flag_avoid_back_to_back_before << 1,
-    Flag_has_call                    = Flag_avoid_back_to_back_after << 1,
-    Flag_is_reduction                = Flag_has_call << 1,
-    Flag_is_scheduled                = Flag_is_reduction << 1,
-    Flag_has_vector_mask_set         = Flag_is_scheduled << 1,
-    Flag_is_expensive                = Flag_has_vector_mask_set << 1,
-    _max_flags = (Flag_is_expensive << 1) - 1 // allow flags combination
+    Flag_is_Copy                     = 1 << 0, // should be first bit to avoid shift
+    Flag_rematerialize               = 1 << 1,
+    Flag_needs_anti_dependence_check = 1 << 2,
+    Flag_is_macro                    = 1 << 3,
+    Flag_is_Con                      = 1 << 4,
+    Flag_is_cisc_alternate           = 1 << 5,
+    Flag_is_dead_loop_safe           = 1 << 6,
+    Flag_may_be_short_branch         = 1 << 7,
+    Flag_avoid_back_to_back_before   = 1 << 8,
+    Flag_avoid_back_to_back_after    = 1 << 9,
+    Flag_has_call                    = 1 << 10,
+    Flag_is_reduction                = 1 << 11,
+    Flag_is_scheduled                = 1 << 12,
+    Flag_has_vector_mask_set         = 1 << 13,
+    Flag_is_expensive                = 1 << 14,
+    Flag_for_post_loop_opts_igvn     = 1 << 15,
+    _last_flag                       = Flag_for_post_loop_opts_igvn,
+    _max_flags = (Flag_for_post_loop_opts_igvn << 1) - 1 // allow flags combination
   };
 
 private:
   juint _class_id;
-  jushort _flags;
+  juint _flags;
 
 protected:
   // These methods should be called from constructors only.
   void init_class_id(juint c) {
     _class_id = c; // cast out const
   }
-  void init_flags(jushort fl) {
+  void init_flags(uint fl) {
     assert(fl <= _max_flags, "invalid node flag");
     _flags |= fl;
   }
-  void clear_flag(jushort fl) {
+  void clear_flag(uint fl) {
     assert(fl <= _max_flags, "invalid node flag");
     _flags &= ~fl;
   }
@@ -779,11 +781,11 @@ protected:
 public:
   const juint class_id() const { return _class_id; }
 
-  const jushort flags() const { return _flags; }
+  const juint flags() const { return _flags; }
 
-  void add_flag(jushort fl) { init_flags(fl); }
+  void add_flag(juint fl) { init_flags(fl); }
 
-  void remove_flag(jushort fl) { clear_flag(fl); }
+  void remove_flag(juint fl) { clear_flag(fl); }
 
   // Return a dense integer opcode number
   virtual int Opcode() const;
@@ -960,6 +962,8 @@ public:
 
   // Used in lcm to mark nodes that have scheduled
   bool is_scheduled() const { return (_flags & Flag_is_scheduled) != 0; }
+
+  bool for_post_loop_opts_igvn() const { return (_flags & Flag_for_post_loop_opts_igvn) != 0; }
 
 //----------------- Optimization
 

--- a/src/hotspot/share/opto/opaquenode.cpp
+++ b/src/hotspot/share/opto/opaquenode.cpp
@@ -34,14 +34,14 @@ uint Opaque1Node::cmp( const Node &n ) const {
 }
 
 //------------------------------Identity---------------------------------------
-// If _major_progress, then more loop optimizations follow.  Do NOT remove
-// the opaque Node until no more loop ops can happen.  Note the timing of
-// _major_progress; it's set in the major loop optimizations THEN comes the
-// call to IterGVN and any chance of hitting this code.  Hence there's no
-// phase-ordering problem with stripping Opaque1 in IGVN followed by some
-// more loop optimizations that require it.
+// Do NOT remove the opaque Node until no more loop ops can happen.
 Node* Opaque1Node::Identity(PhaseGVN* phase) {
-  return phase->C->major_progress() ? this : in(1);
+  if (phase->C->post_loop_opts_phase()) {
+    return in(1);
+  } else {
+    phase->C->record_for_post_loop_opts_igvn(this);
+  }
+  return this;
 }
 
 //=============================================================================
@@ -58,6 +58,25 @@ Node* Opaque1Node::Identity(PhaseGVN* phase) {
 uint Opaque2Node::hash() const { return NO_HASH; }
 uint Opaque2Node::cmp( const Node &n ) const {
   return (&n == this);          // Always fail except on self
+}
+
+Node* Opaque4Node::Identity(PhaseGVN* phase) {
+  if (phase->C->post_loop_opts_phase()) {
+    // With Opaque4 nodes, the expectation is that the test of input 1
+    // is always equal to the constant value of input 2. So we can
+    // remove the Opaque4 and replace it by input 2. In debug builds,
+    // leave the non constant test in instead to sanity check that it
+    // never fails (if it does, that subgraph was constructed so, at
+    // runtime, a Halt node is executed).
+#ifdef ASSERT
+    return this->in(1);
+#else
+    return this->in(2);
+#endif
+  } else {
+    phase->C->record_for_post_loop_opts_igvn(this);
+  }
+  return this;
 }
 
 const Type* Opaque4Node::Value(PhaseGVN* phase) const {

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -114,12 +114,11 @@ class Opaque3Node : public Opaque2Node {
 // GraphKit::must_be_not_null().
 class Opaque4Node : public Node {
   public:
-  Opaque4Node(Compile* C, Node *tst, Node* final_tst) : Node(NULL, tst, final_tst) {
-    // Put it on the Opaque4 nodes list to be removed after all optimizations
-    C->add_opaque4_node(this);
-  }
+  Opaque4Node(Compile* C, Node *tst, Node* final_tst) : Node(NULL, tst, final_tst) {}
+
   virtual int Opcode() const;
   virtual const Type *bottom_type() const { return TypeInt::BOOL; }
+  virtual Node* Identity(PhaseGVN* phase);
   virtual const Type* Value(PhaseGVN* phase) const;
 };
 

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1515,12 +1515,8 @@ void PhaseIterGVN::remove_globally_dead_node( Node *dead ) {
       if (dead->is_expensive()) {
         C->remove_expensive_node(dead);
       }
-      CastIINode* cast = dead->isa_CastII();
-      if (cast != NULL && cast->has_range_check()) {
-        C->remove_range_check_cast(cast);
-      }
-      if (dead->Opcode() == Op_Opaque4) {
-        C->remove_opaque4_node(dead);
+      if (dead->for_post_loop_opts_igvn()) {
+        C->remove_from_post_loop_opts_igvn(dead);
       }
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
       bs->unregister_potential_barrier_node(dead);

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -957,7 +957,7 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   c2_nonstatic_field(Node,                     _outmax,                                       node_idx_t)                            \
   c2_nonstatic_field(Node,                     _idx,                                          const node_idx_t)                      \
   c2_nonstatic_field(Node,                     _class_id,                                     juint)                                 \
-  c2_nonstatic_field(Node,                     _flags,                                        jushort)                               \
+  c2_nonstatic_field(Node,                     _flags,                                        juint)                                 \
                                                                                                                                      \
   c2_nonstatic_field(Compile,                  _root,                                         RootNode*)                             \
   c2_nonstatic_field(Compile,                  _unique,                                       uint)                                  \

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierExpansionDeadMemPhi.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8255400
+ * @summary C2 failures after JDK-8255000
+ * @requires vm.gc.Shenandoah
+ * @modules java.base/jdk.internal.misc:+open
+ *
+ * @run main/othervm -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:+UseShenandoahGC TestBarrierExpansionDeadMemPhi
+ *
+ *
+ */
+
+import jdk.internal.misc.Unsafe;
+import java.util.Arrays;
+import java.lang.reflect.Field;
+
+public class TestBarrierExpansionDeadMemPhi {
+
+    static final jdk.internal.misc.Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static final long F_OFFSET;
+
+    static class A {
+        int f;
+    }
+
+    static {
+        try {
+            Field fField = A.class.getDeclaredField("f");
+            F_OFFSET = UNSAFE.objectFieldOffset(fField);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static int test(Object[] array) {
+        int f = 0;
+        for (int i = 0; i < 100; i++) {
+            f += UNSAFE.getInt(array[i], F_OFFSET);
+        }
+        return f;
+    }
+
+    static public void main(String[] args) {
+        Object[] array = new Object[100];
+        Arrays.fill(array, new A());
+
+        for (int i = 0; i < 20000; i++) {
+            test(array);
+        }
+    }
+}


### PR DESCRIPTION
[Backport] 8255000: C2: Unify IGVN processing when loop opts are over

Summary: it include 3 patches
8255000: C2: Unify IGVN processing when loop opts are over
8255400: Shenandoah: C2 failures after JDK-8255000
8255120: C2: assert(outer->outcnt() >= phis + 2 && outer->outcnt() <= phis + 2 + stores + 1) failed: only phis

Testing: CICD

Reviewers: wangzhuo, yueshi.zwj

Issue: https://github.com/dragonwell-project/dragonwell11/issues/915