### PR TITLE
Exclude HeapDumpCompressedTest#id3 (known heap dump parsing issue)

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -286,3 +286,8 @@ dragonwell
 runtime/coroutine/testJniDetachThreadHoldingMonitor.sh generic-all
 runtime/coroutine/testJniMonitorExit.sh generic-all
 gc/z/unloading/TestUnloadGarbageCollectorMXBean.java linux-aarch64
+
+# HeapDumpCompressedTest#id3 fails: could not parse compressed dump file
+# Known issue: https://github.com/dragonwell-project/dragonwell11/issues/422
+# https://project.aone.alibaba-inc.com/v2/project/1164623/bug/72748280
+serviceability/dcmd/gc/HeapDumpCompressedTest.java#id3 72748280 generic-all


### PR DESCRIPTION
The HeapDumpCompressedTest#id3 fails with RuntimeException: Could not parse dump file (.hprof.gz). This is a known heap dump parsing issue tracked in #422.

Bug: https://project.aone.alibaba-inc.com/v2/project/1164623/bug/72748280