### PR TITLE
[Misc] update version of upload-artifact in gha

### DIFF
--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs

--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -48,14 +48,14 @@ runs:
   steps:
     - name: 'Download bundles artifact'
       id: download-bundles
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles
       continue-on-error: true
 
     - name: 'Download bundles artifact (retry)'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
 
     - name: 'Upload bundles artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,7 +228,7 @@ jobs:
         if: steps.check_if_run.outputs.should_run != 'false'
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}


### PR DESCRIPTION
Summary: gha failed because it uses a deprecated version

Testing: CI

Reviewers: jia-wei-tang, sendaoYan

Issue: https://github.com/dragonwell-project/dragonwell11/issues/932