### PR TITLE
[Wisp] prevent running time-related case in debug mode

### DIFF
--- a/test/jdk/com/alibaba/wisp/bug/TestCancelTimerAndSleep.java
+++ b/test/jdk/com/alibaba/wisp/bug/TestCancelTimerAndSleep.java
@@ -4,6 +4,7 @@
  * @modules java.base/jdk.internal.misc
  * @requires os.family == "linux"
  * @requires os.arch != "riscv64"
+ * @requires vm.debug != true
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableCoroutine -Dcom.alibaba.wisp.transparentWispSwitch=true TestCancelTimerAndSleep
 */
 


### PR DESCRIPTION
Summary: as title

Testing: com/alibaba/wisp/bug/TestCancelTimerAndSleep.java

Reviewers: ziyilin, yulei

Issue: https://github.com/dragonwell-project/dragonwell11/issues/901